### PR TITLE
feat: add interactive quickstart setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Interactive `codex-free quickstart` onboarding for new installations. The
+  wizard selects the project scope, guides tunnel creation and ChatGPT developer
+  mode setup with direct links and concrete connector values, validates the
+  tunnel ID and hidden runtime key, preserves unrelated JSON configuration, and
+  stores the key in a dedicated per-tunnel file outside the project. On Unix, the
+  credential directory and file are restricted to the current user. The wizard
+  can start the normal supervised server immediately so ChatGPT can scan the live
+  tunnel.
+
 ## [1.2.0] - 2026-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "walkdir",
+ "windows-sys 0.59.0",
  "zeroize",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,6 +318,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmcp",
+ "rpassword",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1437,6 +1438,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2357,6 +2379,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ zip = { version = "4", default-features = false, features = ["deflate"] }
 getrandom = "0.2"
 tokio-util = "0.7"
 zeroize = "1"
+rpassword = "7"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ rpassword = "7"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_System_Console"] }
+
 # `thin` LTO keeps nearly all of full-LTO's runtime benefit for an I/O-bound
 # MCP server while cutting release build time roughly in half; the default
 # codegen-units (16) restores parallel codegen instead of serialising on one.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,39 @@ Dotted edges are conditional: `set_project_root` appears only in [multi-project 
 
 ## Quick start
 
-### Native OpenAI tunnel (recommended)
+### Interactive setup (recommended for a first install)
+
+Run the guided setup from an installed binary:
+
+```bash
+codex-free quickstart
+```
+
+Or run it directly from a source checkout:
+
+```bash
+cargo run --release -- quickstart
+```
+
+The wizard asks which project directory ChatGPT may access and whether that
+directory is one project or a multi-project access root. It then walks through
+creating an OpenAI Secure MCP Tunnel, entering the tunnel ID and runtime API key,
+and creating the matching ChatGPT developer-mode connector. The relevant OpenAI
+and ChatGPT links are printed together with the exact connection values to use.
+
+The runtime key is entered without terminal echo and stored in a dedicated
+per-tunnel file under `~/.codex-free/openai-tunnel/credentials/`. On Unix, the
+wizard restricts the credential directory and file to the current user.
+`codex.config.json` receives only a `file:` reference, and unrelated existing JSON
+settings are preserved. At the end, the wizard can start Codex Free immediately
+so ChatGPT can scan the live connector. Keep that process running while using the
+connector.
+
+Use `codex-free quickstart --config /path/to/codex.config.json` to update a
+different config file, or `--work-dir /path/to/project` to change the directory
+initially shown by the wizard.
+
+### Manual native OpenAI tunnel setup
 
 1. Create or obtain a tunnel ID in [OpenAI Platform tunnel settings](https://platform.openai.com/settings/organization/tunnels).
 2. Create a restricted [runtime API key](https://platform.openai.com/settings/organization/api-keys) whose principal has Tunnels **Read** + **Use** for that tunnel. Keep tunnel-management/admin credentials separate.
@@ -129,7 +161,18 @@ cargo build --release
 
 Each release ships a compiled binary per platform — `windows-x64`, `linux-x64`, `linux-arm64`, `darwin-x64` and `darwin-arm64`. Download the archive for your OS/arch, unpack it, and run `codex-free --work-dir …`. These are native builds, so there is no AVX2/baseline caveat: the binary runs on any CPU of its architecture.
 
-## CLI flags
+## CLI
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `quickstart` | Interactively configure the project scope, native OpenAI tunnel credentials, JSON config, and ChatGPT developer-mode connector; optionally start the server when setup is complete |
+
+`quickstart` accepts `--config <PATH>` (default `./codex.config.json`) and
+`--work-dir <DIR>` as the initial project-directory prompt value.
+
+### Server flags
 
 | Flag | Required | Default | Description |
 |------|----------|---------|-------------|
@@ -279,6 +322,12 @@ The `openaiTunnel` block enables OpenAI's native outbound tunnel:
 | `apiKeyRef` | `"env:CONTROL_PLANE_API_KEY"` | Runtime API-key reference. Only `env:NAME` and `file:/path` are accepted; literal keys are rejected |
 | `clientPath` | verified managed runtime | Explicit official `tunnel-client` or `tunnel-client-runtime` binary. Relative paths resolve from the launch directory |
 | `organizationId` | - | Optional organization ID passed as `OpenAI-Organization` by the official client |
+
+The `quickstart` command writes its runtime key to
+`~/.codex-free/openai-tunnel/credentials/<tunnel-id>.key` and sets `apiKeyRef` to
+that absolute `file:` path. It never writes the key itself into
+`codex.config.json`; on Unix, the credential directory is mode `0700` and the key
+file is mode `0600`.
 
 Native mode deliberately cannot be combined with a caller-supplied `apiKey` / `--api-key`: Codex Free generates a high-entropy bearer token for the loopback MCP hop and injects it into the tunnel runtime through static MCP and discovery headers. Host validation is forced to loopback authorities and permissive browser CORS is disabled.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,6 +149,17 @@ multi-project mode, dispatch clones this config per call and substitutes the
 conversation's selected root—or the transport fallback—for `work_dir`; the static
 server policy and bridge configuration remain shared.
 
+### `quickstart` CLI (`quickstart.rs`)
+The `quickstart` subcommand runs before server configuration is loaded. It uses a
+testable line-oriented wizard for ordinary prompts and terminal-hidden input for
+the runtime API key. The wizard canonicalizes the project directory, validates
+the tunnel credentials with the same helpers as normal startup, merges only the
+managed fields into the existing JSON object, and stores the key outside the
+project behind an absolute `file:` reference. Config and credential replacement
+use temporary files in the destination directory. Once setup is complete, the
+same process can pass the generated paths back through `load_config` and enter the
+ordinary supervised server lifecycle; there is no separate quickstart runtime.
+
 ---
 
 ## 4. MCP server layer (`server.rs`, `auth.rs`)
@@ -242,6 +253,7 @@ the original order and rejects duplicate names.
 | `exec_sessions.rs` | Generic-client transport fallback plus unified-exec sessions: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, output truncation (UTF-16 units to match the TS). |
 | `apply_patch.rs` | The Codex patch format: parse then apply, atomically, with fuzzy context matching and CRLF preservation. |
 | `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized active root, with `O_EXCL` locking and atomic writes. In multi-project mode, a configured `memory.dir` is a base containing one hashed child per project. |
+| `quickstart.rs` | Interactive first-install wizard for project scope, native tunnel credentials, JSON config merging, and the ChatGPT developer-mode connector handoff. |
 | `openai_tunnel.rs` | Verified installation and lifecycle supervision for OpenAI's outbound Secure MCP Tunnel runtime. |
 | `process_env.rs` | Child-process environment boundaries: isolate the tunnel runtime and remove tunnel credentials from model-controlled and upstream subprocesses. |
 | `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. Multi-project mode treats the selected directory as the exact project root and never walks into the common access-root parent. |

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,12 +6,14 @@
 
 use std::path::{Path, PathBuf};
 
-use clap::Parser;
+use clap::{Parser, Subcommand};
 use serde::Deserialize;
 
 use std::collections::HashMap;
 
 use crate::codex_mcp::{codex_config_path, discover_codex_mcp_servers};
+use crate::openai_tunnel::validate_tunnel_id;
+use crate::quickstart::QuickstartArgs;
 use crate::types::{
     AppConfig, CommandConfig, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig,
     OpenAiTunnelConfig, OutputConfig, ProjectDocConfig, SkillsConfig, TreeConfig,
@@ -20,12 +22,17 @@ use crate::types::{
 #[derive(Parser, Debug)]
 #[command(
     name = "codex-free",
-    about = "Codex Free MCP bridge (Rust): expose Codex-style agent tools over Streamable HTTP."
+    about = "Codex Free MCP bridge (Rust): expose Codex-style agent tools over Streamable HTTP.",
+    subcommand_negates_reqs = true,
+    args_conflicts_with_subcommands = true
 )]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<CliCommand>,
+
     /// Project directory, or the access root when --multi-project is enabled.
-    #[arg(long = "work-dir")]
-    pub work_dir: String,
+    #[arg(long = "work-dir", required = true)]
+    pub work_dir: Option<String>,
 
     /// Let each ChatGPT conversation bind once to a project below --work-dir.
     /// Other MCP clients fall back to transport-session binding.
@@ -59,6 +66,12 @@ pub struct Cli {
     /// Optional OpenAI organization id sent by tunnel-client.
     #[arg(long = "openai-tunnel-organization-id")]
     pub openai_tunnel_organization_id: Option<String>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum CliCommand {
+    /// Interactively configure a native OpenAI tunnel and ChatGPT connector.
+    Quickstart(QuickstartArgs),
 }
 
 fn default_allowed_commands() -> Vec<String> {
@@ -367,15 +380,6 @@ fn resolve_path(raw: &str) -> PathBuf {
     }
 }
 
-fn valid_tunnel_id(value: &str) -> bool {
-    value.strip_prefix("tunnel_").is_some_and(|suffix| {
-        suffix.len() == 32
-            && suffix
-                .bytes()
-                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
-    })
-}
-
 fn valid_env_name(value: &str) -> bool {
     let mut chars = value.chars();
     matches!(chars.next(), Some(first) if first == '_' || first.is_ascii_alphabetic())
@@ -420,11 +424,7 @@ fn resolve_openai_tunnel(
         .clone()
         .or(file.tunnel_id)
         .ok_or_else(|| "openaiTunnel requires tunnelId (or --openai-tunnel-id)".to_string())?;
-    if !valid_tunnel_id(&tunnel_id) {
-        return Err(
-            "OpenAI tunnel id must be tunnel_ followed by 32 lowercase letters or digits".into(),
-        );
-    }
+    validate_tunnel_id(&tunnel_id).map_err(|error| error.to_string())?;
 
     let api_key_ref = resolve_api_key_ref(
         cli.openai_tunnel_api_key_ref
@@ -461,7 +461,14 @@ fn resolve_openai_tunnel(
 /// Load and merge config. Errors are returned as strings for the caller to
 /// print and exit on, mirroring the TS which validates and `process.exit`s.
 pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
-    let work_dir = resolve_work_dir(&cli.work_dir);
+    if cli.command.is_some() {
+        return Err("cannot load server configuration for a CLI subcommand".into());
+    }
+    let raw_work_dir = cli
+        .work_dir
+        .as_deref()
+        .ok_or_else(|| "--work-dir is required when starting the server".to_string())?;
+    let work_dir = resolve_work_dir(raw_work_dir);
 
     // Validate work-dir exists and is a directory.
     match std::fs::metadata(&work_dir) {
@@ -598,7 +605,8 @@ mod tests {
 
     fn cli(work_dir: &Path, config: &Path) -> Cli {
         Cli {
-            work_dir: work_dir.to_string_lossy().into_owned(),
+            command: None,
+            work_dir: Some(work_dir.to_string_lossy().into_owned()),
             multi_project: false,
             port: None,
             api_key: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod output_budget;
 pub mod process_env;
 pub mod project_bindings;
 pub mod project_doc;
+pub mod quickstart;
 pub mod registry;
 pub mod safe_path;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 
-use codex_free::config::{Cli, load_config};
+use anyhow::Context;
+use codex_free::config::{Cli, CliCommand, load_config};
+use codex_free::quickstart;
 use codex_free::server::start_http_server;
 
 #[tokio::main]
@@ -11,17 +13,29 @@ async fn main() {
         )
         .init();
 
-    let cli = Cli::parse();
-    let config = match load_config(cli) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(1);
-        }
-    };
-
-    if let Err(e) = start_http_server(config).await {
-        eprintln!("Server error: {e}");
+    if let Err(error) = run().await {
+        eprintln!("Error: {error:#}");
         std::process::exit(1);
     }
+}
+
+async fn run() -> anyhow::Result<()> {
+    let mut cli = Cli::parse();
+    if let Some(command) = cli.command.take() {
+        match command {
+            CliCommand::Quickstart(args) => {
+                let outcome = quickstart::run(args)?;
+                if !outcome.start_server {
+                    return Ok(());
+                }
+                cli.work_dir = Some(outcome.work_dir.to_string_lossy().into_owned());
+                cli.config = Some(outcome.config_path.to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    let config = load_config(cli).map_err(anyhow::Error::msg)?;
+    start_http_server(config)
+        .await
+        .context("start Codex Free server")
 }

--- a/src/openai_tunnel.rs
+++ b/src/openai_tunnel.rs
@@ -35,6 +35,19 @@ const LOG_TAIL_BYTES: u64 = 32 * 1024;
 const DETAIL_MAX_CHARS: usize = 2_000;
 const POLL_SUCCESS_METRIC: &str = "commands_poll_last_successful_timestamp_seconds";
 
+pub(crate) fn validate_tunnel_id(value: &str) -> anyhow::Result<()> {
+    if value.strip_prefix("tunnel_").is_some_and(|suffix| {
+        suffix.len() == 32
+            && suffix
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+    }) {
+        return Ok(());
+    }
+
+    bail!("OpenAI tunnel id must be tunnel_ followed by 32 lowercase letters or digits")
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct InstallManifest {
@@ -668,7 +681,7 @@ fn resolve_key_reference(reference: &str) -> anyhow::Result<Zeroizing<String>> {
     Ok(value)
 }
 
-fn validate_runtime_api_key(value: &str) -> anyhow::Result<()> {
+pub(crate) fn validate_runtime_api_key(value: &str) -> anyhow::Result<()> {
     if value.is_empty() {
         bail!("OpenAI tunnel API key is empty");
     }

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::io::{self, BufRead, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context, bail};
 use clap::Args;
@@ -55,9 +57,108 @@ pub fn run(args: QuickstartArgs) -> anyhow::Result<QuickstartOutcome> {
     };
     let mut input = stdin.lock();
     let mut output = stdout.lock();
-    run_with_io(args, environment, &mut input, &mut output, |label, _| {
-        rpassword::prompt_password(format!("{label}: "))
+    run_with_io(
+        args,
+        environment,
+        &mut input,
+        &mut output,
+        prompt_hidden_password,
+    )
+}
+
+fn prompt_hidden_password(output_label: &str, output: &mut impl Write) -> io::Result<String> {
+    let terminal = TerminalEchoProbe::open()?;
+    prompt_hidden_password_with(output_label, output, rpassword::read_password, || {
+        terminal.is_disabled()
     })
+}
+
+fn prompt_hidden_password_with<R, E>(
+    output_label: &str,
+    output: &mut impl Write,
+    read_password: R,
+    mut echo_is_disabled: E,
+) -> io::Result<String>
+where
+    R: FnOnce() -> io::Result<String> + Send + 'static,
+    E: FnMut() -> io::Result<bool>,
+{
+    let reader = thread::spawn(read_password);
+
+    // The reader configures the terminal first; exposing the prompt only after
+    // echo is off prevents a fast paste from being echoed during setup.
+    loop {
+        if reader.is_finished() {
+            return join_password_reader(reader);
+        }
+        if echo_is_disabled()? {
+            break;
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    write!(output, "{output_label}: ")?;
+    output.flush()?;
+    join_password_reader(reader)
+}
+
+fn join_password_reader(reader: thread::JoinHandle<io::Result<String>>) -> io::Result<String> {
+    reader
+        .join()
+        .map_err(|_| io::Error::other("hidden-input reader panicked"))?
+}
+
+struct TerminalEchoProbe {
+    input: fs::File,
+}
+
+#[cfg(unix)]
+impl TerminalEchoProbe {
+    fn open() -> io::Result<Self> {
+        Ok(Self {
+            input: fs::OpenOptions::new().read(true).open("/dev/tty")?,
+        })
+    }
+
+    fn is_disabled(&self) -> io::Result<bool> {
+        use std::mem::MaybeUninit;
+        use std::os::fd::AsRawFd;
+
+        let mut terminal = MaybeUninit::<libc::termios>::uninit();
+        if unsafe { libc::tcgetattr(self.input.as_raw_fd(), terminal.as_mut_ptr()) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let terminal = unsafe { terminal.assume_init() };
+        Ok(terminal.c_lflag & libc::ECHO == 0)
+    }
+}
+
+#[cfg(windows)]
+impl TerminalEchoProbe {
+    fn open() -> io::Result<Self> {
+        Ok(Self {
+            input: fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("CONIN$")?,
+        })
+    }
+
+    fn is_disabled(&self) -> io::Result<bool> {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+        use windows_sys::Win32::System::Console::{ENABLE_ECHO_INPUT, GetConsoleMode};
+
+        let input = self.input.as_raw_handle();
+        if input.is_null() || input == INVALID_HANDLE_VALUE {
+            return Err(io::Error::last_os_error());
+        }
+        let mut mode = 0;
+        if unsafe { GetConsoleMode(input, &mut mode) } == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(mode & ENABLE_ECHO_INPUT == 0)
+    }
 }
 
 fn run_with_io<R, W, F>(
@@ -78,6 +179,7 @@ where
         read_secret,
     };
     let config_path = absolute_path(&environment.current_dir, &args.config);
+    refuse_symlinked_config(&config_path)?;
     let mut file_config = read_config(&config_path)?;
     if file_config
         .get("openaiTunnel")
@@ -152,13 +254,7 @@ where
     let command = launch_command(&environment.executable, &work_dir, &config_path);
     writeln!(wizard.output, "\nLaunch command:\n  {command}")?;
 
-    print_connector_step(
-        &mut wizard,
-        &connector_name,
-        &tunnel_id,
-        &work_dir,
-        multi_project,
-    )?;
+    print_connector_step(&mut wizard, &connector_name, &tunnel_id, multi_project)?;
     let start_server = wizard.confirm(
         "Start Codex Free now and keep this terminal open while ChatGPT scans the connector?",
         true,
@@ -407,7 +503,6 @@ fn print_connector_step<R, W, F>(
     wizard: &mut Wizard<'_, R, W, F>,
     connector_name: &str,
     tunnel_id: &str,
-    work_dir: &Path,
     multi_project: bool,
 ) -> anyhow::Result<()>
 where
@@ -415,10 +510,10 @@ where
     W: Write,
     F: FnMut(&str, &mut W) -> io::Result<String>,
 {
-    let scope = if multi_project {
-        format!("projects below {}", work_dir.display())
+    let description = if multi_project {
+        "Local Codex-style tools with per-chat project selection"
     } else {
-        work_dir.display().to_string()
+        "Local Codex-style file, shell, Git, and MCP tools"
     };
     writeln!(wizard.output, "\n3. Add the connector in ChatGPT Web")?;
     writeln!(
@@ -432,10 +527,7 @@ where
     writeln!(wizard.output, "   Open: {CHATGPT_PLUGINS_URL}")?;
     writeln!(wizard.output, "   Click the + button and enter:")?;
     writeln!(wizard.output, "     Name: {connector_name}")?;
-    writeln!(
-        wizard.output,
-        "     Description: Local Codex-style file, shell, Git, and MCP tools for {scope}"
-    )?;
+    writeln!(wizard.output, "     Description: {description}")?;
     writeln!(wizard.output, "     Connection: Tunnel")?;
     writeln!(
         wizard.output,
@@ -518,12 +610,7 @@ fn read_config(path: &Path) -> anyhow::Result<Map<String, Value>> {
 }
 
 fn write_config(path: &Path, config: &Map<String, Value>) -> anyhow::Result<()> {
-    if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
-        bail!(
-            "refusing to replace symlinked config file {}",
-            path.display()
-        );
-    }
+    refuse_symlinked_config(path)?;
     let parent = path
         .parent()
         .filter(|parent| !parent.as_os_str().is_empty())
@@ -539,6 +626,16 @@ fn write_config(path: &Path, config: &Map<String, Value>) -> anyhow::Result<()> 
     preserve_permissions(path, temp.path())?;
     persist_replacing(temp, path)
         .with_context(|| format!("replace config file {}", path.display()))?;
+    Ok(())
+}
+
+fn refuse_symlinked_config(path: &Path) -> anyhow::Result<()> {
+    if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        bail!(
+            "refusing to replace symlinked config file {}",
+            path.display()
+        );
+    }
     Ok(())
 }
 
@@ -658,6 +755,8 @@ fn quote_shell_arg(value: &str) -> String {
 mod tests {
     use std::collections::VecDeque;
     use std::io::Cursor;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Condvar, Mutex};
 
     use clap::Parser;
     use serde_json::json;
@@ -668,6 +767,27 @@ mod tests {
 
     const TUNNEL_ID: &str = "tunnel_0123456789abcdef0123456789abcdef";
     const RUNTIME_KEY: &str = "sk-runtime-test-key_123";
+
+    struct GuardedPromptOutput {
+        bytes: Vec<u8>,
+        echo_is_disabled: Arc<AtomicBool>,
+        reader_release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl Write for GuardedPromptOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            assert!(self.echo_is_disabled.load(Ordering::Acquire));
+            self.bytes.extend_from_slice(bytes);
+            let (released, wake_reader) = &*self.reader_release;
+            *released.lock().unwrap() = true;
+            wake_reader.notify_one();
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     fn environment(root: &TempDir, work_dir: &Path) -> QuickstartEnvironment {
         let home_dir = root.path().join("home");
@@ -709,6 +829,40 @@ mod tests {
             },
         );
         (result, String::from_utf8(output).unwrap())
+    }
+
+    #[test]
+    fn hidden_secret_prompt_is_published_only_after_echo_is_disabled() {
+        let echo_is_disabled = Arc::new(AtomicBool::new(false));
+        let reader_release = Arc::new((Mutex::new(false), Condvar::new()));
+        let reader_release_for_thread = Arc::clone(&reader_release);
+        let read_password = move || {
+            let (released, wake_reader) = &*reader_release_for_thread;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = wake_reader.wait(released).unwrap();
+            }
+            Ok("secret".to_string())
+        };
+        let echo_for_probe = Arc::clone(&echo_is_disabled);
+        let mut probe_count = 0;
+        let mut output = GuardedPromptOutput {
+            bytes: Vec::new(),
+            echo_is_disabled,
+            reader_release,
+        };
+
+        let secret =
+            prompt_hidden_password_with("Runtime key", &mut output, read_password, move || {
+                probe_count += 1;
+                let disabled = probe_count > 1;
+                echo_for_probe.store(disabled, Ordering::Release);
+                Ok(disabled)
+            })
+            .unwrap();
+
+        assert_eq!(secret, "secret");
+        assert_eq!(output.bytes, b"Runtime key: ");
     }
 
     #[test]
@@ -880,6 +1034,32 @@ mod tests {
             fs::read_to_string(config_path).unwrap(),
             r#"{"openaiTunnel":"invalid"}"#
         );
+        assert!(!credentials.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_config_fails_before_writing_credentials() {
+        use std::os::unix::fs::symlink;
+
+        let root = TempDir::new().unwrap();
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        let target = project.join("actual.json");
+        let config_path = project.join("codex.config.json");
+        fs::write(&target, "{}").unwrap();
+        symlink(&target, &config_path).unwrap();
+        let environment = environment(&root, &project);
+        let credentials = environment.home_dir.join(".codex-free");
+
+        let (result, _) = run_test_wizard(args(config_path, &project), environment, "", &[]);
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("refusing to replace symlinked config file")
+        );
+        assert_eq!(fs::read_to_string(target).unwrap(), "{}");
         assert!(!credentials.exists());
     }
 

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -1,0 +1,897 @@
+use std::fs;
+use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, bail};
+use clap::Args;
+use serde_json::{Map, Value};
+use tempfile::NamedTempFile;
+use zeroize::Zeroizing;
+
+use crate::openai_tunnel::{validate_runtime_api_key, validate_tunnel_id};
+use crate::util::home_dir;
+
+pub const TUNNEL_SETTINGS_URL: &str = "https://platform.openai.com/settings/organization/tunnels";
+pub const API_KEYS_URL: &str = "https://platform.openai.com/settings/organization/api-keys";
+pub const DEVELOPER_MODE_GUIDE_URL: &str =
+    "https://developers.openai.com/api/docs/guides/developer-mode";
+pub const CHATGPT_PLUGINS_URL: &str = "https://chatgpt.com/plugins";
+
+#[derive(Args, Debug, Clone)]
+pub struct QuickstartArgs {
+    /// Config file to create or update.
+    #[arg(long, value_name = "PATH", default_value = "codex.config.json")]
+    pub config: PathBuf,
+
+    /// Initial directory shown by the project-directory prompt.
+    #[arg(long = "work-dir", value_name = "DIR")]
+    pub work_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuickstartOutcome {
+    pub work_dir: PathBuf,
+    pub config_path: PathBuf,
+    pub start_server: bool,
+}
+
+struct QuickstartEnvironment {
+    current_dir: PathBuf,
+    home_dir: PathBuf,
+    executable: PathBuf,
+}
+
+pub fn run(args: QuickstartArgs) -> anyhow::Result<QuickstartOutcome> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    if !stdin.is_terminal() || !stdout.is_terminal() {
+        bail!("quickstart is interactive and requires a terminal");
+    }
+
+    let environment = QuickstartEnvironment {
+        current_dir: std::env::current_dir().context("determine current directory")?,
+        home_dir: home_dir().context("quickstart cannot locate the user's home directory")?,
+        executable: std::env::current_exe().context("locate the running codex-free binary")?,
+    };
+    let mut input = stdin.lock();
+    let mut output = stdout.lock();
+    run_with_io(args, environment, &mut input, &mut output, |label, _| {
+        rpassword::prompt_password(format!("{label}: "))
+    })
+}
+
+fn run_with_io<R, W, F>(
+    args: QuickstartArgs,
+    environment: QuickstartEnvironment,
+    input: &mut R,
+    output: &mut W,
+    read_secret: F,
+) -> anyhow::Result<QuickstartOutcome>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    let mut wizard = Wizard {
+        input,
+        output,
+        read_secret,
+    };
+    let config_path = absolute_path(&environment.current_dir, &args.config);
+    let mut file_config = read_config(&config_path)?;
+    if file_config
+        .get("openaiTunnel")
+        .is_some_and(|value| !value.is_object())
+    {
+        bail!(
+            "openaiTunnel in the existing config must be a JSON object: {}",
+            config_path.display()
+        );
+    }
+
+    writeln!(wizard.output, "Codex Free quickstart")?;
+    writeln!(
+        wizard.output,
+        "This wizard configures an OpenAI Secure MCP Tunnel and a ChatGPT developer-mode connector."
+    )?;
+    writeln!(wizard.output, "Config file: {}\n", config_path.display())?;
+
+    let default_work_dir = args
+        .work_dir
+        .as_deref()
+        .map(|path| absolute_path(&environment.current_dir, path))
+        .unwrap_or_else(|| environment.current_dir.clone());
+    let work_dir = prompt_existing_directory(
+        &mut wizard,
+        &default_work_dir,
+        &environment.current_dir,
+        &environment.home_dir,
+    )?;
+    let multi_project_default = file_config
+        .get("multiProject")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let multi_project = wizard.confirm(
+        "Use this directory as an access root for several independent projects?",
+        multi_project_default,
+    )?;
+
+    let default_connector_name = connector_name_default(&work_dir, multi_project);
+    let connector_name = prompt_connector_name(&mut wizard, &default_connector_name)?;
+
+    if file_config
+        .get("apiKey")
+        .is_some_and(|value| !value.is_null())
+    {
+        writeln!(
+            wizard.output,
+            "\nThe existing config contains apiKey, which cannot be combined with the native OpenAI tunnel."
+        )?;
+        if !wizard.confirm("Remove apiKey from the config?", true)? {
+            bail!("quickstart cancelled without changing the config");
+        }
+        file_config.remove("apiKey");
+    }
+
+    let existing_tunnel_id = configured_tunnel_id(&file_config);
+    print_tunnel_creation_step(&mut wizard, &connector_name)?;
+    wizard.pause("Press Enter after the tunnel has been created")?;
+    let tunnel_id = prompt_tunnel_id(&mut wizard, existing_tunnel_id.as_deref())?;
+
+    let key_path = credential_path(&environment.home_dir, &tunnel_id);
+    print_api_key_step(&mut wizard, &key_path)?;
+    configure_runtime_key(&mut wizard, &key_path)?;
+
+    merge_tunnel_config(&mut file_config, &tunnel_id, &key_path, multi_project)?;
+    write_config(&config_path, &file_config)?;
+
+    writeln!(wizard.output, "\nLocal configuration complete.")?;
+    writeln!(wizard.output, "  Config: {}", config_path.display())?;
+    writeln!(wizard.output, "  Runtime key: {}", key_path.display())?;
+    writeln!(wizard.output, "  Project directory: {}", work_dir.display())?;
+    let command = launch_command(&environment.executable, &work_dir, &config_path);
+    writeln!(wizard.output, "\nLaunch command:\n  {command}")?;
+
+    print_connector_step(
+        &mut wizard,
+        &connector_name,
+        &tunnel_id,
+        &work_dir,
+        multi_project,
+    )?;
+    let start_server = wizard.confirm(
+        "Start Codex Free now and keep this terminal open while ChatGPT scans the connector?",
+        true,
+    )?;
+    if start_server {
+        writeln!(
+            wizard.output,
+            "\nStarting Codex Free. Wait for `OpenAI Secure MCP Tunnel: ready`, then complete the ChatGPT steps above."
+        )?;
+    } else {
+        writeln!(
+            wizard.output,
+            "\nRun the launch command above before scanning or using the connector."
+        )?;
+    }
+
+    Ok(QuickstartOutcome {
+        work_dir,
+        config_path,
+        start_server,
+    })
+}
+
+struct Wizard<'a, R, W, F> {
+    input: &'a mut R,
+    output: &'a mut W,
+    read_secret: F,
+}
+
+impl<R, W, F> Wizard<'_, R, W, F>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    fn prompt(&mut self, label: &str, default: Option<&str>) -> anyhow::Result<String> {
+        match default {
+            Some(default) => write!(self.output, "{label} [{default}]: ")?,
+            None => write!(self.output, "{label}: ")?,
+        }
+        self.output.flush()?;
+
+        let mut line = String::new();
+        if self.input.read_line(&mut line)? == 0 {
+            bail!("quickstart input ended before setup was complete");
+        }
+        let value = line.trim().to_string();
+        if value.is_empty() {
+            return Ok(default.unwrap_or_default().to_string());
+        }
+        Ok(value)
+    }
+
+    fn confirm(&mut self, label: &str, default: bool) -> anyhow::Result<bool> {
+        let suffix = if default { "Y/n" } else { "y/N" };
+        loop {
+            write!(self.output, "{label} [{suffix}]: ")?;
+            self.output.flush()?;
+            let mut line = String::new();
+            if self.input.read_line(&mut line)? == 0 {
+                bail!("quickstart input ended before setup was complete");
+            }
+            match line.trim().to_ascii_lowercase().as_str() {
+                "" => return Ok(default),
+                "y" | "yes" => return Ok(true),
+                "n" | "no" => return Ok(false),
+                _ => writeln!(self.output, "Please answer yes or no.")?,
+            }
+        }
+    }
+
+    fn pause(&mut self, label: &str) -> anyhow::Result<()> {
+        write!(self.output, "{label}: ")?;
+        self.output.flush()?;
+        let mut line = String::new();
+        if self.input.read_line(&mut line)? == 0 {
+            bail!("quickstart input ended before setup was complete");
+        }
+        Ok(())
+    }
+
+    fn secret(&mut self, label: &str) -> anyhow::Result<Zeroizing<String>> {
+        let value =
+            (self.read_secret)(label, self.output).context("read hidden runtime API key")?;
+        writeln!(self.output)?;
+        Ok(Zeroizing::new(value))
+    }
+}
+
+fn prompt_existing_directory<R, W, F>(
+    wizard: &mut Wizard<'_, R, W, F>,
+    default: &Path,
+    current_dir: &Path,
+    home_dir: &Path,
+) -> anyhow::Result<PathBuf>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    let default = default.to_string_lossy();
+    loop {
+        let raw = wizard.prompt("Project directory", Some(&default))?;
+        let candidate = resolve_user_path(&raw, current_dir, home_dir);
+        match fs::canonicalize(&candidate) {
+            Ok(path) if path.is_dir() => return Ok(path),
+            Ok(path) => writeln!(
+                wizard.output,
+                "That path is not a directory: {}",
+                path.display()
+            )?,
+            Err(error) => writeln!(wizard.output, "Cannot use {}: {error}", candidate.display())?,
+        }
+    }
+}
+
+fn prompt_connector_name<R, W, F>(
+    wizard: &mut Wizard<'_, R, W, F>,
+    default: &str,
+) -> anyhow::Result<String>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    loop {
+        let name = wizard.prompt("ChatGPT connector name", Some(default))?;
+        if name.chars().any(char::is_control) {
+            writeln!(
+                wizard.output,
+                "The connector name cannot contain control characters."
+            )?;
+            continue;
+        }
+        return Ok(name);
+    }
+}
+
+fn prompt_tunnel_id<R, W, F>(
+    wizard: &mut Wizard<'_, R, W, F>,
+    default: Option<&str>,
+) -> anyhow::Result<String>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    loop {
+        let tunnel_id = wizard.prompt("Tunnel ID", default)?;
+        match validate_tunnel_id(&tunnel_id) {
+            Ok(()) => return Ok(tunnel_id),
+            Err(error) => writeln!(wizard.output, "{error}")?,
+        }
+    }
+}
+
+fn configure_runtime_key<R, W, F>(
+    wizard: &mut Wizard<'_, R, W, F>,
+    key_path: &Path,
+) -> anyhow::Result<()>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    let can_keep = existing_runtime_key_is_valid(key_path);
+    if can_keep {
+        writeln!(
+            wizard.output,
+            "A valid stored runtime key already exists at {}.",
+            key_path.display()
+        )?;
+    }
+
+    loop {
+        let label = if can_keep {
+            "Paste a replacement runtime API key, or press Enter to keep the stored key"
+        } else {
+            "Paste the runtime API key (input is hidden)"
+        };
+        let raw = wizard.secret(label)?;
+        let key = Zeroizing::new(raw.trim().to_string());
+        if key.is_empty() && can_keep {
+            return Ok(());
+        }
+        if let Err(error) = validate_runtime_api_key(&key) {
+            writeln!(wizard.output, "{error}")?;
+            continue;
+        }
+        write_private_key(key_path, key.as_bytes())?;
+        return Ok(());
+    }
+}
+
+fn print_tunnel_creation_step<R, W, F>(
+    wizard: &mut Wizard<'_, R, W, F>,
+    connector_name: &str,
+) -> anyhow::Result<()>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    writeln!(wizard.output, "\n1. Create an OpenAI Secure MCP Tunnel")?;
+    writeln!(wizard.output, "   Open: {TUNNEL_SETTINGS_URL}")?;
+    writeln!(wizard.output, "   Suggested name: {connector_name}")?;
+    writeln!(
+        wizard.output,
+        "   Associate the tunnel with the Platform organization that owns it and the ChatGPT workspace where the connector will be used."
+    )?;
+    writeln!(
+        wizard.output,
+        "   Creating a tunnel requires Tunnels Read + Manage; running it and selecting it in ChatGPT require Tunnels Read + Use."
+    )?;
+    writeln!(
+        wizard.output,
+        "   Create the tunnel, then copy the identifier beginning with `tunnel_`."
+    )?;
+    Ok(())
+}
+
+fn print_api_key_step<R, W, F>(
+    wizard: &mut Wizard<'_, R, W, F>,
+    key_path: &Path,
+) -> anyhow::Result<()>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    writeln!(wizard.output, "\n2. Create a runtime API key")?;
+    writeln!(wizard.output, "   Open: {API_KEYS_URL}")?;
+    writeln!(
+        wizard.output,
+        "   Use a key whose principal has Tunnels Read + Use for this tunnel. Keep tunnel-management credentials separate."
+    )?;
+    writeln!(
+        wizard.output,
+        "   The key will be stored outside the project at {}; the JSON config stores only a file reference. On Unix, the wizard restricts the credential file to the current user.",
+        key_path.display()
+    )?;
+    Ok(())
+}
+
+fn print_connector_step<R, W, F>(
+    wizard: &mut Wizard<'_, R, W, F>,
+    connector_name: &str,
+    tunnel_id: &str,
+    work_dir: &Path,
+    multi_project: bool,
+) -> anyhow::Result<()>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    let scope = if multi_project {
+        format!("projects below {}", work_dir.display())
+    } else {
+        work_dir.display().to_string()
+    };
+    writeln!(wizard.output, "\n3. Add the connector in ChatGPT Web")?;
+    writeln!(
+        wizard.output,
+        "   Developer-mode guide: {DEVELOPER_MODE_GUIDE_URL}"
+    )?;
+    writeln!(
+        wizard.output,
+        "   In ChatGPT, open Settings > Security and login and enable Developer mode. Managed workspaces may first require an admin grant under Workspace Settings > Permissions & Roles > Connected Data, then expose the toggle under Settings > Apps > Advanced Settings."
+    )?;
+    writeln!(wizard.output, "   Open: {CHATGPT_PLUGINS_URL}")?;
+    writeln!(wizard.output, "   Click the + button and enter:")?;
+    writeln!(wizard.output, "     Name: {connector_name}")?;
+    writeln!(
+        wizard.output,
+        "     Description: Local Codex-style file, shell, Git, and MCP tools for {scope}"
+    )?;
+    writeln!(wizard.output, "     Connection: Tunnel")?;
+    writeln!(
+        wizard.output,
+        "     Tunnel: select `{tunnel_id}` or paste that tunnel ID"
+    )?;
+    writeln!(wizard.output, "     Authentication: No Authentication")?;
+    writeln!(
+        wizard.output,
+        "   Wait until this terminal reports `OpenAI Secure MCP Tunnel: ready`, then scan the tools and create the connector. Enable the read/write actions you intend to use; full Codex-style operation needs both."
+    )?;
+    writeln!(
+        wizard.output,
+        "   In a new chat, open the + menu, choose Developer mode, and select `{connector_name}`."
+    )?;
+    Ok(())
+}
+
+fn connector_name_default(work_dir: &Path, multi_project: bool) -> String {
+    let suffix = if multi_project {
+        "Projects".to_string()
+    } else {
+        work_dir
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .filter(|name| !name.is_empty())
+            .unwrap_or_else(|| "Local".to_string())
+    };
+    format!("Codex Free - {suffix}")
+}
+
+fn configured_tunnel_id(config: &Map<String, Value>) -> Option<String> {
+    config
+        .get("openaiTunnel")
+        .and_then(Value::as_object)
+        .and_then(|tunnel| tunnel.get("tunnelId"))
+        .and_then(Value::as_str)
+        .filter(|value| validate_tunnel_id(value).is_ok())
+        .map(str::to_string)
+}
+
+fn credential_path(home_dir: &Path, tunnel_id: &str) -> PathBuf {
+    home_dir
+        .join(".codex-free")
+        .join("openai-tunnel")
+        .join("credentials")
+        .join(format!("{tunnel_id}.key"))
+}
+
+fn merge_tunnel_config(
+    config: &mut Map<String, Value>,
+    tunnel_id: &str,
+    key_path: &Path,
+    multi_project: bool,
+) -> anyhow::Result<()> {
+    let tunnel = config
+        .entry("openaiTunnel".to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let tunnel = tunnel
+        .as_object_mut()
+        .context("openaiTunnel in the existing config must be a JSON object")?;
+    tunnel.insert("tunnelId".to_string(), Value::String(tunnel_id.to_string()));
+    tunnel.insert(
+        "apiKeyRef".to_string(),
+        Value::String(format!("file:{}", key_path.display())),
+    );
+    config.insert("multiProject".to_string(), Value::Bool(multi_project));
+    Ok(())
+}
+
+fn read_config(path: &Path) -> anyhow::Result<Map<String, Value>> {
+    match fs::read_to_string(path) {
+        Ok(text) => serde_json::from_str::<Value>(&text)
+            .with_context(|| format!("parse existing config {}", path.display()))?
+            .as_object()
+            .cloned()
+            .context("existing config must contain a JSON object"),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(Map::new()),
+        Err(error) => Err(error).with_context(|| format!("read config {}", path.display())),
+    }
+}
+
+fn write_config(path: &Path, config: &Map<String, Value>) -> anyhow::Result<()> {
+    if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        bail!(
+            "refusing to replace symlinked config file {}",
+            path.display()
+        );
+    }
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create config directory {}", parent.display()))?;
+    let mut temp = NamedTempFile::new_in(parent)
+        .with_context(|| format!("create temporary config beside {}", path.display()))?;
+    let mut bytes = serde_json::to_vec_pretty(&Value::Object(config.clone()))?;
+    bytes.push(b'\n');
+    temp.write_all(&bytes)?;
+    temp.as_file().sync_all()?;
+    preserve_permissions(path, temp.path())?;
+    persist_replacing(temp, path)
+        .with_context(|| format!("replace config file {}", path.display()))?;
+    Ok(())
+}
+
+fn write_private_key(path: &Path, key: &[u8]) -> anyhow::Result<()> {
+    let parent = path.parent().context("runtime key path has no parent")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create runtime-key directory {}", parent.display()))?;
+    make_private(parent)?;
+    let mut temp = NamedTempFile::new_in(parent)
+        .with_context(|| format!("create temporary runtime-key file in {}", parent.display()))?;
+    make_private(temp.path())?;
+    temp.write_all(key)?;
+    temp.write_all(b"\n")?;
+    temp.as_file().sync_all()?;
+    persist_replacing(temp, path)
+        .with_context(|| format!("replace runtime-key file {}", path.display()))?;
+    make_private(path)?;
+    Ok(())
+}
+
+fn existing_runtime_key_is_valid(path: &Path) -> bool {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_file() && !metadata.file_type().is_symlink() => metadata,
+        _ => return false,
+    };
+    if metadata.len() == 0 || metadata.len() > 64 * 1024 {
+        return false;
+    }
+    if make_private(path).is_err() {
+        return false;
+    }
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => Zeroizing::new(contents),
+        Err(_) => return false,
+    };
+    validate_runtime_api_key(contents.trim()).is_ok()
+}
+
+fn make_private(path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = if path.is_dir() { 0o700 } else { 0o600 };
+        fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn preserve_permissions(source: &Path, target: &Path) -> io::Result<()> {
+    if let Ok(metadata) = fs::metadata(source) {
+        fs::set_permissions(target, metadata.permissions())?;
+    }
+    Ok(())
+}
+
+fn persist_replacing(temp: NamedTempFile, path: &Path) -> io::Result<()> {
+    match temp.persist(path) {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            #[cfg(windows)]
+            {
+                let temp = error.file;
+                if path.exists() {
+                    fs::remove_file(path)?;
+                    return temp.persist(path).map(|_| ()).map_err(|error| error.error);
+                }
+                return Err(error.error);
+            }
+            #[cfg(not(windows))]
+            {
+                Err(error.error)
+            }
+        }
+    }
+}
+
+fn absolute_path(current_dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        current_dir.join(path)
+    }
+}
+
+fn resolve_user_path(raw: &str, current_dir: &Path, home_dir: &Path) -> PathBuf {
+    if raw == "~" {
+        return home_dir.to_path_buf();
+    }
+    if let Some(rest) = raw.strip_prefix("~/").or_else(|| raw.strip_prefix("~\\")) {
+        return home_dir.join(rest);
+    }
+    absolute_path(current_dir, Path::new(raw))
+}
+
+fn launch_command(executable: &Path, work_dir: &Path, config_path: &Path) -> String {
+    format!(
+        "{} --work-dir {} --config {}",
+        quote_shell_arg(&executable.to_string_lossy()),
+        quote_shell_arg(&work_dir.to_string_lossy()),
+        quote_shell_arg(&config_path.to_string_lossy())
+    )
+}
+
+#[cfg(not(windows))]
+fn quote_shell_arg(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(windows)]
+fn quote_shell_arg(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\\\""))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+    use std::io::Cursor;
+
+    use clap::Parser;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::config::{Cli, CliCommand};
+
+    const TUNNEL_ID: &str = "tunnel_0123456789abcdef0123456789abcdef";
+    const RUNTIME_KEY: &str = "sk-runtime-test-key_123";
+
+    fn environment(root: &TempDir, work_dir: &Path) -> QuickstartEnvironment {
+        let home_dir = root.path().join("home");
+        fs::create_dir_all(&home_dir).unwrap();
+        QuickstartEnvironment {
+            current_dir: work_dir.to_path_buf(),
+            home_dir,
+            executable: root.path().join("bin").join("codex-free"),
+        }
+    }
+
+    fn args(config: PathBuf, work_dir: &Path) -> QuickstartArgs {
+        QuickstartArgs {
+            config,
+            work_dir: Some(work_dir.to_path_buf()),
+        }
+    }
+
+    fn run_test_wizard(
+        args: QuickstartArgs,
+        environment: QuickstartEnvironment,
+        input: &str,
+        secrets: &[&str],
+    ) -> (anyhow::Result<QuickstartOutcome>, String) {
+        let mut input = Cursor::new(input.as_bytes());
+        let mut output = Vec::new();
+        let mut secrets: VecDeque<String> = secrets.iter().map(|value| value.to_string()).collect();
+        let result = run_with_io(
+            args,
+            environment,
+            &mut input,
+            &mut output,
+            |label, output| {
+                write!(output, "{label}: ")?;
+                output.flush()?;
+                secrets.pop_front().ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::UnexpectedEof, "no test secret remains")
+                })
+            },
+        );
+        (result, String::from_utf8(output).unwrap())
+    }
+
+    #[test]
+    fn cli_exposes_quickstart_without_weakening_server_requirements() {
+        let cli = Cli::try_parse_from(["codex-free", "quickstart"]).unwrap();
+        assert!(matches!(cli.command, Some(CliCommand::Quickstart(_))));
+        assert!(cli.work_dir.is_none());
+
+        let error = Cli::try_parse_from(["codex-free"]).unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[test]
+    fn new_install_writes_a_private_key_and_a_secret_free_config() {
+        let root = TempDir::new().unwrap();
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        let config_path = project.join("codex.config.json");
+        let environment = environment(&root, &project);
+        let home_dir = environment.home_dir.clone();
+        let input = format!("\n\n\n\n{TUNNEL_ID}\nn\n");
+
+        let (result, output) = run_test_wizard(
+            args(config_path.clone(), &project),
+            environment,
+            &input,
+            &[RUNTIME_KEY],
+        );
+        let outcome = result.unwrap();
+        assert!(!outcome.start_server);
+        assert_eq!(outcome.work_dir, fs::canonicalize(&project).unwrap());
+        assert_eq!(outcome.config_path, config_path);
+
+        let key_path = credential_path(&home_dir, TUNNEL_ID);
+        assert_eq!(fs::read_to_string(&key_path).unwrap().trim(), RUNTIME_KEY);
+        let config: Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        assert_eq!(config["multiProject"], json!(false));
+        assert_eq!(config["openaiTunnel"]["tunnelId"], json!(TUNNEL_ID));
+        assert_eq!(
+            config["openaiTunnel"]["apiKeyRef"],
+            json!(format!("file:{}", key_path.display()))
+        );
+        assert!(
+            !fs::read_to_string(&config_path)
+                .unwrap()
+                .contains(RUNTIME_KEY)
+        );
+
+        assert!(output.contains(TUNNEL_SETTINGS_URL));
+        assert!(output.contains(API_KEYS_URL));
+        assert!(output.contains(DEVELOPER_MODE_GUIDE_URL));
+        assert!(output.contains(CHATGPT_PLUGINS_URL));
+        assert!(output.contains("Connection: Tunnel"));
+        assert!(output.contains("Authentication: No Authentication"));
+        assert!(output.contains(TUNNEL_ID));
+        assert!(!output.contains(RUNTIME_KEY));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&key_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+            assert_eq!(
+                fs::metadata(key_path.parent().unwrap())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o700
+            );
+        }
+    }
+
+    #[test]
+    fn rerun_preserves_unrelated_config_and_can_keep_the_stored_key() {
+        let root = TempDir::new().unwrap();
+        let project = root.path().join("projects");
+        fs::create_dir_all(&project).unwrap();
+        let config_path = project.join("custom.json");
+        fs::write(
+            &config_path,
+            serde_json::to_vec_pretty(&json!({
+                "apiKey": "legacy-local-token",
+                "multiProject": true,
+                "allowedCommands": ["git"],
+                "openaiTunnel": {
+                    "tunnelId": TUNNEL_ID,
+                    "apiKeyRef": "env:OLD_KEY",
+                    "organizationId": "org_example"
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let environment = environment(&root, &project);
+        let key_path = credential_path(&environment.home_dir, TUNNEL_ID);
+        write_private_key(&key_path, RUNTIME_KEY.as_bytes()).unwrap();
+
+        let (result, output) = run_test_wizard(
+            args(config_path.clone(), &project),
+            environment,
+            "\n\n\n\n\n\nn\n",
+            &[""],
+        );
+        let outcome = result.unwrap();
+        assert!(!outcome.start_server);
+        assert!(output.contains("valid stored runtime key already exists"));
+        assert_eq!(fs::read_to_string(&key_path).unwrap().trim(), RUNTIME_KEY);
+
+        let config: Value =
+            serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+        assert!(config.get("apiKey").is_none());
+        assert_eq!(config["multiProject"], json!(true));
+        assert_eq!(config["allowedCommands"], json!(["git"]));
+        assert_eq!(
+            config["openaiTunnel"]["organizationId"],
+            json!("org_example")
+        );
+        assert_eq!(
+            config["openaiTunnel"]["apiKeyRef"],
+            json!(format!("file:{}", key_path.display()))
+        );
+    }
+
+    #[test]
+    fn invalid_tunnel_ids_and_keys_are_reprompted_without_echoing_secrets() {
+        let root = TempDir::new().unwrap();
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        let config_path = project.join("codex.config.json");
+        let environment = environment(&root, &project);
+        let input = format!("\nn\n\n\ninvalid-tunnel\n{TUNNEL_ID}\nn\n");
+        let invalid_key = "not a valid key!";
+
+        let (result, output) = run_test_wizard(
+            args(config_path, &project),
+            environment,
+            &input,
+            &[invalid_key, RUNTIME_KEY],
+        );
+        result.unwrap();
+        assert!(output.contains("tunnel_ followed by 32 lowercase letters or digits"));
+        assert!(output.contains("OpenAI tunnel API key is malformed"));
+        assert!(!output.contains(invalid_key));
+        assert!(!output.contains(RUNTIME_KEY));
+    }
+
+    #[test]
+    fn malformed_existing_tunnel_config_fails_before_writing_credentials() {
+        let root = TempDir::new().unwrap();
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        let config_path = project.join("codex.config.json");
+        fs::write(&config_path, r#"{"openaiTunnel":"invalid"}"#).unwrap();
+        let environment = environment(&root, &project);
+        let credentials = environment.home_dir.join(".codex-free");
+
+        let (result, _) =
+            run_test_wizard(args(config_path.clone(), &project), environment, "", &[]);
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("openaiTunnel in the existing config must be a JSON object"));
+        assert_eq!(
+            fs::read_to_string(config_path).unwrap(),
+            r#"{"openaiTunnel":"invalid"}"#
+        );
+        assert!(!credentials.exists());
+    }
+
+    #[test]
+    fn tilde_paths_resolve_against_the_injected_home_directory() {
+        let root = TempDir::new().unwrap();
+        let home = root.path().join("home");
+        let project = home.join("src").join("project");
+        fs::create_dir_all(&project).unwrap();
+        assert_eq!(
+            resolve_user_path("~/src/project", root.path(), &home),
+            project
+        );
+    }
+}


### PR DESCRIPTION
## Overview

This PR adds an interactive `codex-free quickstart` command for first-time installation and connector setup.

The wizard guides a user from an unconfigured binary to a running native OpenAI Secure MCP Tunnel and a ChatGPT developer-mode connector. Existing server startup remains unchanged: `--work-dir` is still required when launching the server directly, and `quickstart` is an explicit subcommand.

## Guided setup flow

`codex-free quickstart` walks through:

1. selecting the project directory ChatGPT may access;
2. choosing single-project or multi-project mode;
3. choosing a ChatGPT connector name;
4. opening the OpenAI tunnel settings page, creating a tunnel, and copying its `tunnel_...` identifier;
5. creating and entering a runtime API key with terminal echo disabled;
6. writing or updating `codex.config.json`;
7. enabling ChatGPT developer mode and creating the connector from the Plugins page;
8. selecting `Tunnel`, choosing the configured tunnel ID, and using `No Authentication` for the ChatGPT-to-tunnel connection;
9. optionally starting the ordinary supervised Codex Free server immediately so ChatGPT can scan the live connector.

The terminal output includes direct OpenAI and ChatGPT links, the suggested connector name and description, the exact tunnel value, the required connection and authentication selections, and workspace-specific developer-mode guidance. The suggested connector description deliberately avoids embedding the user's local filesystem path.

## Configuration and credential handling

The wizard validates the tunnel ID and runtime key with the same validation used by normal native-tunnel startup.

Runtime keys are not written into the JSON configuration. Each key is stored under:

```text
~/.codex-free/openai-tunnel/credentials/<tunnel-id>.key
```

The config receives an absolute `file:` reference. On Unix, the credential directory is restricted to mode `0700` and the key file to `0600`.

The hidden-input prompt is published only after the controlling terminal reports that echo has been disabled. This closes the prompt/paste race where a user or password manager could paste immediately after seeing the prompt while the terminal was still echoing. The probe watches `/dev/tty` on Unix and `CONIN$` on Windows, matching the devices used by `rpassword`.

When updating an existing config, the wizard:

- preserves unrelated top-level and `openaiTunnel` fields;
- updates only the managed tunnel ID, key reference, and `multiProject` fields;
- detects the incompatible legacy `apiKey` field and asks before removing it;
- permits reusing an already-valid stored runtime key without displaying it;
- rejects a symlinked config before requesting or writing credentials;
- writes config and credential replacements through temporary files in the destination directory.

Malformed or symlinked existing configuration fails before credentials or config are modified.

## CLI integration

The CLI distinguishes server startup from subcommands:

```text
codex-free --work-dir <DIR> [server options]
codex-free quickstart [--config <PATH>] [--work-dir <DIR>]
```

When the user chooses to start the server, the same process feeds the selected directory and generated config back through the normal `load_config` and supervised server lifecycle. There is no separate quickstart server implementation.

## Documentation

The README documents the recommended interactive flow, manual setup remains available, and the CLI/configuration sections describe credential storage and command options. The changelog and architecture documentation cover the onboarding path.

## Validation

- `cargo test --all-targets --all-features` — 400 passed
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- macOS PTY immediate-paste stress test — 100/100 runs completed without the runtime key appearing in captured terminal output or JSON
- isolated `x86_64-pc-windows-gnu` compile of the Windows console-echo probe

Focused regression coverage verifies:

- the `quickstart` subcommand does not weaken direct server argument requirements;
- new-install config generation and secret-free JSON;
- publication of the secret prompt only after echo is disabled;
- hidden key input and non-echoing validation failures;
- Unix credential permissions;
- preservation of unrelated existing configuration;
- removal of incompatible legacy `apiKey` only after confirmation;
- reuse of an existing valid key;
- repeated prompting for malformed tunnel IDs and runtime keys;
- fail-before-write behavior for malformed and symlinked configuration;
- `~` expansion against the user home directory.
