### PR TITLE
Auto-discover MCP servers configured in Codex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Automatically import local stdio MCP servers from Codex's user-level
+  `$CODEX_HOME/config.toml` (or `~/.codex/config.toml`), including launch
+  environment, working directory, enablement and tool filters. Explicit
+  `codex.config.json` entries overlay imported fields, and discovery can be
+  disabled with `codexMcp.enabled`.
+
 ## [1.0.0] - 2026-08-19
 
 The first Rust release. The server was rewritten from Bun + TypeScript to Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "tower",
  "tower-http",
  "tracing",
@@ -1208,6 +1209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1441,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"
@@ -1771,6 +1820,12 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 async-trait = "0.1.92"
+toml = "1.1.4"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ All paths are resolved relative to `--work-dir`.
     "enabled": true,
     "includePlugins": true
   },
+  "codexMcp": {
+    "enabled": true
+  },
   "allowedHosts": [],
   "mcpServers": {}
 }
@@ -258,6 +261,12 @@ The `skills` block governs `SKILL.md` discovery. See [Skills](#skills):
 | `enabled` | `true` | `false` searches nothing; both tools say so and the catalogue leaves `instructions` |
 | `dirs` | `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` | User-scope directories, **replacing** the home-directory defaults. Relative paths resolve against the work directory; project-scope roots are unaffected |
 | `includePlugins` | `true` | Discover installed Claude Code plugin skills. Setting `dirs` disables this unless you set it back to `true` |
+
+The `codexMcp` block controls [automatic import of MCP servers configured in Codex](#bridging-other-mcp-servers):
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `true` | Read the user-level Codex `config.toml` and merge its MCP servers into `mcpServers`; `false` disables all Codex-config discovery |
 
 The `allowedHosts` array and the `mcpServers` map are covered under [Host allowlist](#host-allowlist) and [Bridging other MCP servers](#bridging-other-mcp-servers).
 
@@ -391,7 +400,31 @@ Discovery runs per MCP session, so adding a skill takes effect on the next conne
 
 Codexrr can also act as an **MCP aggregator**: it connects to your other local MCP servers as a client, discovers their tools at startup, and re-exposes them through its own `/mcp` endpoint — so the ChatGPT-side agent sees and can call them too.
 
-Add an `mcpServers` section to `codex.config.json` (the standard Claude-Desktop shape). Each entry is a stdio command that Codexrr launches and drives over stdin/stdout:
+### Automatic discovery from Codex
+
+By default, Codexrr imports the MCP servers from Codex's user-level configuration: `$CODEX_HOME/config.toml` when `CODEX_HOME` is set, otherwise `~/.codex/config.toml`. The file is read only; Codexrr never rewrites it. This initial implementation intentionally does not reproduce Codex's project-local configuration layers or trust decisions.
+
+For each `[mcp_servers.<name>]` entry, Codexrr imports the fields it can preserve:
+
+- `command`, `args`, `env` and `cwd` for local stdio launch;
+- local `env_vars`, resolved from Codexrr's process environment;
+- `enabled = false` as a disabled upstream;
+- `enabled_tools` as an allow-list and `disabled_tools` as a deny-list applied afterwards.
+
+Streamable-HTTP entries (`url`) and non-local execution environments are skipped because the bridge currently supports only local stdio children. Other Codex-only fields are ignored explicitly: the startup report names those fields, but never prints environment values or other configuration values. A missing or unreadable Codex config does not prevent servers declared directly in `codex.config.json` from loading.
+
+Disable discovery while retaining explicit upstreams with:
+
+```json
+{
+  "codexMcp": { "enabled": false },
+  "mcpServers": {}
+}
+```
+
+### Explicit servers and overrides
+
+The `mcpServers` map in `codex.config.json` remains supported. Each entry is a stdio command that Codexrr launches and drives over stdin/stdout:
 
 ```json
 {
@@ -405,9 +438,27 @@ Add an `mcpServers` section to `codex.config.json` (the standard Claude-Desktop 
 }
 ```
 
+An explicit entry with the same name as an imported Codex server is a field-by-field overlay. That makes Codex-specific launch settings reusable while adding bridge-only settings without copying the command, arguments or environment:
+
+```json
+{
+  "mcpServers": {
+    "remote-exec": {
+      "mode": "gateway",
+      "tools": ["exec", "machine_list"]
+    }
+  }
+}
+```
+
+Set an empty array or object to replace an imported collection with an empty one. Explicit `command` and `url` fields replace the imported transport rather than producing a mixed configuration.
+
 At startup you'll see, e.g.:
 
 ```
+Codex MCP discovery: /home/user/.codex/config.toml
+  idasql -> imported from Codex
+  remote-exec -> imported fields overlaid by codex.config.json
 bridged MCP server 'idasql': 12 tool(s)
 Tools loaded (37): 25 native + 12 bridged from upstream MCP servers
 ```
@@ -424,6 +475,8 @@ Upstream MCP servers:
 
 - `disabled: true` on an entry keeps its config but skips it (shown as `-> disabled`).
 - `tools: ["exec", "machine_list", ...]` limits which upstream tools are bridged (an allow-list on the upstream's own names).
+- `disabledTools: ["dangerous_write", ...]` removes tools after the allow-list has been applied.
+- `cwd` selects the child process's working directory.
 - Bridged names are sanitised to `[A-Za-z0-9_]` (e.g. `remote_exec__exec`) so function-calling layers that reject hyphens don't drop them.
 - A bridged name that would collide with a native tool is skipped with a warning.
 - `type` may be `"stdio"` (default). Only stdio (command-launched) upstreams are bridged today; `type: "sse"`/`"http"` (or a bare `url`) entries are recognised and reported as `not supported yet` rather than failing the whole config.
@@ -437,14 +490,12 @@ Some clients (ChatGPT among them) won't reliably surface a large bridged tool se
 ```json
 "mcpServers": {
   "remote-exec": {
-    "command": "D:\\mcphub\\mcp-server-windows-x86_64.exe",
-    "type": "stdio",
     "mode": "gateway"
   }
 }
 ```
 
-This registers one tool named `remote_exec` taking `{ "function": "<name>", "arguments": { ... } }`, and auto-generates a skill (`skills_read name="remote-exec"`) documenting every function and its argument schema. The agent reads the skill, then calls the one tool — so an 84-tool server shows up as **1 tool + 1 skill** instead of 84 tools. `disabled`, `type`, and `tools` (allow-list) all still apply.
+When `remote-exec` was imported from Codex, that overlay is sufficient; include its `command` and other launch fields when it exists only in `codex.config.json`. Gateway mode registers one tool named `remote_exec` taking `{ "function": "<name>", "arguments": { ... } }`, and auto-generates a skill (`skills_read name="remote-exec"`) documenting every function and its argument schema. The agent reads the skill, then calls the one tool — so an 84-tool server shows up as **1 tool + 1 skill** instead of 84 tools. `disabled`, `type`, `tools` and `disabledTools` all still apply.
 
 ## Connecting to ChatGPT
 
@@ -473,7 +524,7 @@ By default `allowedHosts` is empty, which accepts any `Host` header — the serv
 - **One bounded write outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/`, deliberately outside the repository so nothing lands in your git history. It holds whatever the model chose to note about the task — read it if you want to know, delete the directory to forget, or set `memory.enabled` to `false` to never write it. The write is atomic (temp file plus rename) and guarded by a per-project lock, so a crash mid-write never leaves a torn file and two servers pointed at the same work directory do not lose each other's notes to an interleaved update. See [Context and memory](#context-and-memory).
 - **Bounded reads outside the work directory**: [skills](#skills) may live in `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` or an installed Claude Code plugin. `skills_read` opens files there, but only inside a skill package that already exists — the `resource` path is checked against the skill's own directory, so it cannot walk out into the rest of your home directory. `skills_list` reports the absolute path of every skill it found. Set `skills.enabled` to `false` to switch it off, or `skills.dirs` to point the user scope somewhere you choose.
 - **Command allowlist**: `run_command` only runs binaries listed in `allowedCommands`; everything else is rejected. `exec_command` checks the same list plus `exec.extraAllowedCommands`, at every command position in the string.
-- **Bridged servers run with your privileges**: an `mcpServers` entry launches a real process on your machine and forwards the model's calls to it verbatim. Only bridge servers you trust, and prefer `tools` allow-lists or `gateway` mode to keep the exposed surface small. A bad `command` path is reported, never silently ignored.
+- **Bridged servers run with your privileges**: an explicit `mcpServers` entry or an automatically imported Codex MCP launches a real process on your machine and forwards the model's calls to it verbatim. Only bridge servers you trust, prefer `tools`/`disabledTools` filters or `gateway` mode to keep the exposed surface small, and set `codexMcp.enabled` to `false` when Codex contains servers that should not be exposed through ChatGPT. A bad `command` path is reported, never silently ignored.
 - **Optional bearer token auth**: set `--api-key` to require an `Authorization: Bearer <key>` header on all requests (except `/health`). Useful for non-ChatGPT clients. ChatGPT Plugins do not support simple bearer token auth.
 - **Host allowlist**: set `allowedHosts` to pin the accepted `Host` header for DNS-rebinding protection. See [Host allowlist](#host-allowlist).
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -100,10 +100,11 @@ Per-MCP-session mutable state: the map of resident `exec_command` shells and the
 current plan. Created fresh per session by the factory; `Drop` disposes shells.
 
 ### `AppConfig` (`types.rs`)
-The fully-resolved config handed to every tool. Parsed from `codex.config.json`
-with camelCase field names for backward compatibility. Optional sub-configs
-(`projectDoc`, `output`, `memory`, `skills`, `ignore`) fall back to per-module
-defaults.
+The fully-resolved config handed to every tool. `config.rs` parses
+`codex.config.json` with camelCase field names for backward compatibility, imports
+user-level Codex MCP definitions through `codex_mcp.rs`, then applies explicit
+`mcpServers` entries as field overlays. Optional sub-configs (`projectDoc`,
+`output`, `memory`, `skills`, `ignore`) fall back to per-module defaults.
 
 ---
 
@@ -154,6 +155,7 @@ the original order and rejects duplicate names.
 | `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized work dir, with `O_EXCL` locking and atomic writes. |
 | `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. |
 | `skills.rs` | `SKILL.md` discovery (see §8). |
+| `codex_mcp.rs` | Read-only import of local stdio MCP definitions from `$CODEX_HOME/config.toml` or `~/.codex/config.toml`, with secret-safe diagnostics. |
 | `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc, per session. |
 | `environment.rs` | OS / shell / policy description, shared by `get_environment` and the instructions. |
 
@@ -166,11 +168,16 @@ tools at startup, and re-expose them. Implemented in `bridge.rs`; wired in
 `server.rs::start_http_server` before the HTTP server starts.
 
 ### Discovery
-For each entry in `mcpServers` (sorted, non-disabled), `connect_one`:
+Before bridging, `config.rs` imports compatible `[mcp_servers.<name>]` entries
+from Codex's user-level config. Explicit `codex.config.json.mcpServers` fields
+overlay imports with the same name; `codexMcp.enabled = false` disables the
+import. HTTP and non-local Codex entries are reported and skipped.
+
+For each resulting server entry (sorted, non-disabled), `connect_one`:
 1. Launches the `command` as a stdio child process (`TokioChildProcess`).
 2. Runs the MCP handshake (`().serve(transport)`), then `list_all_tools()`,
    under a 20 s timeout.
-3. Applies the optional `tools` allow-list.
+3. Applies the optional `tools` allow-list, then `disabledTools` deny-list.
 
 Failures are **reported, not fatal** — each server appears in the startup banner
 as `-> N tool(s)`, `-> FAILED: <reason>`, `-> disabled`, or

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -447,6 +447,9 @@ async fn connect_one(
     server_name: &str,
     spec: &crate::types::McpServerSpec,
 ) -> Result<(RunningService<RoleClient, ()>, Vec<rmcp::model::Tool>), String> {
+    if spec.command.is_some() && spec.url.is_some() {
+        return Err("both \"command\" and \"url\" are configured".to_string());
+    }
     // Recognise url-based transports and report them clearly instead of failing
     // to launch a nonexistent command.
     let kind = spec
@@ -456,7 +459,7 @@ async fn connect_one(
         .to_ascii_lowercase();
     if matches!(
         kind.as_str(),
-        "sse" | "http" | "streamable-http" | "websocket" | "ws"
+        "sse" | "http" | "streamable-http" | "streamable_http" | "websocket" | "ws"
     ) {
         return Err(format!(
             "type \"{kind}\" (url transport) is not supported yet; only stdio (command) servers are bridged"
@@ -477,6 +480,9 @@ async fn connect_one(
     for (key, value) in &spec.env {
         command.env(key, value);
     }
+    if let Some(cwd) = spec.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
+        command.current_dir(cwd);
+    }
 
     let transport = TokioChildProcess::new(command)
         .map_err(|e| format!("could not launch '{command_path}': {e}"))?;
@@ -489,12 +495,9 @@ async fn connect_one(
 
     match tokio::time::timeout(CONNECT_TIMEOUT, connect).await {
         Ok(Ok((service, mut tools))) => {
-            // Apply the optional per-server allow-list on the upstream's own names.
-            if let Some(allow) = &spec.tools {
-                let set: std::collections::HashSet<&str> =
-                    allow.iter().map(|s| s.as_str()).collect();
-                tools.retain(|t| set.contains(t.name.as_ref()));
-            }
+            // Codex applies the deny-list after the allow-list; use the same
+            // order so imported filtering has identical results.
+            tools.retain(|tool| tool_is_enabled(spec, tool.name.as_ref()));
             Ok((service, tools))
         }
         Ok(Err(e)) => Err(e),
@@ -503,6 +506,18 @@ async fn connect_one(
             CONNECT_TIMEOUT.as_secs()
         )),
     }
+}
+
+fn tool_is_enabled(spec: &crate::types::McpServerSpec, name: &str) -> bool {
+    let allowed = spec
+        .tools
+        .as_ref()
+        .is_none_or(|tools| tools.iter().any(|tool| tool == name));
+    let denied = spec
+        .disabled_tools
+        .as_ref()
+        .is_some_and(|tools| tools.iter().any(|tool| tool == name));
+    allowed && !denied
 }
 
 #[cfg(test)]
@@ -587,10 +602,12 @@ mod tests {
                 command: Some("codexrr-nonexistent-binary-xyz".into()),
                 args: vec![],
                 env: HashMap::new(),
+                cwd: None,
                 disabled: false,
                 transport: None,
                 url: None,
                 tools: None,
+                disabled_tools: None,
                 mode: None,
             },
         );
@@ -613,10 +630,12 @@ mod tests {
                 command: None,
                 args: vec![],
                 env: HashMap::new(),
+                cwd: None,
                 disabled: false,
                 transport: Some("sse".into()),
                 url: Some("http://localhost:9/sse".into()),
                 tools: None,
+                disabled_tools: None,
                 mode: None,
             },
         );
@@ -638,14 +657,28 @@ mod tests {
                 command: Some("codexrr-should-never-run".into()),
                 args: vec![],
                 env: HashMap::new(),
+                cwd: None,
                 disabled: true,
                 transport: None,
                 url: None,
                 tools: None,
+                disabled_tools: None,
                 mode: None,
             },
         );
         let bridge = connect_upstreams(&config).await;
         assert!(bridge.tools.is_empty());
+    }
+
+    #[test]
+    fn deny_list_is_applied_after_allow_list() {
+        let spec = McpServerSpec {
+            tools: Some(vec!["read".into(), "write".into()]),
+            disabled_tools: Some(vec!["write".into()]),
+            ..Default::default()
+        };
+        assert!(tool_is_enabled(&spec, "read"));
+        assert!(!tool_is_enabled(&spec, "write"));
+        assert!(!tool_is_enabled(&spec, "other"));
     }
 }

--- a/src/codex_mcp.rs
+++ b/src/codex_mcp.rs
@@ -1,0 +1,466 @@
+//! Import user-level MCP server definitions from Codex's `config.toml`.
+
+use std::collections::{BTreeSet, HashMap};
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+
+use crate::types::McpServerSpec;
+use crate::util::home_dir;
+
+#[derive(Debug, Default)]
+pub struct CodexMcpImport {
+    pub servers: HashMap<String, McpServerSpec>,
+    pub report: Vec<String>,
+}
+
+pub fn codex_config_path() -> Result<PathBuf, String> {
+    let codex_home = std::env::var_os("CODEX_HOME").filter(|value| !value.as_os_str().is_empty());
+    codex_config_path_from(codex_home, home_dir())
+}
+
+fn codex_config_path_from(
+    codex_home: Option<OsString>,
+    default_home: Option<PathBuf>,
+) -> Result<PathBuf, String> {
+    if let Some(value) = codex_home {
+        let path = PathBuf::from(value);
+        let metadata = std::fs::metadata(&path).map_err(|_| {
+            format!(
+                "CODEX_HOME points to {}, but that path does not exist or cannot be read",
+                path.display()
+            )
+        })?;
+        if !metadata.is_dir() {
+            return Err(format!(
+                "CODEX_HOME points to {}, but that path is not a directory",
+                path.display()
+            ));
+        }
+        let canonical = path
+            .canonicalize()
+            .map_err(|_| format!("failed to canonicalize CODEX_HOME at {}", path.display()))?;
+        return Ok(canonical.join("config.toml"));
+    }
+
+    let home =
+        default_home.ok_or_else(|| "could not find the user's home directory".to_string())?;
+    Ok(home.join(".codex").join("config.toml"))
+}
+
+pub fn discover_codex_mcp_servers(path: &Path) -> Result<Option<CodexMcpImport>, String> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(_) => {
+            return Err(format!(
+                "failed to read Codex configuration at {}",
+                path.display()
+            ));
+        }
+    };
+
+    parse_codex_mcp_servers(&contents, &|name| std::env::var(name).ok()).map(Some)
+}
+
+fn parse_codex_mcp_servers(
+    contents: &str,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> Result<CodexMcpImport, String> {
+    let root: toml::Value = toml::from_str(contents)
+        .map_err(|_| "Codex config.toml contains invalid TOML".to_string())?;
+    let root = root
+        .as_table()
+        .ok_or_else(|| "Codex config.toml must contain a TOML table".to_string())?;
+    let Some(value) = root.get("mcp_servers") else {
+        return Ok(CodexMcpImport::default());
+    };
+    let Some(servers) = value.as_table() else {
+        return Err("Codex `mcp_servers` must be a TOML table".to_string());
+    };
+
+    let mut names: Vec<&String> = servers.keys().collect();
+    names.sort();
+
+    let mut outcome = CodexMcpImport::default();
+    for name in names {
+        let value = &servers[name];
+        let Some(table) = value.as_table() else {
+            outcome
+                .report
+                .push(format!("{name} -> skipped: server entry must be a table"));
+            continue;
+        };
+
+        match parse_server(table, env_lookup) {
+            Ok(ServerImport::Imported {
+                spec,
+                ignored_fields,
+            }) => {
+                let mut line = if spec.disabled {
+                    format!("{name} -> imported from Codex (disabled)")
+                } else {
+                    format!("{name} -> imported from Codex")
+                };
+                if !ignored_fields.is_empty() {
+                    line.push_str("; unsupported fields ignored: ");
+                    line.push_str(&ignored_fields.join(", "));
+                }
+                outcome.servers.insert(name.clone(), *spec);
+                outcome.report.push(line);
+            }
+            Ok(ServerImport::Skipped(reason)) | Err(reason) => {
+                outcome.report.push(format!("{name} -> skipped: {reason}"));
+            }
+        }
+    }
+
+    Ok(outcome)
+}
+
+enum ServerImport {
+    Imported {
+        spec: Box<McpServerSpec>,
+        ignored_fields: Vec<String>,
+    },
+    Skipped(String),
+}
+
+fn parse_server(
+    table: &toml::Table,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> Result<ServerImport, String> {
+    let command = optional_string(table, "command")?;
+    let url = optional_string(table, "url")?;
+    if command.is_some() && url.is_some() {
+        return Ok(ServerImport::Skipped(
+            "both `command` and `url` are configured".to_string(),
+        ));
+    }
+    if url.is_some() {
+        return Ok(ServerImport::Skipped(
+            "streamable HTTP transport is not supported yet".to_string(),
+        ));
+    }
+    let Some(command) = command.filter(|value| !value.trim().is_empty()) else {
+        return Ok(ServerImport::Skipped(
+            "no non-empty stdio `command` is configured".to_string(),
+        ));
+    };
+
+    let environment_id = optional_string(table, "environment_id")?;
+    let experimental_environment = optional_string(table, "experimental_environment")?;
+    if environment_id
+        .as_deref()
+        .is_some_and(|value| value != "local")
+        || experimental_environment.as_deref() == Some("remote")
+    {
+        return Ok(ServerImport::Skipped(
+            "non-local execution environments are not supported".to_string(),
+        ));
+    }
+
+    let mut env = optional_string_map(table, "env")?.unwrap_or_default();
+    for env_var in optional_env_vars(table)?.unwrap_or_default() {
+        match env_var.source.as_deref() {
+            None | Some("local") => {
+                if !env.contains_key(&env_var.name)
+                    && let Some(value) = env_lookup(&env_var.name)
+                {
+                    env.insert(env_var.name, value);
+                }
+            }
+            Some("remote") => {
+                return Ok(ServerImport::Skipped(
+                    "remote-sourced `env_vars` are not supported".to_string(),
+                ));
+            }
+            Some(_) => {
+                return Err("`env_vars.source` must be `local` or `remote`".to_string());
+            }
+        }
+    }
+
+    let supported_fields = [
+        "args",
+        "command",
+        "cwd",
+        "disabled_tools",
+        "enabled",
+        "enabled_tools",
+        "env",
+        "env_vars",
+        "environment_id",
+        "experimental_environment",
+        "url",
+    ];
+    let supported: BTreeSet<&str> = supported_fields.into_iter().collect();
+    let mut ignored_fields = table
+        .keys()
+        .filter(|key| !supported.contains(key.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    ignored_fields.sort();
+
+    Ok(ServerImport::Imported {
+        spec: Box::new(McpServerSpec {
+            command: Some(command),
+            args: optional_string_list(table, "args")?.unwrap_or_default(),
+            env,
+            cwd: optional_string(table, "cwd")?,
+            disabled: !optional_bool(table, "enabled")?.unwrap_or(true),
+            transport: None,
+            url: None,
+            tools: optional_string_list(table, "enabled_tools")?,
+            disabled_tools: optional_string_list(table, "disabled_tools")?,
+            mode: None,
+        }),
+        ignored_fields,
+    })
+}
+
+#[derive(Debug)]
+struct EnvVarRef {
+    name: String,
+    source: Option<String>,
+}
+
+fn optional_env_vars(table: &toml::Table) -> Result<Option<Vec<EnvVarRef>>, String> {
+    let Some(value) = table.get("env_vars") else {
+        return Ok(None);
+    };
+    let Some(values) = value.as_array() else {
+        return Err("`env_vars` must be an array".to_string());
+    };
+
+    let mut result = Vec::with_capacity(values.len());
+    for value in values {
+        if let Some(name) = value.as_str() {
+            result.push(EnvVarRef {
+                name: name.to_string(),
+                source: None,
+            });
+            continue;
+        }
+        let Some(config) = value.as_table() else {
+            return Err("each `env_vars` entry must be a string or table".to_string());
+        };
+        let name = optional_string(config, "name")?
+            .ok_or_else(|| "an `env_vars` table is missing `name`".to_string())?;
+        let source = optional_string(config, "source")?;
+        result.push(EnvVarRef { name, source });
+    }
+    Ok(Some(result))
+}
+
+fn optional_string(table: &toml::Table, key: &str) -> Result<Option<String>, String> {
+    match table.get(key) {
+        None => Ok(None),
+        Some(value) => value
+            .as_str()
+            .map(|value| Some(value.to_string()))
+            .ok_or_else(|| format!("`{key}` must be a string")),
+    }
+}
+
+fn optional_bool(table: &toml::Table, key: &str) -> Result<Option<bool>, String> {
+    match table.get(key) {
+        None => Ok(None),
+        Some(value) => value
+            .as_bool()
+            .map(Some)
+            .ok_or_else(|| format!("`{key}` must be a boolean")),
+    }
+}
+
+fn optional_string_list(table: &toml::Table, key: &str) -> Result<Option<Vec<String>>, String> {
+    let Some(value) = table.get(key) else {
+        return Ok(None);
+    };
+    let Some(values) = value.as_array() else {
+        return Err(format!("`{key}` must be an array of strings"));
+    };
+    let mut result = Vec::with_capacity(values.len());
+    for value in values {
+        let Some(value) = value.as_str() else {
+            return Err(format!("`{key}` must contain only strings"));
+        };
+        result.push(value.to_string());
+    }
+    Ok(Some(result))
+}
+
+fn optional_string_map(
+    table: &toml::Table,
+    key: &str,
+) -> Result<Option<HashMap<String, String>>, String> {
+    let Some(value) = table.get(key) else {
+        return Ok(None);
+    };
+    let Some(values) = value.as_table() else {
+        return Err(format!("`{key}` must be a string map"));
+    };
+    let mut result = HashMap::with_capacity(values.len());
+    for (name, value) in values {
+        let Some(value) = value.as_str() else {
+            return Err(format!("`{key}` must contain only string values"));
+        };
+        result.insert(name.clone(), value.to_string());
+    }
+    Ok(Some(result))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn explicit_codex_home_is_canonicalized() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = codex_config_path_from(
+            Some(temp.path().as_os_str().to_os_string()),
+            Some(PathBuf::from("/unused")),
+        )
+        .unwrap();
+        assert_eq!(
+            path,
+            temp.path().canonicalize().unwrap().join("config.toml")
+        );
+    }
+
+    #[test]
+    fn default_codex_home_uses_dot_codex() {
+        let path = codex_config_path_from(None, Some(PathBuf::from("/home/tester"))).unwrap();
+        assert_eq!(path, PathBuf::from("/home/tester/.codex/config.toml"));
+    }
+
+    #[test]
+    fn imports_stdio_fields_and_filters_without_leaking_values() {
+        let contents = r#"
+[mcp_servers.demo]
+command = "npx"
+args = ["-y", "demo-server"]
+cwd = "/tmp/demo"
+enabled_tools = ["read", "write"]
+disabled_tools = ["write"]
+required = true
+env_vars = ["TOKEN", { name = "SECOND_TOKEN", source = "local" }]
+
+[mcp_servers.demo.env]
+STATIC_SECRET = "do-not-log-this"
+"#;
+        let outcome = parse_codex_mcp_servers(contents, &|name| match name {
+            "TOKEN" => Some("resolved-secret".to_string()),
+            "SECOND_TOKEN" => Some("second-secret".to_string()),
+            _ => None,
+        })
+        .unwrap();
+        let server = outcome.servers.get("demo").unwrap();
+        assert_eq!(server.command.as_deref(), Some("npx"));
+        assert_eq!(server.args, ["-y", "demo-server"]);
+        assert_eq!(server.cwd.as_deref(), Some("/tmp/demo"));
+        assert_eq!(
+            server.tools.as_ref().unwrap(),
+            &vec!["read".to_string(), "write".to_string()]
+        );
+        assert_eq!(
+            server.disabled_tools.as_ref().unwrap(),
+            &vec!["write".to_string()]
+        );
+        assert_eq!(
+            server.env.get("TOKEN").map(String::as_str),
+            Some("resolved-secret")
+        );
+        assert_eq!(
+            server.env.get("SECOND_TOKEN").map(String::as_str),
+            Some("second-secret")
+        );
+        assert_eq!(
+            server.env.get("STATIC_SECRET").map(String::as_str),
+            Some("do-not-log-this")
+        );
+        let report = outcome.report.join("\n");
+        assert!(report.contains("required"));
+        assert!(!report.contains("resolved-secret"));
+        assert!(!report.contains("second-secret"));
+        assert!(!report.contains("do-not-log-this"));
+    }
+
+    #[test]
+    fn imports_disabled_server_but_skips_http_and_remote_servers() {
+        let contents = r#"
+[mcp_servers.off]
+command = "off-server"
+enabled = false
+
+[mcp_servers.web]
+url = "https://example.invalid/mcp"
+
+[mcp_servers.remote]
+command = "remote-server"
+environment_id = "executor"
+"#;
+        let outcome = parse_codex_mcp_servers(contents, &|_| None).unwrap();
+        assert!(outcome.servers.get("off").unwrap().disabled);
+        assert!(!outcome.servers.contains_key("web"));
+        assert!(!outcome.servers.contains_key("remote"));
+        let report = outcome.report.join("\n");
+        assert!(report.contains("web -> skipped: streamable HTTP"));
+        assert!(report.contains("remote -> skipped: non-local"));
+    }
+
+    #[test]
+    fn bad_server_does_not_hide_valid_sibling() {
+        let contents = r#"
+[mcp_servers.bad]
+command = 42
+
+[mcp_servers.good]
+command = "good-server"
+"#;
+        let outcome = parse_codex_mcp_servers(contents, &|_| None).unwrap();
+        assert!(!outcome.servers.contains_key("bad"));
+        assert!(outcome.servers.contains_key("good"));
+        assert!(
+            outcome
+                .report
+                .join("\n")
+                .contains("bad -> skipped: `command`")
+        );
+    }
+
+    #[test]
+    fn remote_sourced_env_var_skips_only_that_server() {
+        let contents = r#"
+[mcp_servers.remote_env]
+command = "remote-env-server"
+env_vars = [{ name = "TOKEN", source = "remote" }]
+
+[mcp_servers.good]
+command = "good-server"
+"#;
+        let outcome = parse_codex_mcp_servers(contents, &|_| None).unwrap();
+        assert!(!outcome.servers.contains_key("remote_env"));
+        assert!(outcome.servers.contains_key("good"));
+        assert!(
+            outcome
+                .report
+                .join("\n")
+                .contains("remote_env -> skipped: remote-sourced `env_vars`")
+        );
+    }
+
+    #[test]
+    fn invalid_toml_error_does_not_echo_source() {
+        let secret = "secret-that-must-not-appear";
+        let contents = format!("[mcp_servers.demo]\ncommand = \\\"{secret}");
+        let error = parse_codex_mcp_servers(&contents, &|_| None).unwrap_err();
+        assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn missing_file_is_not_an_error() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let result = discover_codex_mcp_servers(&temp.path().join("missing.toml")).unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 
 use std::collections::HashMap;
 
+use crate::codex_mcp::{codex_config_path, discover_codex_mcp_servers};
 use crate::types::{
     AppConfig, CommandConfig, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig,
     OutputConfig, ProjectDocConfig, SkillsConfig, TreeConfig,
@@ -111,6 +112,101 @@ struct PartialExec {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct CodexMcpConfig {
+    enabled: Option<bool>,
+}
+
+impl CodexMcpConfig {
+    fn enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PartialMcpServerSpec {
+    command: Option<String>,
+    args: Option<Vec<String>>,
+    env: Option<HashMap<String, String>>,
+    cwd: Option<String>,
+    disabled: Option<bool>,
+    #[serde(rename = "type")]
+    transport: Option<String>,
+    url: Option<String>,
+    tools: Option<Vec<String>>,
+    disabled_tools: Option<Vec<String>>,
+    mode: Option<String>,
+}
+
+impl PartialMcpServerSpec {
+    fn overlay(self, mut base: McpServerSpec) -> McpServerSpec {
+        let Self {
+            command,
+            args,
+            env,
+            cwd,
+            disabled,
+            transport,
+            url,
+            tools,
+            disabled_tools,
+            mode,
+        } = self;
+        let sets_command = command.is_some();
+        let sets_url = url.is_some();
+        let sets_transport = transport.is_some();
+
+        if let Some(command) = command {
+            base.command = Some(command);
+        }
+        if let Some(args) = args {
+            base.args = args;
+        }
+        if let Some(env) = env {
+            base.env = env;
+        }
+        if let Some(cwd) = cwd {
+            base.cwd = Some(cwd);
+        }
+        if let Some(disabled) = disabled {
+            base.disabled = disabled;
+        }
+        if let Some(transport) = transport {
+            base.transport = Some(transport);
+        }
+        if let Some(url) = url {
+            base.url = Some(url);
+        }
+        if let Some(tools) = tools {
+            base.tools = Some(tools);
+        }
+        if let Some(disabled_tools) = disabled_tools {
+            base.disabled_tools = Some(disabled_tools);
+        }
+        if let Some(mode) = mode {
+            base.mode = Some(mode);
+        }
+
+        // Naming a different transport replaces the imported transport rather
+        // than leaving an impossible command+URL hybrid behind.
+        if sets_command && !sets_url {
+            base.url = None;
+            if !sets_transport {
+                base.transport = None;
+            }
+        } else if sets_url && !sets_command {
+            base.command = None;
+            if !sets_transport {
+                base.transport = Some("streamable-http".to_string());
+            }
+        }
+
+        base
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct FileConfig {
     api_key: Option<String>,
     port: Option<u16>,
@@ -123,8 +219,71 @@ struct FileConfig {
     memory: Option<MemoryConfig>,
     skills: Option<SkillsConfig>,
     ignore: Option<IgnoreConfig>,
+    codex_mcp: Option<CodexMcpConfig>,
     allowed_hosts: Option<Vec<String>>,
-    mcp_servers: Option<HashMap<String, McpServerSpec>>,
+    mcp_servers: Option<HashMap<String, PartialMcpServerSpec>>,
+}
+
+fn merge_mcp_servers(
+    mut imported: HashMap<String, McpServerSpec>,
+    explicit: HashMap<String, PartialMcpServerSpec>,
+) -> (HashMap<String, McpServerSpec>, Vec<String>) {
+    let mut entries: Vec<(String, PartialMcpServerSpec)> = explicit.into_iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    let mut report = Vec::new();
+    for (name, overlay) in entries {
+        let imported_entry = imported.remove(&name);
+        if imported_entry.is_some() {
+            report.push(format!(
+                "{name} -> imported fields overlaid by codex.config.json"
+            ));
+        }
+        let base = imported_entry.unwrap_or_default();
+        imported.insert(name, overlay.overlay(base));
+    }
+    (imported, report)
+}
+
+fn resolve_mcp_servers(file: &mut FileConfig) -> HashMap<String, McpServerSpec> {
+    let discovery_enabled = file.codex_mcp.take().unwrap_or_default().enabled();
+    let explicit = file.mcp_servers.take().unwrap_or_default();
+
+    if !discovery_enabled {
+        println!("Codex MCP discovery: disabled by codexMcp.enabled=false");
+        return merge_mcp_servers(HashMap::new(), explicit).0;
+    }
+
+    let path = match codex_config_path() {
+        Ok(path) => path,
+        Err(error) => {
+            println!("Codex MCP discovery: skipped ({error})");
+            return merge_mcp_servers(HashMap::new(), explicit).0;
+        }
+    };
+
+    let discovery = match discover_codex_mcp_servers(&path) {
+        Ok(Some(discovery)) => discovery,
+        Ok(None) => return merge_mcp_servers(HashMap::new(), explicit).0,
+        Err(error) => {
+            println!(
+                "Codex MCP discovery: failed for {} ({error})",
+                path.display()
+            );
+            return merge_mcp_servers(HashMap::new(), explicit).0;
+        }
+    };
+
+    let (servers, overlay_report) = merge_mcp_servers(discovery.servers, explicit);
+    let mut report = discovery.report;
+    report.extend(overlay_report);
+    if !report.is_empty() {
+        println!("Codex MCP discovery: {}", path.display());
+        for line in report {
+            println!("  {line}");
+        }
+    }
+    servers
 }
 
 /// A fully-defaulted config for a given work directory, matching what
@@ -195,7 +354,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
             .unwrap_or_default()
             .join(&config_path)
     };
-    let file: FileConfig = match std::fs::read_to_string(&config_path) {
+    let mut file: FileConfig = match std::fs::read_to_string(&config_path) {
         Ok(text) => {
             println!("Config: {}", display_path.display());
             serde_json::from_str(&text)
@@ -211,7 +370,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
     };
 
     let mut tree = default_tree();
-    if let Some(t) = file.tree {
+    if let Some(t) = file.tree.take() {
         if let Some(d) = t.default_depth {
             tree.default_depth = d;
         }
@@ -221,7 +380,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
     }
 
     let mut command = default_command();
-    if let Some(c) = file.command {
+    if let Some(c) = file.command.take() {
         if let Some(d) = c.default_timeout {
             command.default_timeout = d;
         }
@@ -231,7 +390,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
     }
 
     let mut exec = default_exec();
-    if let Some(e) = file.exec {
+    if let Some(e) = file.exec.take() {
         if let Some(m) = e.mode {
             exec.mode = m;
         }
@@ -245,6 +404,8 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
             exec.default_shell = e.default_shell;
         }
     }
+
+    let mcp_servers = resolve_mcp_servers(&mut file);
 
     Ok(AppConfig {
         work_dir,
@@ -262,7 +423,99 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
         skills: file.skills.unwrap_or_default(),
         ignore: file.ignore.unwrap_or_default(),
         allowed_hosts: file.allowed_hosts.unwrap_or_default(),
-        mcp_servers: file.mcp_servers.unwrap_or_default(),
+        mcp_servers,
         generated_skills_dir: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn imported_server() -> McpServerSpec {
+        McpServerSpec {
+            command: Some("codex-server".to_string()),
+            args: vec!["--stdio".to_string()],
+            env: HashMap::from([("TOKEN".to_string(), "secret".to_string())]),
+            cwd: Some("/codex/cwd".to_string()),
+            disabled: true,
+            transport: None,
+            url: None,
+            tools: Some(vec!["read".to_string()]),
+            disabled_tools: Some(vec!["write".to_string()]),
+            mode: None,
+        }
+    }
+
+    #[test]
+    fn local_entry_can_add_gateway_mode_without_repeating_launch_config() {
+        let imported = HashMap::from([("demo".to_string(), imported_server())]);
+        let explicit = HashMap::from([(
+            "demo".to_string(),
+            PartialMcpServerSpec {
+                mode: Some("gateway".to_string()),
+                disabled: Some(false),
+                ..Default::default()
+            },
+        )]);
+
+        let (merged, report) = merge_mcp_servers(imported, explicit);
+        let server = merged.get("demo").unwrap();
+        assert_eq!(server.command.as_deref(), Some("codex-server"));
+        assert_eq!(server.args, ["--stdio"]);
+        assert_eq!(server.env.get("TOKEN").map(String::as_str), Some("secret"));
+        assert_eq!(server.mode.as_deref(), Some("gateway"));
+        assert!(!server.disabled);
+        assert_eq!(report.len(), 1);
+    }
+
+    #[test]
+    fn explicit_command_replaces_imported_url_transport() {
+        let imported = HashMap::from([(
+            "demo".to_string(),
+            McpServerSpec {
+                transport: Some("streamable-http".to_string()),
+                url: Some("https://example.invalid/mcp".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let explicit = HashMap::from([(
+            "demo".to_string(),
+            PartialMcpServerSpec {
+                command: Some("local-server".to_string()),
+                ..Default::default()
+            },
+        )]);
+
+        let (merged, _) = merge_mcp_servers(imported, explicit);
+        let server = merged.get("demo").unwrap();
+        assert_eq!(server.command.as_deref(), Some("local-server"));
+        assert!(server.url.is_none());
+        assert!(server.transport.is_none());
+    }
+
+    #[test]
+    fn json_config_accepts_partial_camel_case_overlay() {
+        let file: FileConfig = serde_json::from_str(
+            r#"{
+                "codexMcp": { "enabled": false },
+                "mcpServers": {
+                    "demo": {
+                        "mode": "gateway",
+                        "disabledTools": ["write"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert!(!file.codex_mcp.as_ref().unwrap().enabled());
+        let demo = file.mcp_servers.as_ref().unwrap().get("demo").unwrap();
+        assert_eq!(demo.mode.as_deref(), Some("gateway"));
+        assert_eq!(
+            demo.disabled_tools.as_deref(),
+            Some(&["write".to_string()][..])
+        );
+        assert!(demo.command.is_none());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod apply_patch;
 pub mod auth;
 pub mod bridge;
+pub mod codex_mcp;
 pub mod config;
 pub mod environment;
 pub mod exec_policy;

--- a/src/tools/exec_command.rs
+++ b/src/tools/exec_command.rs
@@ -169,8 +169,7 @@ impl Tool for ExecCommand {
             ..Default::default()
         };
 
-        let is_error;
-        if exited {
+        let is_error = if exited {
             let code = exec_session.exit_code();
             result.exit_code = code;
             session
@@ -178,11 +177,11 @@ impl Tool for ExecCommand {
                 .lock()
                 .unwrap()
                 .remove(&exec_session.id);
-            is_error = code.unwrap_or(0) != 0;
+            code.unwrap_or(0) != 0
         } else {
             result.session_id = Some(exec_session.id);
-            is_error = false;
-        }
+            false
+        };
 
         let structured = serde_json::to_value(&result).unwrap_or(Value::Null);
         ToolResult {

--- a/src/tools/write_stdin.rs
+++ b/src/tools/write_stdin.rs
@@ -109,16 +109,15 @@ impl Tool for WriteStdin {
             ..Default::default()
         };
 
-        let is_error;
-        if exited {
+        let is_error = if exited {
             let code = exec_session.exit_code();
             result.exit_code = code;
             session.exec_sessions.lock().unwrap().remove(&session_id);
-            is_error = code.unwrap_or(0) != 0;
+            code.unwrap_or(0) != 0
         } else {
             result.session_id = Some(session_id);
-            is_error = false;
-        }
+            false
+        };
 
         let structured = serde_json::to_value(&result).unwrap_or(Value::Null);
         ToolResult {

--- a/src/types.rs
+++ b/src/types.rs
@@ -229,7 +229,7 @@ pub struct CommandConfig {
 /// name. Only stdio servers (a `command`) are bridged today; `type: "sse"|"http"`
 /// / `url` entries are recognised and reported as not-yet-supported rather than
 /// failing the whole config.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpServerSpec {
     /// The executable to launch (e.g. `idasql`, `npx`, `python`). Absent for
@@ -240,6 +240,10 @@ pub struct McpServerSpec {
     pub args: Vec<String>,
     #[serde(default)]
     pub env: std::collections::HashMap<String, String>,
+    /// Working directory for the launched stdio server. When absent, the child
+    /// inherits codexrr's process working directory.
+    #[serde(default)]
+    pub cwd: Option<String>,
     /// Skip this server without removing it from the config.
     #[serde(default)]
     pub disabled: bool,
@@ -256,6 +260,10 @@ pub struct McpServerSpec {
     /// some (including ChatGPT) cap how many a connector may expose.
     #[serde(default)]
     pub tools: Option<Vec<String>>,
+    /// Upstream tool names removed after applying `tools`, matching Codex's
+    /// `disabled_tools` semantics.
+    #[serde(default)]
+    pub disabled_tools: Option<Vec<String>>,
     /// How the upstream's tools are exposed:
     /// - `"direct"` (default): each upstream tool becomes its own `<server>__<tool>`.
     /// - `"gateway"`: the whole server collapses into ONE dispatcher tool named


### PR DESCRIPTION
## What changed

- discover the user-level Codex configuration at `$CODEX_HOME/config.toml`, falling back to `~/.codex/config.toml`
- import compatible local stdio MCP fields: `command`, `args`, `env`, local `env_vars`, `cwd`, `enabled`, `enabled_tools`, and `disabled_tools`
- skip unsupported HTTP and non-local execution entries with deterministic, secret-safe startup diagnostics
- merge explicit `codex.config.json.mcpServers` entries as field overlays, so bridge-only settings such as `mode: "gateway"` can be added without duplicating launch configuration
- add `codexMcp.enabled = false` as a global opt-out
- apply Codex's deny-list after its allow-list and honor per-server child working directories
- document discovery, precedence, supported fields, limitations, and the security implications

The importer is intentionally limited to Codex's user-level config. It does not attempt to reproduce Codex's project-local layering and trust semantics.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --all` — 348 tests passed
- `cargo clippy --all-targets -- -D warnings`
- startup smoke test with an isolated temporary `CODEX_HOME`, a disabled imported server, and a local gateway overlay

Closes #3
