### PR TITLE
feat: support persistent per-conversation project roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project aims to
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Per-session project-root selection.** Start with `--multi-project` (or
+  `multiProject: true`) to make `--work-dir` an access root. Each MCP session
+  binds once with `set_project_root`; project tools, command working directories,
+  git operations, `AGENTS.md`, repo skills, plans, and notes then use that
+  session's independently selected root. Canonical containment checks reject
+  traversal and symlink escapes, and project-aware tools remain unavailable until
+  selection.
+
 ## [1.0.0] - 2026-08-19
 
 The first Rust release. The server was rewritten from Bun + TypeScript to Rust

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- **Per-session project-root selection.** Start with `--multi-project` (or
-  `multiProject: true`) to make `--work-dir` an access root. Each MCP session
-  binds once with `set_project_root`; project tools, command working directories,
-  git operations, `AGENTS.md`, repo skills, plans, and notes then use that
-  session's independently selected root. Canonical containment checks reject
-  traversal and symlink escapes, and project-aware tools remain unavailable until
-  selection.
+- **Persistent per-conversation project-root selection.** Start with
+  `--multi-project` (or `multiProject: true`) to make `--work-dir` an access root.
+  ChatGPT conversations bind once with `set_project_root`; the binding is keyed
+  from `_meta["openai/session"]`, stored under `~/.codex-free/` without persisting
+  the raw identifier, and restored across MCP reconnects and server restarts.
+  Project tools, command working directories, git operations, `AGENTS.md`, repo
+  skills, plans, and notes then use that conversation's independently selected
+  root. Clients without ChatGPT conversation metadata retain the transport-session
+  fallback. Canonical containment checks reject traversal and symlink escapes,
+  and project-aware tools remain unavailable until selection.
 
 ## [1.0.0] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To reuse one server across several independent projects, point it at their commo
 cargo run --release -- --work-dir /path/to/projects --multi-project
 ```
 
-Here `--work-dir` is an **access root**, not the active project. Every new MCP session must first call `set_project_root` with an existing directory beneath it, then call `get_agent_brief`. The chosen root is canonicalized and permanently bound to that session; selecting another project requires a new chat/MCP session. Project-scoped tools reject calls until the selection is made.
+Here `--work-dir` is an **access root**, not the active project. In ChatGPT, `set_project_root` binds the current conversation to one existing directory beneath that root. Codexrr keys the binding from ChatGPT's `_meta["openai/session"]` conversation identifier and persists it outside the repository, so later turns in the same chat recover the project after an MCP reconnect or codexrr restart. A new chat gets a new binding and an existing chat cannot switch projects. Clients that do not provide `openai/session` fall back to a one-time MCP transport-session binding and must select again after reconnecting.
 
 To build a standalone binary:
 
@@ -95,7 +95,7 @@ Each release ships a compiled binary per platform — `windows-x64`, `linux-x64`
 | Flag | Required | Default | Description |
 |------|----------|---------|-------------|
 | `--work-dir` | Yes | - | Project directory, or the project access root with `--multi-project` |
-| `--multi-project` | No | Disabled | Require each MCP session to bind once to a project beneath `--work-dir` |
+| `--multi-project` | No | Disabled | Let each ChatGPT conversation bind once to a project beneath `--work-dir`; other clients fall back to transport-session binding |
 | `--port` | No | `3000` | Server port |
 | `--api-key` | No | - | Bearer token for auth |
 | `--config` | No | `./codex.config.json` | Config file path (tolerated if missing) |
@@ -144,11 +144,11 @@ Five always-on tools have no Codex counterpart:
 | `remember` | Save one durable note about the task under a short key |
 | `recall` | Return the plan and notes saved by earlier turns or earlier conversations |
 
-Multi-project mode adds one session-control tool:
+Multi-project mode adds one project-control tool:
 
 | Tool | Description |
 |------|-------------|
-| `set_project_root` | Bind the current MCP session to one existing directory beneath the configured access root; repeated selection of the same canonical directory is idempotent, but switching is rejected |
+| `set_project_root` | Bind the current ChatGPT conversation to one existing directory beneath the configured access root; repeated selection of the same canonical directory is idempotent, but switching is rejected. Without ChatGPT conversation metadata, the binding lasts for the MCP transport session |
 
 Codex needs the first three for none of these reasons: it puts its agent brief in the system prompt, the OS and shell in an `<environment_context>` message, and `AGENTS.md` straight into the prompt, all before the first turn. An MCP server has none of those channels — it can only expose tools — so the same facts are tool calls here as well as part of the server's `instructions`. It needs `remember` and `recall` for the opposite reason: its context is large and its session state lives in the CLI process, whereas the client here is a chat window that loses the conversation. See [Context and memory](#context-and-memory), [Acting as a Codex agent](#acting-as-a-codex-agent), [Shells and the host](#shells-and-the-host), [AGENTS.md](#agentsmd) and [Skills](#skills).
 
@@ -163,7 +163,7 @@ Two deliberate differences from Codex:
 
 Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it.
 
-All project-scoped paths are resolved relative to the active project root: `--work-dir` in single-project mode, or the root selected for that MCP session in multi-project mode.
+All project-scoped paths are resolved relative to the active project root: `--work-dir` in single-project mode, or the root selected for the current ChatGPT conversation in multi-project mode. Non-ChatGPT clients use the root selected for their current MCP transport session.
 
 ## Config file
 
@@ -221,7 +221,7 @@ All project-scoped paths are resolved relative to the active project root: `--wo
 
 CLI flags override values from the config file.
 
-The top-level `multiProject` key is the config-file equivalent of `--multi-project`. In that mode the process still reads one static `codex.config.json`; project selection changes the effective work directory used by project-scoped tools, not the server configuration itself.
+The top-level `multiProject` key is the config-file equivalent of `--multi-project`. In that mode the process still reads one static `codex.config.json`; project selection changes the effective work directory used by project-scoped tools, not the server configuration itself. ChatGPT conversation bindings are independent of the `memory` block and remain enabled even when `memory.enabled` is `false`.
 
 The `exec` block governs `exec_command` and `write_stdin`:
 
@@ -293,9 +293,11 @@ That line matters as much as the cap. Silent truncation reads as "that was the w
 
 **Keep what would be expensive to rediscover.** `remember` writes one keyed note; `recall` hands back the notes and the current plan. `update_plan` persists too, so the plan survives the conversation that made it. Writing to a key that exists replaces it, and an empty value deletes it — a keyed store stays current where an append log accumulates contradictions until it is worthless.
 
-State lives in `~/.codex-free/projects/<name>-<hash>/memory.json`, keyed by the absolute active project root. Nothing is written into the repository you pointed the server at, and two checkouts of the same repo do not share notes. Multi-project sessions therefore share state only when they select the same canonical project root.
+Task state lives in `~/.codex-free/projects/<name>-<hash>/memory.json`, keyed by the absolute active project root. Nothing is written into the repository you pointed the server at, and two checkouts of the same repo do not share notes. Multi-project conversations therefore share task state only when they select the same canonical project root.
 
-In single-project mode, `instructions` is rebuilt for every MCP session, so a new conversation opens with the saved plan and notes already in front of it, under a `## Saved state` heading between the environment and `AGENTS.md`. In multi-project mode the initialize-time instructions deliberately contain only the selection protocol: project state cannot be loaded correctly until `set_project_root` identifies the root. The subsequent `get_agent_brief` call returns the environment, saved state, skills, and `AGENTS.md` for that selected project. If the client ignores `instructions`, one `recall` gets the same saved state after selection.
+ChatGPT project bindings live separately under `~/.codex-free/conversation-projects/<access-root-hash>/<conversation-hash>.json`. The raw `openai/session` value is never written to disk; only its SHA-256-derived key is used as the filename. Each small record contains the canonical access root and selected project root. Delete this directory to forget all conversation bindings. A missing or stale project fails closed rather than silently rebinding the conversation to another directory.
+
+In single-project mode, `instructions` is rebuilt for every MCP session, so a new conversation opens with the saved plan and notes already in front of it, under a `## Saved state` heading between the environment and `AGENTS.md`. In multi-project mode the initialize-time instructions deliberately remain project-neutral: ChatGPT supplies its stable conversation identifier on tool calls, after the MCP initialize exchange. Calling `get_agent_brief` restores an existing conversation binding automatically; for a new conversation it reports that `set_project_root` is required. After binding, `get_agent_brief` returns the environment, saved state, skills, and `AGENTS.md` for the selected project. If the client ignores `instructions`, one `recall` gets the same saved state after selection.
 
 The division of labour is worth keeping straight: `AGENTS.md` is what is true of the **project** and belongs in the repo; notes are what is true of the **task in flight** and belong here.
 
@@ -327,7 +329,7 @@ Task: <what you want done>
 
 Everything else — the shell you're on, the allowlist, your repo's `AGENTS.md` — arrives with that one call. If a chat starts drifting back into generic-assistant behaviour, asking for the brief again re-anchors it.
 
-In multi-project mode, select before requesting the brief:
+For a new chat in multi-project mode, select before requesting the brief:
 
 ```
 Call set_project_root with path "my-project", then call get_agent_brief and follow it for the rest of this chat.
@@ -335,7 +337,17 @@ Call set_project_root with path "my-project", then call get_agent_brief and foll
 Task: <what you want done>
 ```
 
-The path may be relative to the configured access root or absolute, but its canonical target must be an existing directory inside that root. The binding belongs to the MCP session, not globally to the server, so simultaneous chats may select different projects without sharing plans, notes, command sessions, project instructions, or repo skills. A session cannot switch roots after binding; start another chat for another project.
+The path may be relative to the configured access root or absolute, but its canonical target must be an existing directory inside that root. The binding belongs to the ChatGPT conversation, not to the current HTTP/MCP transport, so simultaneous chats may select different projects and later turns recover their respective project roots after reconnects or server restarts. A conversation cannot switch roots after binding; start another chat for another project. Calling `set_project_root` again with the same canonical path is harmless.
+
+On a later turn in an already-bound chat, the path does not need to be repeated:
+
+```
+Call get_agent_brief and follow it for the rest of this task.
+
+Task: <what you want done>
+```
+
+Only project identity is conversation-persistent. A live `exec_command` process and its numeric `session_id` remain tied to the current MCP transport and are deliberately discarded when that transport closes; stale process handles are not resurrected on a later follow-up.
 
 ## Shells and the host
 
@@ -486,7 +498,7 @@ This registers one tool named `remote_exec` taking `{ "function": "<name>", "arg
 5. Set the **Server URL** to the tunnel URL with `/mcp` appended, e.g. `https://<your-tunnel>/mcp`.
 6. Set **Authentication** to "No Auth".
 7. After creating the plugin, go to **Permissions** and set it to **Allow all actions** so ChatGPT can call tools without asking for confirmation each time.
-8. In a new chat, enable the plugin from the composer's tools menu, then open with `Call get_agent_brief and follow it for the rest of this chat.` In multi-project mode, call `set_project_root` first — see [Acting as a Codex agent](#acting-as-a-codex-agent).
+8. In a new chat, enable the plugin from the composer's tools menu, then open with `Call get_agent_brief and follow it for the rest of this chat.` In multi-project mode, call `set_project_root` first for a new chat. Later follow-ups in that same chat can call `get_agent_brief` directly; the project binding is restored from ChatGPT's conversation metadata.
 
 > ChatGPT Plugins only support OAuth, No Auth, and Mixed. The `--api-key` option is for non-ChatGPT clients or tunnel-level auth. When using ChatGPT, secure access through your tunnel provider instead (e.g. ngrok IP restrictions, Cloudflare Access).
 
@@ -496,19 +508,19 @@ By default `allowedHosts` is empty, which accepts any `Host` header — the serv
 
 ## Security
 
-- **Path traversal prevention**: every filesystem tool — including `apply_patch` and `view_image` — resolves paths through a guard that rejects anything outside the active project root. In multi-project mode, `set_project_root` canonicalizes both the configured access root and the requested directory, so `..` and symlinks cannot bind a session outside the access root.
+- **Path traversal prevention**: every filesystem tool — including `apply_patch` and `view_image` — resolves paths through a guard that rejects anything outside the active project root. In multi-project mode, `set_project_root` canonicalizes both the configured access root and the requested directory, so `..` and symlinks cannot bind a conversation or transport session outside the access root.
 - **One bounded exception in single-project mode**: [AGENTS.md](#agentsmd) discovery may read above `--work-dir`, up to the nearest `.git`. It is read-only, opens only `AGENTS.override.md`, `AGENTS.md` and any `projectDoc.fallbackFilenames`, and `get_project_doc` reports the absolute path of every file it used. Set `projectDoc.maxBytes` to `0` to switch it off, or `projectDoc.rootMarkers` to `[]` to keep the search inside the work directory. Multi-project mode does not perform this upward walk; its selected directory is the exact project root.
-- **One bounded write outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/`, deliberately outside the repository so nothing lands in your git history. It holds whatever the model chose to note about the task — read it if you want to know, delete the directory to forget, or set `memory.enabled` to `false` to never write it. The write is atomic (temp file plus rename) and guarded by a per-project lock, so a crash mid-write never leaves a torn file and two servers pointed at the same work directory do not lose each other's notes to an interleaved update. See [Context and memory](#context-and-memory).
+- **Bounded state writes outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/projects/`. Multi-project mode also writes one small project-binding record under `~/.codex-free/conversation-projects/` for each ChatGPT conversation and access root. Both use atomic replacement and per-record locks. The binding filename is derived from a hash of `openai/session`; the raw identifier is not stored. Set `memory.enabled` to `false` to disable plans and notes; delete `~/.codex-free/conversation-projects/` separately to forget conversation bindings. See [Context and memory](#context-and-memory).
 - **Bounded reads outside the work directory**: [skills](#skills) may live in `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` or an installed Claude Code plugin. `skills_read` opens files there, but only inside a skill package that already exists — the `resource` path is checked against the skill's own directory, so it cannot walk out into the rest of your home directory. `skills_list` reports the absolute path of every skill it found. Set `skills.enabled` to `false` to switch it off, or `skills.dirs` to point the user scope somewhere you choose.
 - **Command allowlist**: `run_command` only runs binaries listed in `allowedCommands`; everything else is rejected. `exec_command` checks the same list plus `exec.extraAllowedCommands`, at every command position in the string.
 - **Bridged servers run with your privileges**: an `mcpServers` entry launches a real process on your machine and forwards the model's calls to it verbatim. Only bridge servers you trust, and prefer `tools` allow-lists or `gateway` mode to keep the exposed surface small. A bad `command` path is reported, never silently ignored.
 - **Optional bearer token auth**: set `--api-key` to require an `Authorization: Bearer <key>` header on all requests (except `/health`). Useful for non-ChatGPT clients. ChatGPT Plugins do not support simple bearer token auth.
 - **Host allowlist**: set `allowedHosts` to pin the accepted `Host` header for DNS-rebinding protection. See [Host allowlist](#host-allowlist).
 
-The allowlist is a **guardrail against accidents, not a sandbox**. It catches a model reaching for `curl` or `rm -rf`; it does not contain a determined one. The defaults already include `node`, `python` and `cargo`, each of which runs arbitrary code — `node -e "..."` can do anything the server process can. Shell redirection and explicit absolute or parent paths can also reach outside the active project root even though each command starts with that root as its cwd. Multi-project selection isolates Codexrr's structured tools and per-session state; it is not an operating-system sandbox. Treat everything below as reachable by whoever holds the tunnel URL:
+The allowlist is a **guardrail against accidents, not a sandbox**. It catches a model reaching for `curl` or `rm -rf`; it does not contain a determined one. The defaults already include `node`, `python` and `cargo`, each of which runs arbitrary code — `node -e "..."` can do anything the server process can. Shell redirection and explicit absolute or parent paths can also reach outside the active project root even though each command starts with that root as its cwd. Multi-project selection isolates Codexrr's structured tools and logical per-conversation project state; it is not an operating-system sandbox. Treat everything below as reachable by whoever holds the tunnel URL:
 
 - everything in the active project root, read and write
-- in multi-project mode, any project beneath the configured access root can be selected by a new session
+- in multi-project mode, any project beneath the configured access root can be selected by a new conversation or unbound transport session
 - anything else the user account running the server can touch, via an allowlisted interpreter
 - the network, from your machine
 - anything a bridged MCP server can do

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ cargo run --release -- --work-dir /path/to/your/project
 
 Server starts on `http://localhost:3000`. The MCP endpoint is `/mcp`; a health check is at `/health`.
 
+To reuse one server across several independent projects, point it at their common parent and enable multi-project mode:
+
+```bash
+cargo run --release -- --work-dir /path/to/projects --multi-project
+```
+
+Here `--work-dir` is an **access root**, not the active project. Every new MCP session must first call `set_project_root` with an existing directory beneath it, then call `get_agent_brief`. The chosen root is canonicalized and permanently bound to that session; selecting another project requires a new chat/MCP session. Project-scoped tools reject calls until the selection is made.
+
 To build a standalone binary:
 
 ```bash
@@ -86,7 +94,8 @@ Each release ships a compiled binary per platform — `windows-x64`, `linux-x64`
 
 | Flag | Required | Default | Description |
 |------|----------|---------|-------------|
-| `--work-dir` | Yes | - | Project directory the tools operate on |
+| `--work-dir` | Yes | - | Project directory, or the project access root with `--multi-project` |
+| `--multi-project` | No | Disabled | Require each MCP session to bind once to a project beneath `--work-dir` |
 | `--port` | No | `3000` | Server port |
 | `--api-key` | No | - | Bearer token for auth |
 | `--config` | No | `./codex.config.json` | Config file path (tolerated if missing) |
@@ -125,7 +134,7 @@ Ported from Codex's own agent tools:
 
 Codex's dotted names are flattened to underscores because MCP tool names must match `^[a-zA-Z0-9_-]{1,64}$`.
 
-Five tools have no Codex counterpart:
+Five always-on tools have no Codex counterpart:
 
 | Tool | Description |
 |------|-------------|
@@ -135,9 +144,15 @@ Five tools have no Codex counterpart:
 | `remember` | Save one durable note about the task under a short key |
 | `recall` | Return the plan and notes saved by earlier turns or earlier conversations |
 
+Multi-project mode adds one session-control tool:
+
+| Tool | Description |
+|------|-------------|
+| `set_project_root` | Bind the current MCP session to one existing directory beneath the configured access root; repeated selection of the same canonical directory is idempotent, but switching is rejected |
+
 Codex needs the first three for none of these reasons: it puts its agent brief in the system prompt, the OS and shell in an `<environment_context>` message, and `AGENTS.md` straight into the prompt, all before the first turn. An MCP server has none of those channels — it can only expose tools — so the same facts are tool calls here as well as part of the server's `instructions`. It needs `remember` and `recall` for the opposite reason: its context is large and its session state lives in the CLI process, whereas the client here is a chat window that loses the conversation. See [Context and memory](#context-and-memory), [Acting as a Codex agent](#acting-as-a-codex-agent), [Shells and the host](#shells-and-the-host), [AGENTS.md](#agentsmd) and [Skills](#skills).
 
-That is 25 native tools. When [MCP bridging](#bridging-other-mcp-servers) is configured, the tools of your other MCP servers are re-exposed here too, on top of these.
+That is 25 native tools in the default single-project mode and 26 in multi-project mode. When [MCP bridging](#bridging-other-mcp-servers) is configured, the tools of your other MCP servers are re-exposed here too, on top of these.
 
 Two deliberate differences from Codex:
 
@@ -148,7 +163,7 @@ Two deliberate differences from Codex:
 
 Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it.
 
-All paths are resolved relative to `--work-dir`.
+All project-scoped paths are resolved relative to the active project root: `--work-dir` in single-project mode, or the root selected for that MCP session in multi-project mode.
 
 ## Config file
 
@@ -156,6 +171,7 @@ All paths are resolved relative to `--work-dir`.
 
 ```json
 {
+  "multiProject": false,
   "allowedCommands": ["bun", "npm", "npx", "node", "git", "python", "pip", "cargo", "make"],
   "port": 3000,
   "tree": {
@@ -205,6 +221,8 @@ All paths are resolved relative to `--work-dir`.
 
 CLI flags override values from the config file.
 
+The top-level `multiProject` key is the config-file equivalent of `--multi-project`. In that mode the process still reads one static `codex.config.json`; project selection changes the effective work directory used by project-scoped tools, not the server configuration itself.
+
 The `exec` block governs `exec_command` and `write_stdin`:
 
 | Key | Default | Description |
@@ -248,7 +266,7 @@ The `memory` block governs `remember`, `recall` and the plan `update_plan` saves
 | Key | Default | Description |
 |-----|---------|-------------|
 | `enabled` | `true` | `false` turns persistence off entirely; nothing is read or written |
-| `dir` | `~/.codex-free/projects/<name>-<hash of work-dir>` | Where the state file lives. Outside the repository by default |
+| `dir` | `~/.codex-free/projects/<name>-<hash of work-dir>` | Where the state file lives. Outside the repository by default. In multi-project mode, an explicit `dir` is treated as a base directory and each selected project gets its own hashed child directory |
 | `maxBytes` | `16384` | Budget for all notes together. A note over it is rejected, not silently evicted |
 
 The `skills` block governs `SKILL.md` discovery. See [Skills](#skills):
@@ -275,9 +293,9 @@ That line matters as much as the cap. Silent truncation reads as "that was the w
 
 **Keep what would be expensive to rediscover.** `remember` writes one keyed note; `recall` hands back the notes and the current plan. `update_plan` persists too, so the plan survives the conversation that made it. Writing to a key that exists replaces it, and an empty value deletes it — a keyed store stays current where an append log accumulates contradictions until it is worthless.
 
-State lives in `~/.codex-free/projects/<name>-<hash>/memory.json`, keyed by the absolute work directory. Nothing is written into the repository you pointed the server at, and two checkouts of the same repo do not share notes.
+State lives in `~/.codex-free/projects/<name>-<hash>/memory.json`, keyed by the absolute active project root. Nothing is written into the repository you pointed the server at, and two checkouts of the same repo do not share notes. Multi-project sessions therefore share state only when they select the same canonical project root.
 
-Because `instructions` is rebuilt for every MCP session, a new conversation opens with the saved plan and notes already in front of it, under a `## Saved state` heading between the environment and `AGENTS.md`. If the client ignores `instructions`, one `recall` gets the same thing.
+In single-project mode, `instructions` is rebuilt for every MCP session, so a new conversation opens with the saved plan and notes already in front of it, under a `## Saved state` heading between the environment and `AGENTS.md`. In multi-project mode the initialize-time instructions deliberately contain only the selection protocol: project state cannot be loaded correctly until `set_project_root` identifies the root. The subsequent `get_agent_brief` call returns the environment, saved state, skills, and `AGENTS.md` for that selected project. If the client ignores `instructions`, one `recall` gets the same saved state after selection.
 
 The division of labour is worth keeping straight: `AGENTS.md` is what is true of the **project** and belongs in the repo; notes are what is true of the **task in flight** and belong here.
 
@@ -309,6 +327,16 @@ Task: <what you want done>
 
 Everything else — the shell you're on, the allowlist, your repo's `AGENTS.md` — arrives with that one call. If a chat starts drifting back into generic-assistant behaviour, asking for the brief again re-anchors it.
 
+In multi-project mode, select before requesting the brief:
+
+```
+Call set_project_root with path "my-project", then call get_agent_brief and follow it for the rest of this chat.
+
+Task: <what you want done>
+```
+
+The path may be relative to the configured access root or absolute, but its canonical target must be an existing directory inside that root. The binding belongs to the MCP session, not globally to the server, so simultaneous chats may select different projects without sharing plans, notes, command sessions, project instructions, or repo skills. A session cannot switch roots after binding; start another chat for another project.
+
 ## Shells and the host
 
 Windows, macOS and Linux are all supported natively; there is no WSL or POSIX-emulation layer in between. Which shell runs is decided by name, not by host platform, the same way Codex's `Shell::derive_exec_args` does it:
@@ -333,7 +361,7 @@ Because the resolved shell decides what a command should even look like, it is p
 
 A project's `AGENTS.md` is how it tells an agent its own conventions — which test command to run, which files not to touch, how commits should look. Codex reads it before the first turn; so does this bridge, using the same algorithm as `codex-rs/core/src/agents_md.rs`.
 
-Discovery walks up from `--work-dir` to the nearest directory holding a **root marker** (`.git` by default), then collects **one doc per directory on the way back down**, so a monorepo's root conventions arrive before the ones belonging to the subdirectory you pointed the server at. In each directory, `AGENTS.override.md` wins over `AGENTS.md`, which wins over anything in `projectDoc.fallbackFilenames`. The files are concatenated outermost-first under a **shared 32 KiB budget**, counted in bytes rather than characters; a file that runs past what is left is cut there and reported as truncated, and whitespace-only files are skipped without spending any of it. If no marker is found anywhere above, only the work directory itself is checked.
+In single-project mode, discovery walks up from `--work-dir` to the nearest directory holding a **root marker** (`.git` by default), then collects **one doc per directory on the way back down**, so a monorepo's root conventions arrive before the ones belonging to the subdirectory you pointed the server at. In multi-project mode the selected directory is treated as the exact project root and discovery never reads an access-root parent, preventing instructions from one sibling project or the common parent from leaking into another session. In each directory considered, `AGENTS.override.md` wins over `AGENTS.md`, which wins over anything in `projectDoc.fallbackFilenames`. The files are concatenated outermost-first under a **shared 32 KiB budget**, counted in bytes rather than characters; a file that runs past what is left is cut there and reported as truncated, and whitespace-only files are skipped without spending any of it. If no marker is found anywhere above in single-project mode, only the work directory itself is checked.
 
 Like the environment, the result is published more than one way:
 
@@ -373,7 +401,7 @@ description: Cut and publish a release of this project
 
 | Scope | Directories |
 |-------|-------------|
-| `repo` | `.agents/skills`, `.codex/skills` and `.claude/skills`, in every directory from the project root down to `--work-dir` |
+| `repo` | `.agents/skills`, `.codex/skills` and `.claude/skills`, in every directory from the project root down to the active work directory; in multi-project mode the selected directory is the exact project root |
 | `user` | `~/.agents/skills`, `~/.codex/skills` and `~/.claude/skills`, or whatever `skills.dirs` names instead |
 | `plugin` | Installed **Claude Code plugin** skills under `~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/skills/*` |
 
@@ -381,9 +409,9 @@ Repo skills come first, so a project decides how a name behaves inside it; a per
 
 **Claude Code plugins.** Codexrr also discovers skills bundled with your installed Claude Code plugins, namespaced `<plugin>:<skill>` (e.g. `idasql:decompiler`) so they never collide with your own. The highest installed version of each plugin is used. Turn this off with `"skills": { "includePlugins": false }`. Setting `skills.dirs` overrides the standalone roots and, by default, disables plugin discovery too — set `includePlugins: true` alongside `dirs` to keep it.
 
-**What the model sees.** The catalogue — a name and a description per skill — goes into `instructions` under a `## Skills` heading, so a chat opens knowing what is available without spending a call to find out. Bodies are not loaded: `skills_read` fetches one only once a skill has actually been chosen. That is the progressive disclosure that makes a large library affordable on a small context window. The section is omitted entirely when nothing is installed.
+**What the model sees.** The catalogue — a name and a description per skill — goes into the project-aware brief under a `## Skills` heading. In single-project mode that is available at initialization; in multi-project mode it arrives from `get_agent_brief` after selection. Bodies are not loaded: `skills_read` fetches one only once a skill has actually been chosen. That is the progressive disclosure that makes a large library affordable on a small context window. The section is omitted entirely when nothing is installed.
 
-**Reaching the rest of a package.** Reference files, scripts and assets are read with `skills_read` and the skill's name, passing the file's path as `resource`. `read_file` will not do: it is confined to `--work-dir`, and user- and plugin-scope skills live in your home directory. Paths inside a skill are relative to the skill's own directory, and a `resource` that tries to leave it is rejected — so the only thing this opens up is the inside of a skill you or the project deliberately installed. Reading a `SKILL.md` lists the package's other files, since the model cannot glob a directory it cannot see.
+**Reaching the rest of a package.** Reference files, scripts and assets are read with `skills_read` and the skill's name, passing the file's path as `resource`. `read_file` will not do: it is confined to the active project root, and user- and plugin-scope skills live in your home directory. Paths inside a skill are relative to the skill's own directory, and a `resource` that tries to leave it is rejected — so the only thing this opens up is the inside of a skill you or the project deliberately installed. Reading a `SKILL.md` lists the package's other files, since the model cannot glob a directory it cannot see.
 
 Discovery runs per MCP session, so adding a skill takes effect on the next connection without restarting the server. Set `skills.enabled` to `false` to turn the whole thing off.
 
@@ -449,7 +477,7 @@ This registers one tool named `remote_exec` taking `{ "function": "<name>", "arg
 ## Connecting to ChatGPT
 
 1. In ChatGPT, go to **Settings > Security and login** and enable **Developer mode**.
-2. Start the server: `cargo run --release -- --work-dir /path/to/your/project` (or run the release binary directly).
+2. Start the server: `cargo run --release -- --work-dir /path/to/your/project` (or use `--work-dir /path/to/projects --multi-project` for one connector shared across projects).
 3. Expose it with a tunnel (ngrok, Cloudflare Tunnel, etc.):
    ```bash
    ngrok http 3000
@@ -458,7 +486,7 @@ This registers one tool named `remote_exec` taking `{ "function": "<name>", "arg
 5. Set the **Server URL** to the tunnel URL with `/mcp` appended, e.g. `https://<your-tunnel>/mcp`.
 6. Set **Authentication** to "No Auth".
 7. After creating the plugin, go to **Permissions** and set it to **Allow all actions** so ChatGPT can call tools without asking for confirmation each time.
-8. In a new chat, enable the plugin from the composer's tools menu, then open with `Call get_agent_brief and follow it for the rest of this chat.` — see [Acting as a Codex agent](#acting-as-a-codex-agent).
+8. In a new chat, enable the plugin from the composer's tools menu, then open with `Call get_agent_brief and follow it for the rest of this chat.` In multi-project mode, call `set_project_root` first — see [Acting as a Codex agent](#acting-as-a-codex-agent).
 
 > ChatGPT Plugins only support OAuth, No Auth, and Mixed. The `--api-key` option is for non-ChatGPT clients or tunnel-level auth. When using ChatGPT, secure access through your tunnel provider instead (e.g. ngrok IP restrictions, Cloudflare Access).
 
@@ -468,8 +496,8 @@ By default `allowedHosts` is empty, which accepts any `Host` header — the serv
 
 ## Security
 
-- **Path traversal prevention**: every filesystem tool — including `apply_patch` and `view_image` — resolves paths through a guard that rejects anything outside `--work-dir`.
-- **One bounded exception**: [AGENTS.md](#agentsmd) discovery reads above `--work-dir`, up to the nearest `.git`. Nothing else does. It is read-only, opens only `AGENTS.override.md`, `AGENTS.md` and any `projectDoc.fallbackFilenames`, and `get_project_doc` reports the absolute path of every file it used. Set `projectDoc.maxBytes` to `0` to switch it off, or `projectDoc.rootMarkers` to `[]` to keep the search inside the work directory.
+- **Path traversal prevention**: every filesystem tool — including `apply_patch` and `view_image` — resolves paths through a guard that rejects anything outside the active project root. In multi-project mode, `set_project_root` canonicalizes both the configured access root and the requested directory, so `..` and symlinks cannot bind a session outside the access root.
+- **One bounded exception in single-project mode**: [AGENTS.md](#agentsmd) discovery may read above `--work-dir`, up to the nearest `.git`. It is read-only, opens only `AGENTS.override.md`, `AGENTS.md` and any `projectDoc.fallbackFilenames`, and `get_project_doc` reports the absolute path of every file it used. Set `projectDoc.maxBytes` to `0` to switch it off, or `projectDoc.rootMarkers` to `[]` to keep the search inside the work directory. Multi-project mode does not perform this upward walk; its selected directory is the exact project root.
 - **One bounded write outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/`, deliberately outside the repository so nothing lands in your git history. It holds whatever the model chose to note about the task — read it if you want to know, delete the directory to forget, or set `memory.enabled` to `false` to never write it. The write is atomic (temp file plus rename) and guarded by a per-project lock, so a crash mid-write never leaves a torn file and two servers pointed at the same work directory do not lose each other's notes to an interleaved update. See [Context and memory](#context-and-memory).
 - **Bounded reads outside the work directory**: [skills](#skills) may live in `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` or an installed Claude Code plugin. `skills_read` opens files there, but only inside a skill package that already exists — the `resource` path is checked against the skill's own directory, so it cannot walk out into the rest of your home directory. `skills_list` reports the absolute path of every skill it found. Set `skills.enabled` to `false` to switch it off, or `skills.dirs` to point the user scope somewhere you choose.
 - **Command allowlist**: `run_command` only runs binaries listed in `allowedCommands`; everything else is rejected. `exec_command` checks the same list plus `exec.extraAllowedCommands`, at every command position in the string.
@@ -477,16 +505,17 @@ By default `allowedHosts` is empty, which accepts any `Host` header — the serv
 - **Optional bearer token auth**: set `--api-key` to require an `Authorization: Bearer <key>` header on all requests (except `/health`). Useful for non-ChatGPT clients. ChatGPT Plugins do not support simple bearer token auth.
 - **Host allowlist**: set `allowedHosts` to pin the accepted `Host` header for DNS-rebinding protection. See [Host allowlist](#host-allowlist).
 
-The allowlist is a **guardrail against accidents, not a sandbox**. It catches a model reaching for `curl` or `rm -rf`; it does not contain a determined one. The defaults already include `node`, `python` and `cargo`, each of which runs arbitrary code — `node -e "..."` can do anything the server process can. Shell redirection can also write outside the work directory even though the command's cwd is confined to it. Treat everything below as reachable by whoever holds the tunnel URL:
+The allowlist is a **guardrail against accidents, not a sandbox**. It catches a model reaching for `curl` or `rm -rf`; it does not contain a determined one. The defaults already include `node`, `python` and `cargo`, each of which runs arbitrary code — `node -e "..."` can do anything the server process can. Shell redirection and explicit absolute or parent paths can also reach outside the active project root even though each command starts with that root as its cwd. Multi-project selection isolates Codexrr's structured tools and per-session state; it is not an operating-system sandbox. Treat everything below as reachable by whoever holds the tunnel URL:
 
-- everything in `--work-dir`, read and write
+- everything in the active project root, read and write
+- in multi-project mode, any project beneath the configured access root can be selected by a new session
 - anything else the user account running the server can touch, via an allowlisted interpreter
 - the network, from your machine
 - anything a bridged MCP server can do
 
 `exec_command` sessions that outlive a request are killed when the MCP session closes, and the kill takes the children with it: `taskkill /T /F` walks the process tree on Windows, and on POSIX each session gets its own process group that is signalled as a whole. A process that deliberately re-parents or daemonises itself still escapes, so check for strays if a run leaves something listening.
 
-Don't expose this without tunnel-level access control (ngrok IP restrictions, Cloudflare Access), and don't point it at directories you don't trust ChatGPT with. If the work directory holds anything sensitive, set `exec.mode` and the allowlists tighter than the defaults rather than relying on them.
+Don't expose this without tunnel-level access control (ngrok IP restrictions, Cloudflare Access), and don't point it at directories you don't trust ChatGPT with. In multi-project mode, the entire access-root subtree is intentionally selectable. If the active project or access root holds anything sensitive, set `exec.mode` and the allowlists tighter than the defaults rather than relying on them.
 
 ## Dev commands
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,8 +3,9 @@
 A Rust port of the `codex-free` MCP bridge. codexrr is a local [Model Context
 Protocol](https://modelcontextprotocol.io) server that exposes Codex-style agent
 tools over **Streamable HTTP**, scoped either to one configured working directory
-or to a project root selected independently by each MCP session, and can
+or to a project root selected independently by each ChatGPT conversation, and can
 additionally **aggregate other local MCP servers** and **surface local skills**.
+Clients without ChatGPT conversation metadata use an MCP-transport-session fallback.
 
 This document explains how it is put together and why. For usage, see
 [README.md](../README.md).
@@ -34,9 +35,13 @@ ChatGPT / MCP client
 │    • bridged tools  ← upstream MCP servers    │
 │    • gateway tools  ← upstream MCP servers    │
 │                                               │
-│  per-session SessionState                     │
-│    • selected project root                    │
-│    • exec sessions + plan                     │
+│  shared ProjectBindingStore                   │
+│    • openai/session hash → project root       │
+│    • persistent atomic binding records        │
+│                                               │
+│  per-transport SessionState                   │
+│    • fallback root for generic MCP clients    │
+│    • exec sessions + current plan             │
 └──────────────────────────────────────────────┘
         │ reads/writes           │ stdio child processes
         ▼                        ▼
@@ -49,7 +54,7 @@ Three surfaces reach the model:
 - **Skills** — a catalogue in the server `instructions` plus the `skills_list` /
   `skills_read` tools, discovered from disk.
 - **Instructions** — the agent brief + environment + memory + project doc,
-  rebuilt per MCP session.
+  rebuilt from the active project config.
 
 ---
 
@@ -61,19 +66,26 @@ Three surfaces reach the model:
 2. `CodexHandler::get_info` returns the negotiated protocol version, capabilities
    (`tools`), server identity, and the `instructions` string. Single-project mode
    builds the full project-aware brief immediately. Multi-project mode emits only
-   the root-selection protocol and a project-neutral environment because no
-   project is known yet.
+   the root-selection protocol and a project-neutral environment because ChatGPT's
+   conversation identity arrives in request `_meta` on tool calls, after
+   initialization.
 3. `tools/list` → `CodexHandler::list_tools` maps the shared tool registry into
    rmcp `Tool` definitions.
-4. In multi-project mode, `set_project_root` canonicalizes an existing directory
-   below the configured access root and stores it in `SessionState`. The same
-   root may be selected again idempotently; a different root is rejected.
-5. `tools/call` → `CodexHandler::call_tool` finds the tool by name. Project-scoped
-   tools require a selected root and receive an effective clone of `AppConfig`
-   whose `work_dir` is that root. The server then fills in default
-   `structuredContent` when appropriate.
-6. When the session ends, rmcp drops the `CodexHandler`; its `SessionState`
-   `Drop` kills any resident `exec_command` shells.
+4. `tools/call` → `CodexHandler::call_tool` reads `openai/session` from rmcp's
+   `RequestContext::meta`. rmcp moves wire-level request `_meta` into that context
+   before dispatch, so the typed tool parameters are not the authoritative source.
+5. In multi-project mode, `set_project_root` canonicalizes an existing directory
+   below the configured access root. With `openai/session`, it writes an immutable
+   conversation binding through the shared `ProjectBindingStore`; without it, the
+   root is stored in the current `SessionState`. Re-selecting the same canonical
+   root is idempotent and selecting a different root is rejected.
+6. Other project-scoped calls resolve the durable conversation binding first, or
+   the transport-session fallback when no conversation identity exists, then
+   receive an effective clone of `AppConfig` whose `work_dir` is that root. The
+   server fills in default `structuredContent` when appropriate.
+7. When the transport session ends, rmcp drops the `CodexHandler`; its
+   `SessionState::Drop` kills resident `exec_command` shells. The conversation
+   binding remains on disk and is restored by a later transport or server process.
 
 Cross-cutting HTTP concerns live in the axum layer: a `/health` route, a
 `tower-http` CORS layer (exposing `mcp-session-id`), and a bearer-auth middleware
@@ -107,18 +119,28 @@ whose text *is* the structured form rely on the server's default-fill
 (`{ "content": <joined text> }`); tools that build their own structured content —
 or bridge it from upstream — return `fills_structured_content() == false`.
 
+### `ProjectBindingStore` (`project_bindings.rs`)
+Shared, durable conversation-to-project bindings. `ConversationIdentity` hashes
+ChatGPT's `openai/session` value before it reaches a filename; no raw conversation
+identifier is written to disk. Records are namespaced by canonical access-root
+hash, written atomically under a per-record lock, and validated again on every
+load so a deleted project or changed symlink fails closed. A new store instance
+can recover the same binding after a server restart.
+
 ### `SessionState` (`exec_sessions.rs`)
-Per-MCP-session mutable state: the optional selected project root, the map of
-resident `exec_command` shells, and the current plan. Created fresh per session
-by the factory; the root binding is immutable and `Drop` disposes shells.
+Per-MCP-transport mutable state: the optional fallback project root used only when
+the client provides no stable ChatGPT conversation identity, the map of resident
+`exec_command` shells, and the current plan. Created fresh by the service factory;
+the fallback root is immutable and `Drop` disposes shells. Live process handles are
+intentionally not persisted across reconnects.
 
 ### `AppConfig` (`types.rs`)
 The fully-resolved process config. Parsed from `codex.config.json` with camelCase
 field names for backward compatibility. Optional sub-configs (`projectDoc`,
 `output`, `memory`, `skills`, `ignore`) fall back to per-module defaults. In
 multi-project mode, dispatch clones this config per call and substitutes the
-session's selected root for `work_dir`; the static server policy and bridge
-configuration remain shared.
+conversation's selected root—or the transport fallback—for `work_dir`; the static
+server policy and bridge configuration remain shared.
 
 ---
 
@@ -128,10 +150,12 @@ configuration remain shared.
   configured with `json_response = true` and DNS-rebinding host checks disabled by
   default (so it works behind a tunnel presenting an arbitrary hostname; set
   `allowedHosts` to re-enable).
-- **Session model**: the factory runs per session, so each conversation gets its
-  own root binding, plan, and resident command sessions in `SessionState`.
-  Upstream MCP connections and the tool registry are shared (`Arc`) across
-  sessions.
+- **Session model**: the factory runs per MCP transport session. `SessionState`
+  therefore owns only transport-lifetime resources such as resident commands and
+  the generic-client root fallback. ChatGPT project identity is taken from
+  `RequestContext::meta["openai/session"]` and resolved through the shared,
+  persistent `ProjectBindingStore`. Upstream MCP connections, the binding store,
+  and the tool registry are shared (`Arc`) across transports.
 - **`get_info`** advertises server name `codex-free` (wire-compatible identity),
   version, `tools` capability, and the `instructions`.
 - **Errors**: a tool that fails returns `Ok(CallToolResult::error(...))`
@@ -155,7 +179,7 @@ configuration remain shared.
 Multi-project mode prepends `set_project_root`. It is omitted entirely in the
 default registry, preserving the original 25-tool surface and behaviour. Clocks
 and bridged/gateway tools are project-independent; every other native tool is
-blocked until a root is selected.
+blocked until a conversation binding or transport fallback is available.
 
 Each lives in `src/tools/<name>.rs`; the registry (`registry.rs`) lists them in
 the original order and rejects duplicate names.
@@ -170,12 +194,13 @@ the original order and rejects duplicate names.
 | `output_budget.rs` | Line/byte windowing and list caps, each cut announced with the continuation argument. |
 | `ignore_rules.rs` | One `.gitignore`-accurate matcher (the `ignore` crate) shared by glob/grep/tree/list_directory. |
 | `exec_policy.rs` | Shell-string allowlist guard for `exec_command` (a guardrail, not a sandbox). |
-| `exec_sessions.rs` | Per-session project-root binding plus unified-exec sessions: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, output truncation (UTF-16 units to match the TS). |
+| `project_bindings.rs` | Canonical project-root validation plus durable ChatGPT conversation bindings keyed by a hash of `openai/session`, namespaced by access root, locked per record, and atomically written. |
+| `exec_sessions.rs` | Generic-client transport fallback plus unified-exec sessions: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, output truncation (UTF-16 units to match the TS). |
 | `apply_patch.rs` | The Codex patch format: parse then apply, atomically, with fuzzy context matching and CRLF preservation. |
 | `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized active root, with `O_EXCL` locking and atomic writes. In multi-project mode, a configured `memory.dir` is a base containing one hashed child per project. |
 | `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. Multi-project mode treats the selected directory as the exact project root and never walks into the common access-root parent. |
 | `skills.rs` | `SKILL.md` discovery (see §8). |
-| `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc. Multi-project initialization emits a project-neutral selector brief; `get_agent_brief` builds the full brief after binding. |
+| `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc. Multi-project initialization emits a project-neutral selector brief because conversation metadata is available only on subsequent tool calls; `get_agent_brief` builds the full brief after restoring or creating a binding. |
 | `environment.rs` | OS / shell / policy description, shared by `get_environment` and the instructions. |
 
 ---
@@ -312,9 +337,9 @@ Auth: disabled (no --api-key)
 - `Config:` reveals the common mistake of editing a different file than the one
   loaded (config is resolved relative to the launch directory unless `--config`).
 - The `Upstream MCP servers:` block reports each server's outcome.
-- Multi-project startup also prints `Project access root:` and `Project mode:
-  per-session selection required`; its native count is 26 because the selector
-  is present.
+- Multi-project startup also prints `Project access root:`, `Project mode:
+  persistent ChatGPT conversation binding`, and the conversation-binding state
+  directory; its native count is 26 because the selector is present.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,8 @@
 
 A Rust port of the `codex-free` MCP bridge. codexrr is a local [Model Context
 Protocol](https://modelcontextprotocol.io) server that exposes Codex-style agent
-tools over **Streamable HTTP**, scoped to a chosen working directory, and can
+tools over **Streamable HTTP**, scoped either to one configured working directory
+or to a project root selected independently by each MCP session, and can
 additionally **aggregate other local MCP servers** and **surface local skills**.
 
 This document explains how it is put together and why. For usage, see
@@ -29,14 +30,17 @@ ChatGPT / MCP client
 │        ▼                                      │
 │  registry: Vec<Box<dyn Tool>>                 │
 │    • 25 native tools                          │
+│    • + set_project_root in multi-project mode │
 │    • bridged tools  ← upstream MCP servers    │
 │    • gateway tools  ← upstream MCP servers    │
 │                                               │
-│  per-session SessionState (exec + plan)       │
+│  per-session SessionState                     │
+│    • selected project root                    │
+│    • exec sessions + plan                     │
 └──────────────────────────────────────────────┘
         │ reads/writes           │ stdio child processes
         ▼                        ▼
-   work directory         upstream MCP servers (idasql, remote-exec, …)
+   active project root     upstream MCP servers (idasql, remote-exec, …)
 ```
 
 Three surfaces reach the model:
@@ -55,13 +59,20 @@ Three surfaces reach the model:
    `StreamableHttpService` manages the session and calls the **service factory**
    once per session, producing a fresh `CodexHandler`.
 2. `CodexHandler::get_info` returns the negotiated protocol version, capabilities
-   (`tools`), server identity, and the `instructions` string (built per session,
-   so a resumed conversation opens with the saved plan and notes in front of it).
+   (`tools`), server identity, and the `instructions` string. Single-project mode
+   builds the full project-aware brief immediately. Multi-project mode emits only
+   the root-selection protocol and a project-neutral environment because no
+   project is known yet.
 3. `tools/list` → `CodexHandler::list_tools` maps the shared tool registry into
    rmcp `Tool` definitions.
-4. `tools/call` → `CodexHandler::call_tool` finds the tool by name, runs it, then
-   fills in the default `structuredContent` when appropriate.
-5. When the session ends, rmcp drops the `CodexHandler`; its `SessionState`
+4. In multi-project mode, `set_project_root` canonicalizes an existing directory
+   below the configured access root and stores it in `SessionState`. The same
+   root may be selected again idempotently; a different root is rejected.
+5. `tools/call` → `CodexHandler::call_tool` finds the tool by name. Project-scoped
+   tools require a selected root and receive an effective clone of `AppConfig`
+   whose `work_dir` is that root. The server then fills in default
+   `structuredContent` when appropriate.
+6. When the session ends, rmcp drops the `CodexHandler`; its `SessionState`
    `Drop` kills any resident `exec_command` shells.
 
 Cross-cutting HTTP concerns live in the axum layer: a `/health` route, a
@@ -84,6 +95,7 @@ trait Tool: Send + Sync {
     fn input_schema(&self) -> Value;
     fn output_schema(&self) -> Option<Value>;
     fn fills_structured_content(&self) -> bool;         // opt out of default-fill
+    fn requires_project_root(&self) -> bool;            // true by default
     async fn call(&self, args: Value, cfg: &AppConfig, session: &SessionState) -> ToolResult;
 }
 ```
@@ -96,14 +108,17 @@ whose text *is* the structured form rely on the server's default-fill
 or bridge it from upstream — return `fills_structured_content() == false`.
 
 ### `SessionState` (`exec_sessions.rs`)
-Per-MCP-session mutable state: the map of resident `exec_command` shells and the
-current plan. Created fresh per session by the factory; `Drop` disposes shells.
+Per-MCP-session mutable state: the optional selected project root, the map of
+resident `exec_command` shells, and the current plan. Created fresh per session
+by the factory; the root binding is immutable and `Drop` disposes shells.
 
 ### `AppConfig` (`types.rs`)
-The fully-resolved config handed to every tool. Parsed from `codex.config.json`
-with camelCase field names for backward compatibility. Optional sub-configs
-(`projectDoc`, `output`, `memory`, `skills`, `ignore`) fall back to per-module
-defaults.
+The fully-resolved process config. Parsed from `codex.config.json` with camelCase
+field names for backward compatibility. Optional sub-configs (`projectDoc`,
+`output`, `memory`, `skills`, `ignore`) fall back to per-module defaults. In
+multi-project mode, dispatch clones this config per call and substitutes the
+session's selected root for `work_dir`; the static server policy and bridge
+configuration remain shared.
 
 ---
 
@@ -114,8 +129,9 @@ defaults.
   default (so it works behind a tunnel presenting an arbitrary hostname; set
   `allowedHosts` to re-enable).
 - **Session model**: the factory runs per session, so each conversation gets its
-  own `SessionState`. Upstream MCP connections and the tool registry are shared
-  (`Arc`) across sessions.
+  own root binding, plan, and resident command sessions in `SessionState`.
+  Upstream MCP connections and the tool registry are shared (`Arc`) across
+  sessions.
 - **`get_info`** advertises server name `codex-free` (wire-compatible identity),
   version, `tools` capability, and the `instructions`.
 - **Errors**: a tool that fails returns `Ok(CallToolResult::error(...))`
@@ -124,7 +140,7 @@ defaults.
 
 ---
 
-## 5. Native tools (25)
+## 5. Native tools (25 default, 26 multi-project)
 
 | Group | Tools |
 |-------|-------|
@@ -135,6 +151,11 @@ defaults.
 | Task state | `update_plan`, `remember`, `recall` |
 | Skills | `skills_list`, `skills_read` |
 | Timing | `clock_curr_time`, `clock_sleep` |
+
+Multi-project mode prepends `set_project_root`. It is omitted entirely in the
+default registry, preserving the original 25-tool surface and behaviour. Clocks
+and bridged/gateway tools are project-independent; every other native tool is
+blocked until a root is selected.
 
 Each lives in `src/tools/<name>.rs`; the registry (`registry.rs`) lists them in
 the original order and rejects duplicate names.
@@ -149,12 +170,12 @@ the original order and rejects duplicate names.
 | `output_budget.rs` | Line/byte windowing and list caps, each cut announced with the continuation argument. |
 | `ignore_rules.rs` | One `.gitignore`-accurate matcher (the `ignore` crate) shared by glob/grep/tree/list_directory. |
 | `exec_policy.rs` | Shell-string allowlist guard for `exec_command` (a guardrail, not a sandbox). |
-| `exec_sessions.rs` | Unified-exec sessions: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, output truncation (UTF-16 units to match the TS). |
+| `exec_sessions.rs` | Per-session project-root binding plus unified-exec sessions: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, output truncation (UTF-16 units to match the TS). |
 | `apply_patch.rs` | The Codex patch format: parse then apply, atomically, with fuzzy context matching and CRLF preservation. |
-| `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized work dir, with `O_EXCL` locking and atomic writes. |
-| `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. |
+| `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized active root, with `O_EXCL` locking and atomic writes. In multi-project mode, a configured `memory.dir` is a base containing one hashed child per project. |
+| `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. Multi-project mode treats the selected directory as the exact project root and never walks into the common access-root parent. |
 | `skills.rs` | `SKILL.md` discovery (see §8). |
-| `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc, per session. |
+| `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc. Multi-project initialization emits a project-neutral selector brief; `get_agent_brief` builds the full brief after binding. |
 | `environment.rs` | OS / shell / policy description, shared by `get_environment` and the instructions. |
 
 ---
@@ -247,6 +268,7 @@ startup banner prints the exact file with `Config:`). All fields optional.
 {
   "port": 3000,
   "apiKey": "…",                      // or --api-key; bearer token
+  "multiProject": false,               // or --multi-project; work-dir becomes access root
   "allowedCommands": ["git", "node", …],   // run_command allowlist
   "allowedHosts": [],                  // DNS-rebinding allowlist; empty = any host
   "tree":   { "defaultDepth": 3, "ignore": ["node_modules", ".git", …] },
@@ -290,6 +312,9 @@ Auth: disabled (no --api-key)
 - `Config:` reveals the common mistake of editing a different file than the one
   loaded (config is resolved relative to the launch directory unless `--config`).
 - The `Upstream MCP servers:` block reports each server's outcome.
+- Multi-project startup also prints `Project access root:` and `Project mode:
+  per-session selection required`; its native count is 26 because the selector
+  is present.
 
 ---
 
@@ -313,10 +338,14 @@ units to match the TS `text.length` / `text.slice`.
 
 ## 12. Testing
 
-- **334 tests** — unit tests inside modules plus integration tests under `tests/`
+- **346 tests** — unit tests inside modules plus integration tests under `tests/`
   (`tempfile`-isolated), ported from the TS Bun suite.
 - Memory / skills tests pin `memory.dir` / `skills.dirs` to temp dirs so they never
   touch the real home; plugin discovery is suppressed when `skills.dirs` is set.
+- `tests/project_selection.rs` covers pre-selection blocking, immutable canonical
+  bindings, concurrent session isolation, traversal and symlink escapes,
+  project-keyed persistent state, deferred project instructions, and CLI/config
+  activation.
 - `tests/review_fixes.rs` locks the behavioral-fidelity fixes found by the
   adversarial review of the port. The bridge/gateway/skills code was reviewed the
   same way; the confirmed low-severity findings (name-collision dedup, YAML-safe

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -82,6 +82,10 @@ impl Tool for BridgedTool {
         false
     }
 
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
     async fn call(&self, args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
         let mut params = CallToolRequestParams::new(self.original_name.clone());
         if let Some(obj) = args.as_object()
@@ -400,6 +404,10 @@ impl Tool for GatewayTool {
     }
 
     fn fills_structured_content(&self) -> bool {
+        false
+    }
+
+    fn requires_project_root(&self) -> bool {
         false
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,8 @@ pub struct Cli {
     #[arg(long = "work-dir")]
     pub work_dir: String,
 
-    /// Let each MCP session bind once to a project below --work-dir.
+    /// Let each ChatGPT conversation bind once to a project below --work-dir.
+    /// Other MCP clients fall back to transport-session binding.
     #[arg(long = "multi-project")]
     pub multi_project: bool,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,9 +22,13 @@ use crate::types::{
     about = "Codex Free MCP bridge (Rust): expose Codex-style agent tools over Streamable HTTP."
 )]
 pub struct Cli {
-    /// Project directory the tools operate on (required).
+    /// Project directory, or the access root when --multi-project is enabled.
     #[arg(long = "work-dir")]
     pub work_dir: String,
+
+    /// Let each MCP session bind once to a project below --work-dir.
+    #[arg(long = "multi-project")]
+    pub multi_project: bool,
 
     /// Server port. Default: 3000 (or the config file's value).
     #[arg(long)]
@@ -114,6 +118,7 @@ struct PartialExec {
 struct FileConfig {
     api_key: Option<String>,
     port: Option<u16>,
+    multi_project: Option<bool>,
     allowed_commands: Option<Vec<String>>,
     tree: Option<PartialTree>,
     command: Option<PartialCommand>,
@@ -133,6 +138,7 @@ struct FileConfig {
 pub fn default_config(work_dir: std::path::PathBuf) -> AppConfig {
     AppConfig {
         work_dir,
+        multi_project: false,
         api_key: None,
         port: 3000,
         allowed_commands: default_allowed_commands(),
@@ -248,6 +254,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
 
     Ok(AppConfig {
         work_dir,
+        multi_project: cli.multi_project || file.multi_project.unwrap_or(false),
         api_key: cli.api_key.or(file.api_key),
         port: cli.port.or(file.port).unwrap_or(3000),
         allowed_commands: file

--- a/src/exec_policy.rs
+++ b/src/exec_policy.rs
@@ -244,6 +244,7 @@ mod tests {
     fn cfg(mode: ExecMode) -> AppConfig {
         AppConfig {
             work_dir: std::path::PathBuf::from("/w"),
+            multi_project: false,
             api_key: None,
             port: 3000,
             allowed_commands: vec!["git".into(), "node".into()],

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -16,6 +16,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{ChildStdin, Command};
 use tokio::sync::{Mutex as TokioMutex, Notify};
 
+use crate::project_bindings::{ProjectBindingScope, ProjectRootSelection, resolve_project_root};
 use crate::types::{AppConfig, PlanState};
 
 // Codex constants (shell_spec.rs). Kept as code, not config, because they are
@@ -214,15 +215,11 @@ impl ExecSession {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ProjectRootSelection {
-    pub access_root: PathBuf,
-    pub project_root: PathBuf,
-    pub newly_selected: bool,
-}
-
-/// Per-MCP-session mutable state. A fresh instance is created for every MCP
-/// session so concurrent clients never share project roots, exec sessions, or plans.
+/// Per-MCP-transport mutable state. A fresh instance is created for every MCP
+/// transport session so concurrent transports never share exec sessions or
+/// in-memory plans.
+/// Project-root state here is the fallback for clients without a durable
+/// conversation identifier.
 pub struct SessionState {
     pub exec_sessions: StdMutex<HashMap<u64, Arc<ExecSession>>>,
     next_exec_id: AtomicU64,
@@ -253,7 +250,7 @@ impl SessionState {
 
         let Some(project_root) = self.project_root.lock().unwrap().clone() else {
             return Err(format!(
-                "No project root is selected for this MCP session. Call `set_project_root` with a directory relative to the access root `{}`, then call `get_agent_brief` before using project tools.",
+                "No project root is selected for this MCP transport session. Call `set_project_root` with a directory relative to the access root `{}`, then call `get_agent_brief` before using project tools.",
                 config.work_dir.display()
             ));
         };
@@ -275,42 +272,7 @@ impl SessionState {
             );
         }
 
-        let input = input.trim();
-        if input.is_empty() {
-            return Err("path must be a non-empty string".to_string());
-        }
-
-        let access_root = std::fs::canonicalize(&config.work_dir).map_err(|e| {
-            format!(
-                "Could not resolve project access root {}: {e}",
-                config.work_dir.display()
-            )
-        })?;
-        let input_path = std::path::Path::new(input);
-        let candidate = if input_path.is_absolute() {
-            input_path.to_path_buf()
-        } else {
-            config.work_dir.join(input_path)
-        };
-        let project_root = std::fs::canonicalize(&candidate).map_err(|e| {
-            format!(
-                "Project root does not exist or cannot be resolved: {}: {e}",
-                candidate.display()
-            )
-        })?;
-
-        if !project_root.is_dir() {
-            return Err(format!(
-                "Project root is not a directory: {}",
-                project_root.display()
-            ));
-        }
-        if project_root != access_root && !project_root.starts_with(&access_root) {
-            return Err(format!(
-                "Project root escapes the configured access root: {}",
-                project_root.display()
-            ));
-        }
+        let (access_root, project_root) = resolve_project_root(config, input)?;
 
         let mut selected = self.project_root.lock().unwrap();
         match selected.as_ref() {
@@ -318,9 +280,10 @@ impl SessionState {
                 access_root,
                 project_root,
                 newly_selected: false,
+                scope: ProjectBindingScope::McpTransportSession,
             }),
             Some(current) => Err(format!(
-                "This MCP session is already bound to project root `{}` and cannot switch to `{}`. Open a new chat or MCP session for another project.",
+                "This MCP transport session is already bound to project root `{}` and cannot switch to `{}`. Open a new session for another project.",
                 current.display(),
                 project_root.display()
             )),
@@ -330,6 +293,7 @@ impl SessionState {
                     access_root,
                     project_root,
                     newly_selected: true,
+                    scope: ProjectBindingScope::McpTransportSession,
                 })
             }
         }

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -6,6 +6,7 @@
 //! as the default, so the default path matches — only `tty: true` is unsupported.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
@@ -213,12 +214,20 @@ impl ExecSession {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectRootSelection {
+    pub access_root: PathBuf,
+    pub project_root: PathBuf,
+    pub newly_selected: bool,
+}
+
 /// Per-MCP-session mutable state. A fresh instance is created for every MCP
-/// session so concurrent clients never share exec sessions or plans.
+/// session so concurrent clients never share project roots, exec sessions, or plans.
 pub struct SessionState {
     pub exec_sessions: StdMutex<HashMap<u64, Arc<ExecSession>>>,
     next_exec_id: AtomicU64,
     pub plan: StdMutex<Option<PlanState>>,
+    project_root: StdMutex<Option<PathBuf>>,
 }
 
 impl Default for SessionState {
@@ -227,6 +236,7 @@ impl Default for SessionState {
             exec_sessions: StdMutex::new(HashMap::new()),
             next_exec_id: AtomicU64::new(1),
             plan: StdMutex::new(None),
+            project_root: StdMutex::new(None),
         }
     }
 }
@@ -234,6 +244,99 @@ impl Default for SessionState {
 impl SessionState {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn effective_config(&self, config: &AppConfig) -> Result<AppConfig, String> {
+        if !config.multi_project {
+            return Ok(config.clone());
+        }
+
+        let Some(project_root) = self.project_root.lock().unwrap().clone() else {
+            return Err(format!(
+                "No project root is selected for this MCP session. Call `set_project_root` with a directory relative to the access root `{}`, then call `get_agent_brief` before using project tools.",
+                config.work_dir.display()
+            ));
+        };
+
+        let mut effective = config.clone();
+        effective.work_dir = project_root;
+        Ok(effective)
+    }
+
+    pub fn select_project_root(
+        &self,
+        config: &AppConfig,
+        input: &str,
+    ) -> Result<ProjectRootSelection, String> {
+        if !config.multi_project {
+            return Err(
+                "Project-root selection is disabled. Start codexrr with `--multi-project` or set `multiProject` to true."
+                    .to_string(),
+            );
+        }
+
+        let input = input.trim();
+        if input.is_empty() {
+            return Err("path must be a non-empty string".to_string());
+        }
+
+        let access_root = std::fs::canonicalize(&config.work_dir).map_err(|e| {
+            format!(
+                "Could not resolve project access root {}: {e}",
+                config.work_dir.display()
+            )
+        })?;
+        let input_path = std::path::Path::new(input);
+        let candidate = if input_path.is_absolute() {
+            input_path.to_path_buf()
+        } else {
+            config.work_dir.join(input_path)
+        };
+        let project_root = std::fs::canonicalize(&candidate).map_err(|e| {
+            format!(
+                "Project root does not exist or cannot be resolved: {}: {e}",
+                candidate.display()
+            )
+        })?;
+
+        if !project_root.is_dir() {
+            return Err(format!(
+                "Project root is not a directory: {}",
+                project_root.display()
+            ));
+        }
+        if project_root != access_root && !project_root.starts_with(&access_root) {
+            return Err(format!(
+                "Project root escapes the configured access root: {}",
+                project_root.display()
+            ));
+        }
+
+        let mut selected = self.project_root.lock().unwrap();
+        match selected.as_ref() {
+            Some(current) if current == &project_root => Ok(ProjectRootSelection {
+                access_root,
+                project_root,
+                newly_selected: false,
+            }),
+            Some(current) => Err(format!(
+                "This MCP session is already bound to project root `{}` and cannot switch to `{}`. Open a new chat or MCP session for another project.",
+                current.display(),
+                project_root.display()
+            )),
+            None => {
+                *selected = Some(project_root.clone());
+                Ok(ProjectRootSelection {
+                    access_root,
+                    project_root,
+                    newly_selected: true,
+                })
+            }
+        }
+    }
+
+    pub fn selected_project_root(&self) -> Option<PathBuf> {
+        self.project_root.lock().unwrap().clone()
     }
 }
 

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -60,9 +60,37 @@ pub const AGENT_BRIEF: &str = concat!(
     "- Offer natural next steps briefly — tests, a commit, a build — and say plainly what you could not verify yourself.",
 );
 
-/// The brief a client sees at initialize time, and the exact text
-/// `get_agent_brief` returns. Rebuilt per MCP session so a conversation that
-/// starts after a previous one was lost opens with the plan and notes in front.
+/// The initialize-time instructions. Multi-project sessions deliberately omit
+/// project state until the client binds the session to one root.
+pub fn build_initial_instructions(config: &AppConfig) -> String {
+    if !config.multi_project {
+        return build_instructions(config);
+    }
+
+    let mut environment = describe_environment(config);
+    environment.cwd = "<not selected>".to_string();
+
+    [
+        AGENT_BRIEF.to_string(),
+        String::new(),
+        "## Project selection".to_string(),
+        String::new(),
+        "This server is running in multi-project mode. This MCP session has no project root yet, so project-scoped tools will reject calls until one is selected.".to_string(),
+        format!("Project access root: {}", config.work_dir.display()),
+        "Call `set_project_root` with an existing directory beneath that access root before using filesystem, search, edit, command, git, project-instruction, skill, memory, or plan tools.".to_string(),
+        "The selection is permanent for this MCP session. Use a new chat or MCP session for another project.".to_string(),
+        "Immediately after selecting, call `get_agent_brief` and follow the returned environment, saved state, skills, and project instructions for the rest of the task.".to_string(),
+        String::new(),
+        "## Environment".to_string(),
+        String::new(),
+        render_environment(&environment),
+    ]
+    .join("\n")
+}
+
+/// The full project-aware brief returned by `get_agent_brief`, and used at
+/// initialize time in single-project mode. Rebuilt from the effective project
+/// config so a later conversation can recover the saved plan and notes.
 ///
 /// Codex assembles the same layers in the same order: base instructions, then
 /// `<environment_context>`, then the skill catalogue, then the project's

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -60,8 +60,9 @@ pub const AGENT_BRIEF: &str = concat!(
     "- Offer natural next steps briefly — tests, a commit, a build — and say plainly what you could not verify yourself.",
 );
 
-/// The initialize-time instructions. Multi-project sessions deliberately omit
-/// project state until the client binds the session to one root.
+/// The initialize-time instructions. Multi-project initialization deliberately
+/// omits project state because ChatGPT's conversation ID arrives on tool calls,
+/// after the MCP initialize exchange.
 pub fn build_initial_instructions(config: &AppConfig) -> String {
     if !config.multi_project {
         return build_instructions(config);
@@ -75,11 +76,12 @@ pub fn build_initial_instructions(config: &AppConfig) -> String {
         String::new(),
         "## Project selection".to_string(),
         String::new(),
-        "This server is running in multi-project mode. This MCP session has no project root yet, so project-scoped tools will reject calls until one is selected.".to_string(),
+        "This server is running in multi-project mode. Project identity cannot be resolved during MCP initialization because stable ChatGPT conversation metadata arrives on tool calls.".to_string(),
         format!("Project access root: {}", config.work_dir.display()),
-        "Call `set_project_root` with an existing directory beneath that access root before using filesystem, search, edit, command, git, project-instruction, skill, memory, or plan tools.".to_string(),
-        "The selection is permanent for this MCP session. Use a new chat or MCP session for another project.".to_string(),
-        "Immediately after selecting, call `get_agent_brief` and follow the returned environment, saved state, skills, and project instructions for the rest of the task.".to_string(),
+        "For ChatGPT, a project selected earlier in this same conversation is restored automatically even after an MCP reconnect or server restart. A new conversation has no binding.".to_string(),
+        "Call `get_agent_brief` first. If this conversation is not yet bound, call `set_project_root` with an existing directory beneath the access root, then call `get_agent_brief` again. Re-selecting the same canonical directory is idempotent.".to_string(),
+        "A ChatGPT conversation cannot switch projects; start a new chat for another project. Clients without stable `openai/session` metadata fall back to an MCP-transport-session binding and must select again after reconnecting.".to_string(),
+        "Follow the environment, saved state, skills, and project instructions returned by `get_agent_brief` for the rest of the task.".to_string(),
         String::new(),
         "## Environment".to_string(),
         String::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod ignore_rules;
 pub mod instructions;
 pub mod memory;
 pub mod output_budget;
+pub mod project_bindings;
 pub mod project_doc;
 pub mod registry;
 pub mod safe_path;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -44,16 +44,8 @@ pub fn memory_max_bytes(config: &AppConfig) -> usize {
     config.memory.max_bytes.unwrap_or(DEFAULT_MEMORY_MAX_BYTES)
 }
 
-/// Per-project state directory, outside the work directory by default. The
-/// basename is only there to make the directory recognisable to a human; the
-/// hash of the absolute path is what keys it.
-pub fn memory_dir(config: &AppConfig) -> PathBuf {
-    if let Some(dir) = &config.memory.dir {
-        return PathBuf::from(dir);
-    }
-    // Hash and slug the lexically-normalised path so `/proj` and `/proj/` key the
-    // same per-project directory, mirroring the TS `resolve(config.workDir)`.
-    let normalized = crate::safe_path::lexical_normalize(&config.work_dir);
+fn project_state_dir_name(work_dir: &std::path::Path) -> String {
+    let normalized = crate::safe_path::lexical_normalize(work_dir);
     let abs = normalized.to_string_lossy().to_string();
     let mut hasher = Sha256::new();
     hasher.update(abs.as_bytes());
@@ -79,10 +71,26 @@ pub fn memory_dir(config: &AppConfig) -> PathBuf {
         slug
     };
 
+    format!("{slug}-{digest}")
+}
+
+/// Per-project state directory, outside the work directory by default. The
+/// basename is only there to make the directory recognisable to a human; the
+/// hash of the absolute path is what keys it.
+pub fn memory_dir(config: &AppConfig) -> PathBuf {
+    if let Some(dir) = &config.memory.dir {
+        let base = PathBuf::from(dir);
+        return if config.multi_project {
+            base.join(project_state_dir_name(&config.work_dir))
+        } else {
+            base
+        };
+    }
+
     let home = home_dir().unwrap_or_else(|| PathBuf::from("."));
     home.join(".codex-free")
         .join("projects")
-        .join(format!("{slug}-{digest}"))
+        .join(project_state_dir_name(&config.work_dir))
 }
 
 pub fn memory_path(config: &AppConfig) -> PathBuf {

--- a/src/project_bindings.rs
+++ b/src/project_bindings.rs
@@ -1,0 +1,439 @@
+//! Durable project selection for clients that provide a stable conversation ID.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
+
+use rmcp::model::RequestMetaObject;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::types::AppConfig;
+use crate::util::home_dir;
+
+pub const OPENAI_SESSION_META_KEY: &str = "openai/session";
+
+const BINDING_VERSION: u32 = 1;
+const LOCK_STALE_MS: u128 = 10_000;
+const LOCK_TIMEOUT_MS: u128 = 2_000;
+const LOCK_RETRY_MS: u64 = 20;
+
+static ATOMIC_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ConversationIdentity {
+    key: String,
+}
+
+impl std::fmt::Debug for ConversationIdentity {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ConversationIdentity")
+            .field("key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ConversationIdentity {
+    pub fn from_request_meta(meta: &RequestMetaObject) -> Option<Self> {
+        meta.get(OPENAI_SESSION_META_KEY)
+            .and_then(serde_json::Value::as_str)
+            .and_then(Self::from_openai_session)
+    }
+
+    pub fn from_openai_session(session: &str) -> Option<Self> {
+        let session = session.trim();
+        if session.is_empty() {
+            return None;
+        }
+
+        let mut hasher = Sha256::new();
+        hasher.update(b"codex-free/openai-session/v1\0");
+        hasher.update(session.as_bytes());
+        Some(Self {
+            key: encode_hex(&hasher.finalize(), 64),
+        })
+    }
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectBindingScope {
+    ChatGptConversation,
+    McpTransportSession,
+}
+
+impl ProjectBindingScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ChatGptConversation => "chatgpt_conversation",
+            Self::McpTransportSession => "mcp_transport_session",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectRootSelection {
+    pub access_root: PathBuf,
+    pub project_root: PathBuf,
+    pub newly_selected: bool,
+    pub scope: ProjectBindingScope,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProjectBindingStore {
+    base_dir: PathBuf,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct StoredProjectBinding {
+    version: u32,
+    access_root: String,
+    project_root: String,
+}
+
+struct BindingLock {
+    path: PathBuf,
+}
+
+impl Drop for BindingLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+impl ProjectBindingStore {
+    pub fn for_current_user() -> Self {
+        let home = home_dir().unwrap_or_else(|| PathBuf::from("."));
+        Self::new(home.join(".codex-free").join("conversation-projects"))
+    }
+
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self { base_dir }
+    }
+
+    pub fn base_dir(&self) -> &Path {
+        &self.base_dir
+    }
+
+    pub fn effective_config(
+        &self,
+        config: &AppConfig,
+        identity: &ConversationIdentity,
+    ) -> Result<AppConfig, String> {
+        if !config.multi_project {
+            return Ok(config.clone());
+        }
+
+        let Some(project_root) = self.selected_project_root(config, identity)? else {
+            return Err(format!(
+                "No project root is selected for this ChatGPT conversation. Call `set_project_root` with a directory relative to the access root `{}`, then call `get_agent_brief` before using project tools. The selection is stored by ChatGPT conversation ID and will survive MCP reconnects and server restarts.",
+                config.work_dir.display()
+            ));
+        };
+
+        let mut effective = config.clone();
+        effective.work_dir = project_root;
+        Ok(effective)
+    }
+
+    pub fn selected_project_root(
+        &self,
+        config: &AppConfig,
+        identity: &ConversationIdentity,
+    ) -> Result<Option<PathBuf>, String> {
+        let access_root = canonical_access_root(config)?;
+        let path = self.binding_path(&access_root, identity);
+        self.read_binding(&path, &access_root)
+    }
+
+    pub fn select_project_root(
+        &self,
+        config: &AppConfig,
+        identity: &ConversationIdentity,
+        input: &str,
+    ) -> Result<ProjectRootSelection, String> {
+        let (access_root, project_root) = resolve_project_root(config, input)?;
+        let binding_path = self.binding_path(&access_root, identity);
+        let _lock = acquire_lock(&binding_path)?;
+
+        if let Some(current) = self.read_binding(&binding_path, &access_root)? {
+            if current == project_root {
+                return Ok(ProjectRootSelection {
+                    access_root,
+                    project_root,
+                    newly_selected: false,
+                    scope: ProjectBindingScope::ChatGptConversation,
+                });
+            }
+
+            return Err(format!(
+                "This ChatGPT conversation is already bound to project root `{}` and cannot switch to `{}`. Start a new chat for another project.",
+                current.display(),
+                project_root.display()
+            ));
+        }
+
+        let binding = StoredProjectBinding {
+            version: BINDING_VERSION,
+            access_root: access_root.to_string_lossy().into_owned(),
+            project_root: project_root.to_string_lossy().into_owned(),
+        };
+        self.write_binding(&binding_path, &binding)?;
+
+        Ok(ProjectRootSelection {
+            access_root,
+            project_root,
+            newly_selected: true,
+            scope: ProjectBindingScope::ChatGptConversation,
+        })
+    }
+
+    fn binding_path(&self, access_root: &Path, identity: &ConversationIdentity) -> PathBuf {
+        let mut hasher = Sha256::new();
+        hasher.update(b"codex-free/access-root/v1\0");
+        hasher.update(access_root.to_string_lossy().as_bytes());
+        let access_key = encode_hex(&hasher.finalize(), 24);
+        self.base_dir
+            .join(access_key)
+            .join(format!("{}.json", identity.key()))
+    }
+
+    fn read_binding(&self, path: &Path, access_root: &Path) -> Result<Option<PathBuf>, String> {
+        let raw = match std::fs::read_to_string(path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(format!(
+                    "Could not read the stored ChatGPT conversation project binding at {}: {error}",
+                    path.display()
+                ));
+            }
+        };
+
+        let binding: StoredProjectBinding = serde_json::from_str(&raw).map_err(|error| {
+            format!(
+                "The stored ChatGPT conversation project binding at {} is invalid: {error}. Start a new chat or remove that binding file.",
+                path.display()
+            )
+        })?;
+        if binding.version != BINDING_VERSION {
+            return Err(format!(
+                "The stored ChatGPT conversation project binding at {} uses unsupported version {}. Start a new chat or remove that binding file.",
+                path.display(),
+                binding.version
+            ));
+        }
+
+        if Path::new(&binding.access_root) != access_root {
+            return Err(format!(
+                "The stored ChatGPT conversation project binding at {} belongs to a different access root. Start a new chat or remove that binding file.",
+                path.display()
+            ));
+        }
+
+        let stored_root = PathBuf::from(&binding.project_root);
+        let project_root = std::fs::canonicalize(&stored_root).map_err(|error| {
+            format!(
+                "The project bound to this ChatGPT conversation no longer exists or cannot be resolved: {}: {error}. Start a new chat for another project.",
+                stored_root.display()
+            )
+        })?;
+        if !project_root.is_dir() {
+            return Err(format!(
+                "The project bound to this ChatGPT conversation is no longer a directory: {}. Start a new chat for another project.",
+                project_root.display()
+            ));
+        }
+        if project_root != access_root && !project_root.starts_with(access_root) {
+            return Err(format!(
+                "The project bound to this ChatGPT conversation now resolves outside the configured access root: {}. Start a new chat or remove the binding file at {}.",
+                project_root.display(),
+                path.display()
+            ));
+        }
+
+        Ok(Some(project_root))
+    }
+
+    fn write_binding(&self, target: &Path, binding: &StoredProjectBinding) -> Result<(), String> {
+        let parent = target.parent().ok_or_else(|| {
+            format!(
+                "Could not determine the directory for project binding {}",
+                target.display()
+            )
+        })?;
+        std::fs::create_dir_all(parent).map_err(|error| {
+            format!(
+                "Could not create project-binding directory {}: {error}",
+                parent.display()
+            )
+        })?;
+
+        let counter = ATOMIC_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let mut temporary = target.as_os_str().to_os_string();
+        temporary.push(format!(".tmp.{}.{}", std::process::id(), counter));
+        let temporary = PathBuf::from(temporary);
+        let json = serde_json::to_string_pretty(binding)
+            .map_err(|error| format!("Could not serialize project binding: {error}"))?;
+
+        let result = (|| -> std::io::Result<()> {
+            {
+                let mut file = std::fs::File::create(&temporary)?;
+                file.write_all(json.as_bytes())?;
+                file.write_all(b"\n")?;
+                file.sync_all()?;
+            }
+            std::fs::rename(&temporary, target)?;
+            Ok(())
+        })();
+
+        if let Err(error) = result {
+            let _ = std::fs::remove_file(&temporary);
+            return Err(format!(
+                "Could not persist the ChatGPT conversation project binding at {}: {error}",
+                target.display()
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+pub fn resolve_project_root(config: &AppConfig, input: &str) -> Result<(PathBuf, PathBuf), String> {
+    if !config.multi_project {
+        return Err(
+            "Project-root selection is disabled. Start codexrr with `--multi-project` or set `multiProject` to true."
+                .to_string(),
+        );
+    }
+
+    let input = input.trim();
+    if input.is_empty() {
+        return Err("path must be a non-empty string".to_string());
+    }
+
+    let access_root = canonical_access_root(config)?;
+    let input_path = Path::new(input);
+    let candidate = if input_path.is_absolute() {
+        input_path.to_path_buf()
+    } else {
+        config.work_dir.join(input_path)
+    };
+    let project_root = std::fs::canonicalize(&candidate).map_err(|error| {
+        format!(
+            "Project root does not exist or cannot be resolved: {}: {error}",
+            candidate.display()
+        )
+    })?;
+
+    if !project_root.is_dir() {
+        return Err(format!(
+            "Project root is not a directory: {}",
+            project_root.display()
+        ));
+    }
+    if project_root != access_root && !project_root.starts_with(&access_root) {
+        return Err(format!(
+            "Project root escapes the configured access root: {}",
+            project_root.display()
+        ));
+    }
+
+    Ok((access_root, project_root))
+}
+
+fn canonical_access_root(config: &AppConfig) -> Result<PathBuf, String> {
+    std::fs::canonicalize(&config.work_dir).map_err(|error| {
+        format!(
+            "Could not resolve project access root {}: {error}",
+            config.work_dir.display()
+        )
+    })
+}
+
+fn acquire_lock(binding_path: &Path) -> Result<BindingLock, String> {
+    let parent = binding_path.parent().ok_or_else(|| {
+        format!(
+            "Could not determine the directory for project binding {}",
+            binding_path.display()
+        )
+    })?;
+    std::fs::create_dir_all(parent).map_err(|error| {
+        format!(
+            "Could not create project-binding directory {}: {error}",
+            parent.display()
+        )
+    })?;
+
+    let mut lock_path = binding_path.as_os_str().to_os_string();
+    lock_path.push(".lock");
+    let lock_path = PathBuf::from(lock_path);
+    let deadline = now_ms() + LOCK_TIMEOUT_MS;
+
+    loop {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock_path)
+        {
+            Ok(mut file) => {
+                let _ = writeln!(file, "{} {}", std::process::id(), now_ms());
+                return Ok(BindingLock { path: lock_path });
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                match std::fs::metadata(&lock_path).and_then(|metadata| metadata.modified()) {
+                    Ok(modified) => {
+                        let age = SystemTime::now()
+                            .duration_since(modified)
+                            .map(|duration| duration.as_millis())
+                            .unwrap_or(0);
+                        if age > LOCK_STALE_MS {
+                            let _ = std::fs::remove_file(&lock_path);
+                            continue;
+                        }
+                    }
+                    Err(_) => continue,
+                }
+                if now_ms() >= deadline {
+                    return Err(format!(
+                        "Timed out waiting to update project binding {}",
+                        binding_path.display()
+                    ));
+                }
+                std::thread::sleep(Duration::from_millis(LOCK_RETRY_MS));
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Could not lock project binding {}: {error}",
+                    binding_path.display()
+                ));
+            }
+        }
+    }
+}
+
+fn now_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}
+
+fn encode_hex(bytes: &[u8], chars: usize) -> String {
+    let mut encoded = String::with_capacity(chars);
+    for byte in bytes {
+        if encoded.len() >= chars {
+            break;
+        }
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded.truncate(chars);
+    encoded
+}

--- a/src/project_doc.rs
+++ b/src/project_doc.rs
@@ -59,6 +59,10 @@ pub fn find_project_root(start_dir: &Path, markers: &[String]) -> Option<PathBuf
 /// Directories from the project root down to the work directory, outermost
 /// first. Shared by AGENTS.md discovery and (in `skills.rs`) repo skill roots.
 pub fn project_dirs(config: &AppConfig) -> Vec<PathBuf> {
+    if config.multi_project {
+        return vec![config.work_dir.clone()];
+    }
+
     let settings = &config.project_doc;
     let root = find_project_root(&config.work_dir, &root_markers(settings));
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,14 +1,23 @@
 //! The tool registry. Ports `src/registry.ts`.
 //!
-//! `load_tools` returns every registered tool and enforces that names are
-//! unique, panicking on a duplicate (a programming error, as in the TS which
-//! throws at startup). The order mirrors the TypeScript registry.
+//! `load_tools` returns the single-project registry; `load_tools_for_mode` adds
+//! the session selector only when multi-project mode is enabled. Both enforce
+//! unique names, panicking on a duplicate (a programming error, as in the TS
+//! which throws at startup). The common order mirrors the TypeScript registry.
 
 use crate::tool::Tool;
 use crate::tools;
 
 pub fn load_tools() -> Vec<Box<dyn Tool>> {
-    let all: Vec<Box<dyn Tool>> = vec![
+    load_tools_for_mode(false)
+}
+
+pub fn load_tools_for_mode(multi_project: bool) -> Vec<Box<dyn Tool>> {
+    let mut all: Vec<Box<dyn Tool>> = Vec::new();
+    if multi_project {
+        all.push(Box::new(tools::set_project_root::SetProjectRoot));
+    }
+    all.extend([
         Box::new(tools::read_file::ReadFile),
         Box::new(tools::write_file::WriteFile),
         Box::new(tools::run_command::RunCommand),
@@ -41,7 +50,7 @@ pub fn load_tools() -> Vec<Box<dyn Tool>> {
         // Codex's skills.list / skills.read.
         Box::new(tools::skills_list::SkillsList),
         Box::new(tools::skills_read::SkillsRead),
-    ];
+    ] as [Box<dyn Tool>; 25]);
 
     let mut seen = std::collections::HashSet::new();
     for tool in &all {

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,9 +2,10 @@
 //! the axum wiring (`/mcp` Streamable HTTP, `/health`, CORS, bearer auth).
 //!
 //! Ports `src/server.ts`. rmcp's `StreamableHttpService` owns the transport and
-//! MCP session lifecycle: the service factory runs once per MCP session, so a
-//! fresh [`SessionState`] lives inside each handler and is dropped — killing any
-//! resident exec processes — when the session ends.
+//! MCP session lifecycle: the service factory runs once per transport session,
+//! so a fresh [`SessionState`] owns resident exec processes and drops them when
+//! that session ends. ChatGPT project selection is stored separately by its
+//! stable conversation metadata and survives transport replacement.
 
 use std::sync::Arc;
 
@@ -26,8 +27,10 @@ use tower_http::cors::{Any, CorsLayer};
 use crate::auth::require_auth;
 use crate::exec_sessions::SessionState;
 use crate::instructions::build_initial_instructions;
+use crate::project_bindings::{ConversationIdentity, ProjectBindingStore};
 use crate::registry::load_tools_for_mode;
 use crate::tool::Tool;
+use crate::tools::set_project_root::{SetProjectRoot, select_and_render};
 use crate::types::{AppConfig, ToolContent, ToolResult};
 
 /// One MCP session: shared config and tool registry, plus this session's own
@@ -35,6 +38,7 @@ use crate::types::{AppConfig, ToolContent, ToolResult};
 pub struct CodexHandler {
     config: Arc<AppConfig>,
     tools: Arc<Vec<Box<dyn Tool>>>,
+    project_bindings: Arc<ProjectBindingStore>,
     session: SessionState,
 }
 
@@ -91,8 +95,14 @@ impl ServerHandler for CodexHandler {
     async fn call_tool(
         &self,
         request: CallToolRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, McpError> {
+        let conversation = ConversationIdentity::from_request_meta(&context.meta).or_else(|| {
+            request
+                .meta
+                .as_ref()
+                .and_then(ConversationIdentity::from_request_meta)
+        });
         let name = request.name.as_ref();
         let args = request.arguments.map(Value::Object).unwrap_or(Value::Null);
 
@@ -102,22 +112,39 @@ impl ServerHandler for CodexHandler {
             return Ok(result.into());
         };
 
-        let effective_config = if tool.requires_project_root() {
-            match self.session.effective_config(&self.config) {
-                Ok(config) => Some(config),
-                Err(error) => {
-                    let result = ToolResult::error(error);
-                    tracing::info!("  tool: {name} -> error");
-                    return Ok(to_call_tool_result(result).into());
-                }
+        let mut result = if name == SetProjectRoot::NAME {
+            if let Some(identity) = conversation.as_ref() {
+                select_and_render(&args, |path| {
+                    self.project_bindings
+                        .select_project_root(&self.config, identity, path)
+                })
+            } else {
+                tool.call(args, &self.config, &self.session).await
             }
         } else {
-            None
+            let effective_config = if tool.requires_project_root() {
+                let resolved = match conversation.as_ref() {
+                    Some(identity) => self
+                        .project_bindings
+                        .effective_config(&self.config, identity),
+                    None => self.session.effective_config(&self.config),
+                };
+                match resolved {
+                    Ok(config) => Some(config),
+                    Err(error) => {
+                        let result = ToolResult::error(error);
+                        tracing::info!("  tool: {name} -> error");
+                        return Ok(to_call_tool_result(result).into());
+                    }
+                }
+            } else {
+                None
+            };
+            let call_config = effective_config
+                .as_ref()
+                .unwrap_or_else(|| self.config.as_ref());
+            tool.call(args, call_config, &self.session).await
         };
-        let call_config = effective_config
-            .as_ref()
-            .unwrap_or_else(|| self.config.as_ref());
-        let mut result = tool.call(args, call_config, &self.session).await;
 
         // Fill in the `structuredContent` the MCP spec expects from any tool that
         // advertises an `outputSchema`. Most tools use the `{ content: string }`
@@ -154,6 +181,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     let _ = std::fs::remove_dir_all(&gen_dir);
     config.generated_skills_dir = Some(gen_dir);
     let config = Arc::new(config);
+    let project_bindings = Arc::new(ProjectBindingStore::for_current_user());
 
     // Connect to any configured upstream MCP servers and merge their tools in.
     // The returned services must stay alive for the whole server lifetime, so
@@ -197,11 +225,13 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
 
     let factory_config = config.clone();
     let factory_tools = tools.clone();
+    let factory_project_bindings = project_bindings.clone();
     let service = StreamableHttpService::new(
         move || {
             Ok(CodexHandler {
                 config: factory_config.clone(),
                 tools: factory_tools.clone(),
+                project_bindings: factory_project_bindings.clone(),
                 session: SessionState::new(),
             })
         },
@@ -233,7 +263,11 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     );
     if config.multi_project {
         println!("Project access root: {}", config.work_dir.display());
-        println!("Project mode: per-session selection required");
+        println!("Project mode: persistent ChatGPT conversation binding");
+        println!(
+            "Conversation bindings: {}",
+            project_bindings.base_dir().display()
+        );
     } else {
         println!("Work directory: {}", config.work_dir.display());
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -25,8 +25,8 @@ use tower_http::cors::{Any, CorsLayer};
 
 use crate::auth::require_auth;
 use crate::exec_sessions::SessionState;
-use crate::instructions::build_instructions;
-use crate::registry::load_tools;
+use crate::instructions::build_initial_instructions;
+use crate::registry::load_tools_for_mode;
 use crate::tool::Tool;
 use crate::types::{AppConfig, ToolContent, ToolResult};
 
@@ -62,7 +62,7 @@ impl ServerHandler for CodexHandler {
     fn get_info(&self) -> ServerInfo {
         InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("codexrr", "1.0.0"))
-            .with_instructions(build_instructions(&self.config))
+            .with_instructions(build_initial_instructions(&self.config))
     }
 
     async fn list_tools(
@@ -102,7 +102,22 @@ impl ServerHandler for CodexHandler {
             return Ok(result.into());
         };
 
-        let mut result = tool.call(args, &self.config, &self.session).await;
+        let effective_config = if tool.requires_project_root() {
+            match self.session.effective_config(&self.config) {
+                Ok(config) => Some(config),
+                Err(error) => {
+                    let result = ToolResult::error(error);
+                    tracing::info!("  tool: {name} -> error");
+                    return Ok(to_call_tool_result(result).into());
+                }
+            }
+        } else {
+            None
+        };
+        let call_config = effective_config
+            .as_ref()
+            .unwrap_or_else(|| self.config.as_ref());
+        let mut result = tool.call(args, call_config, &self.session).await;
 
         // Fill in the `structuredContent` the MCP spec expects from any tool that
         // advertises an `outputSchema`. Most tools use the `{ content: string }`
@@ -147,7 +162,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     let bridge_report = bridge.report;
     let _bridge_services = bridge.services;
 
-    let mut all_tools = load_tools();
+    let mut all_tools = load_tools_for_mode(config.multi_project);
     let native: std::collections::HashSet<&'static str> =
         all_tools.iter().map(|t| t.name()).collect();
     let mut seen = native.clone();
@@ -216,7 +231,12 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
         "\nCodex Free MCP Bridge (Rust) running on http://localhost:{}",
         config.port
     );
-    println!("Work directory: {}", config.work_dir.display());
+    if config.multi_project {
+        println!("Project access root: {}", config.work_dir.display());
+        println!("Project mode: per-session selection required");
+    } else {
+        println!("Work directory: {}", config.work_dir.display());
+    }
     println!(
         "Tools loaded ({tool_count}): {} native + {bridged_count} bridged from upstream MCP servers",
         tool_count - bridged_count

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -43,6 +43,12 @@ pub trait Tool: Send + Sync {
         true
     }
 
+    /// Whether this tool needs the project root selected for the current MCP
+    /// session. Upstream tools and project-independent clocks opt out.
+    fn requires_project_root(&self) -> bool {
+        true
+    }
+
     /// Run the tool. `args` is the arguments object (or `Value::Null` when the
     /// call named none).
     async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult;

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -43,8 +43,8 @@ pub trait Tool: Send + Sync {
         true
     }
 
-    /// Whether this tool needs the project root selected for the current MCP
-    /// session. Upstream tools and project-independent clocks opt out.
+    /// Whether this tool needs an active project root for the current call.
+    /// Upstream tools and project-independent clocks opt out.
     fn requires_project_root(&self) -> bool {
         true
     }

--- a/src/tools/clock_curr_time.rs
+++ b/src/tools/clock_curr_time.rs
@@ -41,6 +41,10 @@ impl Tool for ClockCurrTime {
         }))
     }
 
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
     async fn call(&self, _args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
         let current_time = format_utc_now();
         ToolResult::text(current_time.clone())

--- a/src/tools/clock_sleep.rs
+++ b/src/tools/clock_sleep.rs
@@ -50,6 +50,10 @@ impl Tool for ClockSleep {
         }))
     }
 
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
     async fn call(&self, args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
         let Some(duration_ms) = args.get("duration_ms").and_then(|v| v.as_f64()) else {
             return ToolResult::error("duration_ms must be a number");

--- a/src/tools/exec_command.rs
+++ b/src/tools/exec_command.rs
@@ -169,8 +169,7 @@ impl Tool for ExecCommand {
             ..Default::default()
         };
 
-        let is_error;
-        if exited {
+        let is_error = if exited {
             let code = exec_session.exit_code();
             result.exit_code = code;
             session
@@ -178,11 +177,11 @@ impl Tool for ExecCommand {
                 .lock()
                 .unwrap()
                 .remove(&exec_session.id);
-            is_error = code.unwrap_or(0) != 0;
+            code.unwrap_or(0) != 0
         } else {
             result.session_id = Some(exec_session.id);
-            is_error = false;
-        }
+            false
+        };
 
         let structured = serde_json::to_value(&result).unwrap_or(Value::Null);
         ToolResult {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -18,6 +18,7 @@ pub mod read_file;
 pub mod recall;
 pub mod remember;
 pub mod run_command;
+pub mod set_project_root;
 pub mod skills_list;
 pub mod skills_read;
 pub mod tree;

--- a/src/tools/set_project_root.rs
+++ b/src/tools/set_project_root.rs
@@ -2,19 +2,65 @@ use async_trait::async_trait;
 use serde_json::{Value, json};
 
 use crate::exec_sessions::SessionState;
+use crate::project_bindings::{ProjectBindingScope, ProjectRootSelection};
 use crate::tool::{Tool, arg_str};
 use crate::types::{AppConfig, ToolResult};
 
 pub struct SetProjectRoot;
 
+impl SetProjectRoot {
+    pub const NAME: &'static str = "set_project_root";
+}
+
+pub fn select_and_render(
+    args: &Value,
+    select: impl FnOnce(&str) -> Result<ProjectRootSelection, String>,
+) -> ToolResult {
+    let Some(path) = arg_str(args, "path") else {
+        return ToolResult::error("path must be a string");
+    };
+
+    let selection = match select(path) {
+        Ok(selection) => selection,
+        Err(error) => return ToolResult::error(error),
+    };
+
+    let state = if selection.newly_selected {
+        "Project root selected"
+    } else {
+        "Project root was already selected"
+    };
+    let persistence = match selection.scope {
+        ProjectBindingScope::ChatGptConversation => {
+            "This ChatGPT conversation is permanently bound to that project. The binding survives MCP reconnects and server restarts; start a new chat for another project."
+        }
+        ProjectBindingScope::McpTransportSession => {
+            "This MCP transport session is permanently bound to that project. Clients that do not provide a stable conversation identifier must select again after reconnecting."
+        }
+    };
+    let content = format!(
+        "{state}: {}\nAccess root: {}\n{persistence}\nCall `get_agent_brief` now so the environment, saved state, skills, and project instructions are loaded from the selected root.",
+        selection.project_root.display(),
+        selection.access_root.display()
+    );
+
+    ToolResult::text(content.clone()).with_structured(json!({
+        "access_root": selection.access_root.to_string_lossy(),
+        "project_root": selection.project_root.to_string_lossy(),
+        "newly_selected": selection.newly_selected,
+        "binding_scope": selection.scope.as_str(),
+        "content": content
+    }))
+}
+
 #[async_trait]
 impl Tool for SetProjectRoot {
     fn name(&self) -> &'static str {
-        "set_project_root"
+        Self::NAME
     }
 
     fn description(&self) -> String {
-        "Bind this MCP session to one project directory beneath the server's configured access root. In multi-project mode, call this before any filesystem, search, edit, command, git, project-instruction, skill, memory, or plan tool. The binding cannot be changed within the same session; open a new chat or MCP session for another project. After selecting, call get_agent_brief.".into()
+        "Bind the current ChatGPT conversation to one project directory beneath the server's configured access root. ChatGPT bindings survive MCP reconnects and server restarts and cannot be changed; start a new chat for another project. Clients without ChatGPT's stable conversation metadata fall back to binding the current MCP transport session. In multi-project mode, call this for a new unbound conversation before any filesystem, search, edit, command, git, project-instruction, skill, memory, or plan tool, then call get_agent_brief.".into()
     }
 
     fn describe(&self, config: &AppConfig) -> String {
@@ -50,9 +96,10 @@ impl Tool for SetProjectRoot {
                 "access_root": { "type": "string" },
                 "project_root": { "type": "string" },
                 "newly_selected": { "type": "boolean" },
+                "binding_scope": { "type": "string", "enum": ["chatgpt_conversation", "mcp_transport_session"] },
                 "content": { "type": "string" }
             },
-            "required": ["access_root", "project_root", "newly_selected", "content"]
+            "required": ["access_root", "project_root", "newly_selected", "binding_scope", "content"]
         }))
     }
 
@@ -65,31 +112,6 @@ impl Tool for SetProjectRoot {
     }
 
     async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult {
-        let Some(path) = arg_str(&args, "path") else {
-            return ToolResult::error("path must be a string");
-        };
-
-        let selection = match session.select_project_root(config, path) {
-            Ok(selection) => selection,
-            Err(error) => return ToolResult::error(error),
-        };
-
-        let state = if selection.newly_selected {
-            "Project root selected"
-        } else {
-            "Project root was already selected"
-        };
-        let content = format!(
-            "{state}: {}\nAccess root: {}\nThis MCP session is permanently bound to that project. Call `get_agent_brief` now so the environment, saved state, skills, and project instructions are loaded from the selected root.",
-            selection.project_root.display(),
-            selection.access_root.display()
-        );
-
-        ToolResult::text(content.clone()).with_structured(json!({
-            "access_root": selection.access_root.to_string_lossy(),
-            "project_root": selection.project_root.to_string_lossy(),
-            "newly_selected": selection.newly_selected,
-            "content": content
-        }))
+        select_and_render(&args, |path| session.select_project_root(config, path))
     }
 }

--- a/src/tools/set_project_root.rs
+++ b/src/tools/set_project_root.rs
@@ -1,0 +1,95 @@
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::exec_sessions::SessionState;
+use crate::tool::{Tool, arg_str};
+use crate::types::{AppConfig, ToolResult};
+
+pub struct SetProjectRoot;
+
+#[async_trait]
+impl Tool for SetProjectRoot {
+    fn name(&self) -> &'static str {
+        "set_project_root"
+    }
+
+    fn description(&self) -> String {
+        "Bind this MCP session to one project directory beneath the server's configured access root. In multi-project mode, call this before any filesystem, search, edit, command, git, project-instruction, skill, memory, or plan tool. The binding cannot be changed within the same session; open a new chat or MCP session for another project. After selecting, call get_agent_brief.".into()
+    }
+
+    fn describe(&self, config: &AppConfig) -> String {
+        if config.multi_project {
+            format!(
+                "{} The access root is `{}`. The path may be relative to that root or an absolute path inside it.",
+                self.description(),
+                config.work_dir.display()
+            )
+        } else {
+            "Project-root selection is disabled on this server. Start codexrr with --multi-project or set multiProject to true to enable it.".into()
+        }
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Existing project directory, relative to the configured access root or an absolute path inside it"
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "access_root": { "type": "string" },
+                "project_root": { "type": "string" },
+                "newly_selected": { "type": "boolean" },
+                "content": { "type": "string" }
+            },
+            "required": ["access_root", "project_root", "newly_selected", "content"]
+        }))
+    }
+
+    fn fills_structured_content(&self) -> bool {
+        false
+    }
+
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult {
+        let Some(path) = arg_str(&args, "path") else {
+            return ToolResult::error("path must be a string");
+        };
+
+        let selection = match session.select_project_root(config, path) {
+            Ok(selection) => selection,
+            Err(error) => return ToolResult::error(error),
+        };
+
+        let state = if selection.newly_selected {
+            "Project root selected"
+        } else {
+            "Project root was already selected"
+        };
+        let content = format!(
+            "{state}: {}\nAccess root: {}\nThis MCP session is permanently bound to that project. Call `get_agent_brief` now so the environment, saved state, skills, and project instructions are loaded from the selected root.",
+            selection.project_root.display(),
+            selection.access_root.display()
+        );
+
+        ToolResult::text(content.clone()).with_structured(json!({
+            "access_root": selection.access_root.to_string_lossy(),
+            "project_root": selection.project_root.to_string_lossy(),
+            "newly_selected": selection.newly_selected,
+            "content": content
+        }))
+    }
+}

--- a/src/tools/write_stdin.rs
+++ b/src/tools/write_stdin.rs
@@ -109,16 +109,15 @@ impl Tool for WriteStdin {
             ..Default::default()
         };
 
-        let is_error;
-        if exited {
+        let is_error = if exited {
             let code = exec_session.exit_code();
             result.exit_code = code;
             session.exec_sessions.lock().unwrap().remove(&session_id);
-            is_error = code.unwrap_or(0) != 0;
+            code.unwrap_or(0) != 0
         } else {
             result.session_id = Some(session_id);
-            is_error = false;
-        }
+            false
+        };
 
         let structured = serde_json::to_value(&result).unwrap_or(Value::Null);
         ToolResult {

--- a/src/types.rs
+++ b/src/types.rs
@@ -274,6 +274,7 @@ pub struct McpServerSpec {
 #[derive(Debug, Clone)]
 pub struct AppConfig {
     pub work_dir: std::path::PathBuf,
+    pub multi_project: bool,
     pub api_key: Option<String>,
     pub port: u16,
     pub allowed_commands: Vec<String>,

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -17,7 +17,7 @@ use tempfile::TempDir;
 
 use codexrr::config::default_config;
 use codexrr::exec_sessions::SessionState;
-use codexrr::registry::load_tools;
+use codexrr::registry::{load_tools, load_tools_for_mode};
 use codexrr::safe_path::resolve_safe_path;
 use codexrr::tool::Tool;
 use codexrr::types::{AppConfig, ToolContent, ToolResult};
@@ -28,6 +28,13 @@ use codexrr::types::{AppConfig, ToolContent, ToolResult};
 fn loads_all_25_tools() {
     let tools = load_tools();
     assert_eq!(tools.len(), 25);
+}
+
+#[test]
+fn multi_project_mode_adds_only_the_session_selector() {
+    let tools = load_tools_for_mode(true);
+    assert_eq!(tools.len(), 26);
+    assert_eq!(tools[0].name(), "set_project_root");
 }
 
 #[test]

--- a/tests/project_selection.rs
+++ b/tests/project_selection.rs
@@ -1,0 +1,351 @@
+use std::fs;
+
+use clap::Parser;
+use codexrr::config::{Cli, default_config, load_config};
+use codexrr::exec_sessions::SessionState;
+use codexrr::instructions::{build_initial_instructions, build_instructions};
+use codexrr::memory::memory_dir;
+use codexrr::tool::Tool;
+use codexrr::tools::git_status::GitStatus;
+use codexrr::tools::read_file::ReadFile;
+use codexrr::tools::recall::Recall;
+use codexrr::tools::remember::Remember;
+use codexrr::tools::run_command::RunCommand;
+use codexrr::tools::set_project_root::SetProjectRoot;
+use serde_json::json;
+use tempfile::TempDir;
+
+fn multi_project_config(access_root: &std::path::Path) -> codexrr::types::AppConfig {
+    let mut config = default_config(access_root.to_path_buf());
+    config.multi_project = true;
+    config.skills.enabled = Some(false);
+    config
+}
+
+#[test]
+fn project_tools_require_a_selection_in_multi_project_mode() {
+    let root = TempDir::new().unwrap();
+    let config = multi_project_config(root.path());
+    let session = SessionState::new();
+
+    let error = session.effective_config(&config).unwrap_err();
+    assert!(error.contains("set_project_root"));
+    assert!(error.contains(root.path().to_string_lossy().as_ref()));
+}
+
+#[tokio::test]
+async fn sessions_are_isolated_to_their_selected_roots() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let project_a = access.join("alpha");
+    let project_b = access.join("beta");
+    fs::create_dir_all(&project_a).unwrap();
+    fs::create_dir_all(&project_b).unwrap();
+    fs::write(project_a.join("identity.txt"), "alpha").unwrap();
+    fs::write(project_b.join("identity.txt"), "beta").unwrap();
+
+    let config = multi_project_config(&access);
+    let alpha_session = SessionState::new();
+    let beta_session = SessionState::new();
+
+    let alpha_selector = SetProjectRoot;
+    let beta_selector = SetProjectRoot;
+    let beta_path = project_b.to_string_lossy().into_owned();
+    let (alpha, beta) = tokio::join!(
+        alpha_selector.call(json!({ "path": "alpha" }), &config, &alpha_session),
+        beta_selector.call(json!({ "path": beta_path }), &config, &beta_session)
+    );
+    assert!(!alpha.is_error);
+    assert!(!beta.is_error);
+
+    let alpha_config = alpha_session.effective_config(&config).unwrap();
+    let beta_config = beta_session.effective_config(&config).unwrap();
+    assert_eq!(alpha_config.work_dir, fs::canonicalize(&project_a).unwrap());
+    assert_eq!(beta_config.work_dir, fs::canonicalize(&project_b).unwrap());
+
+    let alpha_reader = ReadFile;
+    let beta_reader = ReadFile;
+    let (alpha_file, beta_file) = tokio::join!(
+        alpha_reader.call(
+            json!({ "path": "identity.txt" }),
+            &alpha_config,
+            &alpha_session,
+        ),
+        beta_reader.call(
+            json!({ "path": "identity.txt" }),
+            &beta_config,
+            &beta_session,
+        )
+    );
+    assert_eq!(alpha_file.joined_text(), "1\talpha");
+    assert_eq!(beta_file.joined_text(), "1\tbeta");
+
+    let sibling = ReadFile
+        .call(
+            json!({ "path": "../beta/identity.txt" }),
+            &alpha_config,
+            &alpha_session,
+        )
+        .await;
+    assert!(sibling.is_error);
+    assert!(sibling.joined_text().contains("within work directory"));
+}
+
+#[tokio::test]
+async fn command_and_git_tools_use_the_selected_root() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let project_a = access.join("alpha");
+    let project_b = access.join("beta");
+    fs::create_dir_all(&project_a).unwrap();
+    fs::create_dir_all(&project_b).unwrap();
+
+    for project in [&project_a, &project_b] {
+        let status = std::process::Command::new("git")
+            .args(["init", "--quiet"])
+            .current_dir(project)
+            .status()
+            .expect("git must be installed to run these tests");
+        assert!(status.success());
+    }
+    fs::write(project_a.join("alpha-only.txt"), "alpha").unwrap();
+    fs::write(project_b.join("beta-only.txt"), "beta").unwrap();
+
+    let config = multi_project_config(&access);
+    let session = SessionState::new();
+    SetProjectRoot
+        .call(json!({ "path": "alpha" }), &config, &session)
+        .await;
+    let selected = session.effective_config(&config).unwrap();
+
+    let command = RunCommand
+        .call(
+            json!({
+                "command": "git",
+                "args": ["status", "--porcelain"]
+            }),
+            &selected,
+            &session,
+        )
+        .await;
+    assert!(!command.is_error);
+    assert!(command.joined_text().contains("alpha-only.txt"));
+    assert!(!command.joined_text().contains("beta-only.txt"));
+
+    let git = GitStatus.call(json!({}), &selected, &session).await;
+    assert!(!git.is_error);
+    assert!(git.joined_text().contains("alpha-only.txt"));
+    assert!(!git.joined_text().contains("beta-only.txt"));
+}
+
+#[tokio::test]
+async fn project_selection_is_idempotent_but_cannot_switch() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    fs::create_dir_all(access.join("alpha")).unwrap();
+    fs::create_dir_all(access.join("beta")).unwrap();
+    let config = multi_project_config(&access);
+    let session = SessionState::new();
+
+    let first = SetProjectRoot
+        .call(json!({ "path": "alpha" }), &config, &session)
+        .await;
+    assert!(!first.is_error);
+    assert_eq!(
+        first
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("newly_selected"))
+            .and_then(|value| value.as_bool()),
+        Some(true)
+    );
+
+    let repeated = SetProjectRoot
+        .call(json!({ "path": "alpha/." }), &config, &session)
+        .await;
+    assert!(!repeated.is_error);
+    assert_eq!(
+        repeated
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("newly_selected"))
+            .and_then(|value| value.as_bool()),
+        Some(false)
+    );
+
+    let switched = SetProjectRoot
+        .call(json!({ "path": "beta" }), &config, &session)
+        .await;
+    assert!(switched.is_error);
+    assert!(switched.joined_text().contains("cannot switch"));
+}
+
+#[tokio::test]
+async fn selection_rejects_paths_outside_the_access_root_and_non_directories() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&access).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    fs::write(access.join("file.txt"), "not a directory").unwrap();
+    let config = multi_project_config(&access);
+    let session = SessionState::new();
+
+    let relative_escape = SetProjectRoot
+        .call(json!({ "path": "../outside" }), &config, &session)
+        .await;
+    assert!(relative_escape.is_error);
+
+    let absolute_escape = SetProjectRoot
+        .call(
+            json!({ "path": outside.to_string_lossy() }),
+            &config,
+            &session,
+        )
+        .await;
+    assert!(absolute_escape.is_error);
+
+    let file = SetProjectRoot
+        .call(json!({ "path": "file.txt" }), &config, &session)
+        .await;
+    assert!(file.is_error);
+    assert!(file.joined_text().contains("not a directory"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn selection_rejects_a_symlink_that_resolves_outside_the_access_root() {
+    use std::os::unix::fs::symlink;
+
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let outside = root.path().join("outside");
+    fs::create_dir_all(&access).unwrap();
+    fs::create_dir_all(&outside).unwrap();
+    symlink(&outside, access.join("linked-outside")).unwrap();
+    let config = multi_project_config(&access);
+    let session = SessionState::new();
+
+    let result = SetProjectRoot
+        .call(json!({ "path": "linked-outside" }), &config, &session)
+        .await;
+    assert!(result.is_error);
+    assert!(
+        result
+            .joined_text()
+            .contains("escapes the configured access root")
+    );
+}
+
+#[tokio::test]
+async fn persistent_state_is_keyed_by_the_selected_root_even_with_a_custom_base_dir() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    fs::create_dir_all(access.join("alpha")).unwrap();
+    fs::create_dir_all(access.join("beta")).unwrap();
+    let mut config = multi_project_config(&access);
+    let state_base = root.path().join("state");
+    config.memory.dir = Some(state_base.to_string_lossy().into_owned());
+
+    let alpha_session = SessionState::new();
+    let beta_session = SessionState::new();
+    SetProjectRoot
+        .call(json!({ "path": "alpha" }), &config, &alpha_session)
+        .await;
+    SetProjectRoot
+        .call(json!({ "path": "beta" }), &config, &beta_session)
+        .await;
+    let alpha_config = alpha_session.effective_config(&config).unwrap();
+    let beta_config = beta_session.effective_config(&config).unwrap();
+
+    assert_ne!(memory_dir(&alpha_config), memory_dir(&beta_config));
+    assert!(memory_dir(&alpha_config).starts_with(&state_base));
+    assert!(memory_dir(&beta_config).starts_with(&state_base));
+
+    Remember
+        .call(
+            json!({ "key": "identity", "value": "alpha-state" }),
+            &alpha_config,
+            &alpha_session,
+        )
+        .await;
+    Remember
+        .call(
+            json!({ "key": "identity", "value": "beta-state" }),
+            &beta_config,
+            &beta_session,
+        )
+        .await;
+
+    let alpha = Recall
+        .call(json!({}), &alpha_config, &alpha_session)
+        .await
+        .joined_text();
+    let beta = Recall
+        .call(json!({}), &beta_config, &beta_session)
+        .await
+        .joined_text();
+    assert!(alpha.contains("alpha-state"));
+    assert!(!alpha.contains("beta-state"));
+    assert!(beta.contains("beta-state"));
+    assert!(!beta.contains("alpha-state"));
+}
+
+#[tokio::test]
+async fn initialize_instructions_defer_project_state_until_selection() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let project = access.join("alpha");
+    fs::create_dir_all(&project).unwrap();
+    fs::write(access.join("AGENTS.md"), "ACCESS-ROOT-INSTRUCTION").unwrap();
+    fs::write(project.join("AGENTS.md"), "SELECTED-PROJECT-INSTRUCTION").unwrap();
+    let mut config = multi_project_config(&access);
+    config.memory.enabled = Some(false);
+
+    let initial = build_initial_instructions(&config);
+    assert!(initial.contains("set_project_root"));
+    assert!(initial.contains("<not selected>"));
+    assert!(!initial.contains("ACCESS-ROOT-INSTRUCTION"));
+    assert!(!initial.contains("SELECTED-PROJECT-INSTRUCTION"));
+
+    let session = SessionState::new();
+    SetProjectRoot
+        .call(json!({ "path": "alpha" }), &config, &session)
+        .await;
+    let selected = session.effective_config(&config).unwrap();
+    let brief = build_instructions(&selected);
+    assert!(brief.contains("SELECTED-PROJECT-INSTRUCTION"));
+    assert!(!brief.contains("ACCESS-ROOT-INSTRUCTION"));
+}
+
+#[test]
+fn multi_project_mode_can_be_enabled_by_config_or_cli() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    fs::create_dir_all(&access).unwrap();
+
+    let enabled_config = root.path().join("enabled.json");
+    fs::write(&enabled_config, r#"{ "multiProject": true }"#).unwrap();
+    let from_file = Cli::try_parse_from([
+        "codexrr",
+        "--work-dir",
+        access.to_str().unwrap(),
+        "--config",
+        enabled_config.to_str().unwrap(),
+    ])
+    .unwrap();
+    assert!(load_config(from_file).unwrap().multi_project);
+
+    let disabled_config = root.path().join("disabled.json");
+    fs::write(&disabled_config, r#"{ "multiProject": false }"#).unwrap();
+    let from_cli = Cli::try_parse_from([
+        "codexrr",
+        "--work-dir",
+        access.to_str().unwrap(),
+        "--config",
+        disabled_config.to_str().unwrap(),
+        "--multi-project",
+    ])
+    .unwrap();
+    assert!(load_config(from_cli).unwrap().multi_project);
+}

--- a/tests/project_selection.rs
+++ b/tests/project_selection.rs
@@ -1,10 +1,12 @@
 use std::fs;
+use std::sync::{Arc, Barrier};
 
 use clap::Parser;
 use codexrr::config::{Cli, default_config, load_config};
 use codexrr::exec_sessions::SessionState;
 use codexrr::instructions::{build_initial_instructions, build_instructions};
 use codexrr::memory::memory_dir;
+use codexrr::project_bindings::{ConversationIdentity, ProjectBindingScope, ProjectBindingStore};
 use codexrr::tool::Tool;
 use codexrr::tools::git_status::GitStatus;
 use codexrr::tools::read_file::ReadFile;
@@ -12,6 +14,7 @@ use codexrr::tools::recall::Recall;
 use codexrr::tools::remember::Remember;
 use codexrr::tools::run_command::RunCommand;
 use codexrr::tools::set_project_root::SetProjectRoot;
+use rmcp::model::RequestMetaObject;
 use serde_json::json;
 use tempfile::TempDir;
 
@@ -20,6 +23,10 @@ fn multi_project_config(access_root: &std::path::Path) -> codexrr::types::AppCon
     config.multi_project = true;
     config.skills.enabled = Some(false);
     config
+}
+
+fn conversation_identity(session: &str) -> ConversationIdentity {
+    ConversationIdentity::from_openai_session(session).unwrap()
 }
 
 #[test]
@@ -159,6 +166,14 @@ async fn project_selection_is_idempotent_but_cannot_switch() {
             .and_then(|value| value.as_bool()),
         Some(true)
     );
+    assert_eq!(
+        first
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("binding_scope"))
+            .and_then(|value| value.as_str()),
+        Some("mcp_transport_session")
+    );
 
     let repeated = SetProjectRoot
         .call(json!({ "path": "alpha/." }), &config, &session)
@@ -178,6 +193,208 @@ async fn project_selection_is_idempotent_but_cannot_switch() {
         .await;
     assert!(switched.is_error);
     assert!(switched.joined_text().contains("cannot switch"));
+}
+
+#[test]
+fn openai_conversation_identity_is_read_from_request_metadata() {
+    let mut meta = RequestMetaObject::new();
+    assert!(ConversationIdentity::from_request_meta(&meta).is_none());
+
+    meta.insert("openai/session".to_string(), json!("conversation-123"));
+    assert!(ConversationIdentity::from_request_meta(&meta).is_some());
+
+    meta.insert("openai/session".to_string(), json!("   "));
+    assert!(ConversationIdentity::from_request_meta(&meta).is_none());
+}
+
+#[test]
+fn chatgpt_project_binding_survives_transport_reconnect_and_server_restart() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let project = access.join("alpha");
+    fs::create_dir_all(&project).unwrap();
+
+    let mut config = multi_project_config(&access);
+    config.memory.enabled = Some(false);
+    let state_dir = root.path().join("bindings");
+    let identity = conversation_identity("conversation-follow-up");
+
+    let first_process = ProjectBindingStore::new(state_dir.clone());
+    let selected = first_process
+        .select_project_root(&config, &identity, "alpha")
+        .unwrap();
+    assert!(selected.newly_selected);
+    assert_eq!(selected.scope, ProjectBindingScope::ChatGptConversation);
+
+    let replacement_transport = SessionState::new();
+    assert!(replacement_transport.effective_config(&config).is_err());
+
+    drop(first_process);
+    let restarted_process = ProjectBindingStore::new(state_dir);
+    let restored = restarted_process
+        .effective_config(&config, &identity)
+        .unwrap();
+    assert_eq!(restored.work_dir, fs::canonicalize(&project).unwrap());
+
+    let repeated = restarted_process
+        .select_project_root(&config, &identity, "alpha/.")
+        .unwrap();
+    assert!(!repeated.newly_selected);
+}
+
+#[test]
+fn chatgpt_conversations_keep_independent_project_bindings() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let alpha = access.join("alpha");
+    let beta = access.join("beta");
+    fs::create_dir_all(&alpha).unwrap();
+    fs::create_dir_all(&beta).unwrap();
+
+    let config = multi_project_config(&access);
+    let store = ProjectBindingStore::new(root.path().join("bindings"));
+    let first = conversation_identity("conversation-alpha");
+    let second = conversation_identity("conversation-beta");
+
+    store.select_project_root(&config, &first, "alpha").unwrap();
+    store.select_project_root(&config, &second, "beta").unwrap();
+
+    assert_eq!(
+        store.effective_config(&config, &first).unwrap().work_dir,
+        fs::canonicalize(&alpha).unwrap()
+    );
+    assert_eq!(
+        store.effective_config(&config, &second).unwrap().work_dir,
+        fs::canonicalize(&beta).unwrap()
+    );
+}
+
+#[test]
+fn chatgpt_conversation_cannot_switch_projects_after_restart() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    fs::create_dir_all(access.join("alpha")).unwrap();
+    fs::create_dir_all(access.join("beta")).unwrap();
+
+    let config = multi_project_config(&access);
+    let state_dir = root.path().join("bindings");
+    let identity = conversation_identity("immutable-conversation");
+    ProjectBindingStore::new(state_dir.clone())
+        .select_project_root(&config, &identity, "alpha")
+        .unwrap();
+
+    let error = ProjectBindingStore::new(state_dir)
+        .select_project_root(&config, &identity, "beta")
+        .unwrap_err();
+    assert!(error.contains("already bound"));
+    assert!(error.contains("Start a new chat"));
+}
+
+#[test]
+fn concurrent_chatgpt_bindings_choose_one_project_without_overwriting() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let alpha = access.join("alpha");
+    let beta = access.join("beta");
+    fs::create_dir_all(&alpha).unwrap();
+    fs::create_dir_all(&beta).unwrap();
+
+    let config = multi_project_config(&access);
+    let state_dir = root.path().join("bindings");
+    let identity = conversation_identity("concurrent-conversation");
+    let barrier = Arc::new(Barrier::new(3));
+
+    let attempts = ["alpha", "beta"].map(|project| {
+        let barrier = barrier.clone();
+        let config = config.clone();
+        let identity = identity.clone();
+        let store = ProjectBindingStore::new(state_dir.clone());
+        std::thread::spawn(move || {
+            barrier.wait();
+            store.select_project_root(&config, &identity, project)
+        })
+    });
+    barrier.wait();
+
+    let results = attempts.map(|attempt| attempt.join().unwrap());
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+    assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
+
+    let selected = ProjectBindingStore::new(state_dir)
+        .effective_config(&config, &identity)
+        .unwrap()
+        .work_dir;
+    assert!(
+        selected == fs::canonicalize(alpha).unwrap() || selected == fs::canonicalize(beta).unwrap()
+    );
+}
+
+#[test]
+fn missing_bound_project_fails_closed_instead_of_rebinding() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let alpha = access.join("alpha");
+    fs::create_dir_all(&alpha).unwrap();
+    fs::create_dir_all(access.join("beta")).unwrap();
+
+    let config = multi_project_config(&access);
+    let store = ProjectBindingStore::new(root.path().join("bindings"));
+    let identity = conversation_identity("missing-project-conversation");
+    store
+        .select_project_root(&config, &identity, "alpha")
+        .unwrap();
+    fs::remove_dir_all(alpha).unwrap();
+
+    let restore_error = store.effective_config(&config, &identity).unwrap_err();
+    assert!(restore_error.contains("no longer exists"));
+
+    let rebind_error = store
+        .select_project_root(&config, &identity, "beta")
+        .unwrap_err();
+    assert!(rebind_error.contains("no longer exists"));
+}
+
+#[test]
+fn conversation_binding_is_namespaced_by_access_root_and_hides_the_session_id() {
+    let root = TempDir::new().unwrap();
+    let first_access = root.path().join("first");
+    let second_access = root.path().join("second");
+    fs::create_dir_all(first_access.join("project")).unwrap();
+    fs::create_dir_all(second_access.join("project")).unwrap();
+
+    let state_dir = root.path().join("bindings");
+    let store = ProjectBindingStore::new(state_dir.clone());
+    let session_id = "sensitive-conversation-identifier";
+    let identity = conversation_identity(session_id);
+    let first_config = multi_project_config(&first_access);
+    let second_config = multi_project_config(&second_access);
+
+    store
+        .select_project_root(&first_config, &identity, "project")
+        .unwrap();
+    assert!(
+        store
+            .selected_project_root(&second_config, &identity)
+            .unwrap()
+            .is_none()
+    );
+    store
+        .select_project_root(&second_config, &identity, "project")
+        .unwrap();
+
+    let mut pending = vec![state_dir];
+    while let Some(path) = pending.pop() {
+        for entry in fs::read_dir(path).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            assert!(!path.to_string_lossy().contains(session_id));
+            assert!(!fs::read_to_string(path).unwrap().contains(session_id));
+        }
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This PR adds an opt-in multi-project mode that allows one `codex-free` connector to serve multiple projects while keeping each ChatGPT conversation bound to exactly one project root.

Single-project behavior remains the default. When `--multi-project` or `multiProject: true` is enabled, `--work-dir` becomes the common access root and the new `set_project_root` tool selects an existing project directory beneath it.

## Conversation binding

For ChatGPT tool calls, the project association is keyed by `_meta["openai/session"]`, the logical ChatGPT conversation identifier, rather than by the MCP transport session or an in-memory handler instance.

Once a conversation selects a project:

- selecting the same canonical path again is idempotent;
- selecting a different project is rejected, and requires a new ChatGPT conversation;
- the binding is restored automatically after an MCP reconnect or `codex-free` restart;
- separate ChatGPT conversations can select different projects through the same connector without sharing project-scoped state.

The raw ChatGPT identifier is never persisted. It is SHA-256 hashed and namespaced by the canonical access root before being used as a binding key. Bindings are stored under `~/.codex-free/conversation-projects/` using lock-protected, atomic writes.

MCP clients that do not provide a stable conversation identifier fall back to an MCP-transport-scoped binding and must select the project again after reconnecting.

## Project scoping

After selection, the effective project root is applied consistently to:

- filesystem, search, and edit tools;
- command working directories and dedicated Git tools;
- `AGENTS.md` and project instructions;
- repository skills;
- persistent memory and saved plans;
- environment and agent briefs.

Project-specific initialization is deferred until selection. `get_agent_brief` then loads the environment, saved state, skills, and instructions from the selected root.

Live `exec_command` processes and their numeric handles remain scoped to the current MCP transport. They are not restored across reconnects and are terminated when that transport closes.

## Validation and failure behavior

`set_project_root` canonicalizes the requested path and requires it to:

- exist;
- be a directory;
- remain beneath the canonical access root.

Traversal and symlink escapes are rejected. Persisted bindings are revalidated when restored and fail closed if the record is corrupt, the project no longer exists, or the path now resolves outside the access root. Concurrent first-selection attempts cannot overwrite an existing binding.

This provides logical project scoping for Codex-style tools, not an operating-system sandbox. An allowlisted interpreter or shell command still has the privileges of the account running `codex-free`.

## Compatibility

- Existing single-project behavior and the default 25-tool surface are unchanged.
- `set_project_root` is registered only in multi-project mode.
- Custom `memory.dir` configurations remain isolated by selected project.

## Validation

- `cargo test --all-targets --all-features` — 353 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Regression coverage includes conversation restoration after reconnect and restart, independent conversation bindings, immutable and idempotent selection, concurrent selection races, stale binding failures, access-root namespacing, raw-identifier non-persistence, traversal and symlink rejection, project-scoped tools and state, and the generic MCP transport fallback.

Closes #2.
