### PR TITLE
feat: discover plugin MCP servers through the Codex CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Optional Codex CLI enrichment for MCP discovery. By default Codex Free uses
+  `codex mcp list/get --json` when the executable is available, adding MCP
+  servers contributed by enabled Codex plugins while retaining direct
+  `config.toml` parsing as the standalone fallback. Missing or incompatible CLI
+  discovery warns in automatic mode; `--codex-cli` makes it a startup error.
+  `codexMcp.useCli` disables enrichment and `codexMcp.cliPath` selects an
+  explicit executable.
+
 ## [1.2.0] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ flowchart LR
     Bindings[("~/.codex-free\nconversation-projects")]
     SkillDirs[(".agents/skills\n.codex/skills\n.claude/skills")]
     CodexCfg[("$CODEX_HOME\nconfig.toml")]
+    CodexCli["optional Codex CLI\nmcp list/get --json"]
     Upstream[("Upstream MCP\nservers (stdio)")]
 
     ChatGPT <-->|"connector calls"| OpenAITunnel
@@ -68,11 +69,12 @@ flowchart LR
     Skills --> SkillDirs
     SetRoot --> Bindings
     SetRoot -.->|"selects"| WorkDir
-    CodexCfg -.->|"auto-import"| Bridge
+    CodexCfg -.->|"direct fallback"| Bridge
+    CodexCli -.->|"plugin/effective MCPs"| Bridge
     Bridge --> Upstream
 ```
 
-Dotted edges are conditional: `set_project_root` appears only in [multi-project mode](#multi-project-mode) and binds this conversation's project root, and the aggregator [auto-imports](#automatic-discovery-from-codex) the stdio MCP servers configured in Codex's own `config.toml` on top of any declared in `codex.config.json`.
+Dotted edges are conditional: `set_project_root` appears only in [multi-project mode](#multi-project-mode) and binds this conversation's project root. The aggregator [auto-imports](#automatic-discovery-from-codex) user-configured servers directly from Codex's `config.toml`, then uses the Codex CLI when available to add plugin-provided servers before applying any `codex.config.json` overlays.
 
 ## Quick start
 
@@ -138,6 +140,7 @@ Each release ships a compiled binary per platform — `windows-x64`, `linux-x64`
 | `--port` | No | `3000` | Server port |
 | `--api-key` | No | - | Bearer token for auth |
 | `--config` | No | `./codex.config.json` | Config file path (tolerated if missing) |
+| `--codex-cli` | No | Auto when available | Require successful Codex CLI-backed MCP discovery. When omitted, failure produces a warning and direct `config.toml` parsing remains the fallback |
 | `--openai-tunnel-id` | No | - | Existing OpenAI Secure MCP Tunnel ID; enables native tunnel mode |
 | `--openai-tunnel-api-key-ref` | No | `env:CONTROL_PLANE_API_KEY` | Runtime key reference in `env:NAME` or `file:/path` form |
 | `--openai-tunnel-client` | No | managed pinned runtime | Explicit `tunnel-client` or `tunnel-client-runtime` binary |
@@ -258,7 +261,8 @@ All project-scoped paths are resolved relative to the active project root: `--wo
     "includePlugins": true
   },
   "codexMcp": {
-    "enabled": true
+    "enabled": true,
+    "useCli": true
   },
   "openaiTunnel": {
     "tunnelId": "tunnel_0123456789abcdef0123456789abcdef",
@@ -344,7 +348,9 @@ The `codexMcp` block controls [automatic import of MCP servers configured in Cod
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `enabled` | `true` | Read the user-level Codex `config.toml` and merge its MCP servers into `mcpServers`; `false` disables all Codex-config discovery |
+| `enabled` | `true` | Import Codex MCP servers; `false` disables direct config and CLI discovery unless the explicit `--codex-cli` requirement overrides it |
+| `useCli` | `true` | Enrich direct config parsing with `codex mcp list/get --json`, which includes MCP servers contributed by enabled Codex plugins. `false` keeps direct `config.toml` parsing but does not invoke Codex |
+| `cliPath` | `CODEX_CLI_PATH`, then `codex` on `PATH` | Codex executable used for CLI enrichment. Relative paths resolve from the directory where Codex Free was launched |
 
 The `openaiTunnel` block, `allowedHosts` array, and `mcpServers` map are covered under [Native OpenAI tunnel](#native-openai-tunnel-recommended), [Host allowlist](#host-allowlist), and [Bridging other MCP servers](#bridging-other-mcp-servers).
 
@@ -519,7 +525,7 @@ Codex Free can also act as an **MCP aggregator**: it connects to your other loca
 
 ### Automatic discovery from Codex
 
-By default, Codex Free imports the MCP servers from Codex's user-level configuration: `$CODEX_HOME/config.toml` when `CODEX_HOME` is set, otherwise `~/.codex/config.toml`. The file is read only; Codex Free never rewrites it. This initial implementation intentionally does not reproduce Codex's project-local configuration layers or trust decisions.
+Codex Free always has a standalone fallback: it reads `$CODEX_HOME/config.toml` when `CODEX_HOME` is set, otherwise `~/.codex/config.toml`. The file is read only; Codex Free never rewrites it. This direct parser imports user-configured MCP servers without requiring a `codex` executable.
 
 For each `[mcp_servers.<name>]` entry, Codex Free imports the fields it can preserve:
 
@@ -528,7 +534,11 @@ For each `[mcp_servers.<name>]` entry, Codex Free imports the fields it can pres
 - `enabled = false` as a disabled upstream;
 - `enabled_tools` as an allow-list and `disabled_tools` as a deny-list applied afterwards.
 
-Streamable-HTTP entries (`url`) and non-local execution environments are skipped because the bridge currently supports only local stdio children. Other Codex-only fields are ignored explicitly: the startup report names those fields, but never prints environment values or other configuration values. A missing or unreadable Codex config does not prevent servers declared directly in `codex.config.json` from loading.
+By default, Codex Free also tries `codex mcp list --json`. Servers present in Codex's effective catalogue but absent from `config.toml` are fetched with `codex mcp get <name> --json` so plugin-provided enablement and tool allow/deny lists are preserved. The executable is selected from `codexMcp.cliPath`, then `CODEX_CLI_PATH`, then `codex` on `PATH`. Each invocation is bounded to 30 seconds and 4 MiB of stdout, and its JSON is parsed in memory without logging literal environment values.
+
+When the CLI is missing, fails, times out, or returns incompatible JSON, normal startup continues with the direct `config.toml` result and prints a warning that plugin-provided MCP servers may be missing. Pass `--codex-cli` to make successful CLI discovery mandatory instead; the same condition then becomes a startup error. Set `"codexMcp": { "useCli": false }` to suppress CLI invocation while retaining direct config parsing.
+
+Streamable-HTTP entries (`url`) and non-local execution environments are skipped because the bridge currently supports only local stdio children. Other Codex-only fields are ignored explicitly: the startup report names those fields, but never prints environment values or other configuration values. A missing or unreadable Codex config does not prevent CLI-discovered or explicitly declared `codex.config.json` servers from loading.
 
 Disable discovery while retaining explicit upstreams with:
 
@@ -536,6 +546,14 @@ Disable discovery while retaining explicit upstreams with:
 {
   "codexMcp": { "enabled": false },
   "mcpServers": {}
+}
+```
+
+To keep direct Codex config import but never start the Codex CLI:
+
+```json
+{
+  "codexMcp": { "enabled": true, "useCli": false }
 }
 ```
 
@@ -573,8 +591,11 @@ Set an empty array or object to replace an imported collection with an empty one
 At startup you'll see, e.g.:
 
 ```
-Codex MCP discovery: /home/user/.codex/config.toml
-  idasql -> imported from Codex
+Codex MCP config discovery: /home/user/.codex/config.toml
+  idasql -> imported from Codex config
+Codex CLI MCP discovery: codex
+  idalib -> imported from Codex CLI (not present in config.toml)
+Codex MCP overrides:
   remote-exec -> imported fields overlaid by codex.config.json
 bridged MCP server 'idasql': 12 tool(s)
 Tools loaded (37): 25 native + 12 bridged from upstream MCP servers
@@ -649,7 +670,7 @@ Native tunnel mode ignores `allowedHosts` and forces the accepted authorities to
 - **Bounded state writes outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/projects/`. Multi-project mode also writes one small project-binding record under `~/.codex-free/conversation-projects/` for each ChatGPT conversation and access root. Both use atomic replacement and per-record locks. The binding filename is derived from a hash of `openai/session`; the raw identifier is not stored. Set `memory.enabled` to `false` to disable plans and notes; delete `~/.codex-free/conversation-projects/` separately to forget conversation bindings. See [Context and memory](#context-and-memory).
 - **Bounded reads outside the work directory**: [skills](#skills) may live in `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` or an installed Claude Code plugin. `skills_read` opens files there, but only inside a skill package that already exists — the `resource` path is checked against the skill's own directory, so it cannot walk out into the rest of your home directory. `skills_list` reports the absolute path of every skill it found. Set `skills.enabled` to `false` to switch it off, or `skills.dirs` to point the user scope somewhere you choose.
 - **Command allowlist**: `run_command` only runs binaries listed in `allowedCommands`; everything else is rejected. `exec_command` checks the same list plus `exec.extraAllowedCommands`, at every command position in the string.
-- **Bridged servers run with your privileges**: an explicit `mcpServers` entry or an automatically imported Codex MCP launches a real process on your machine and forwards the model's calls to it verbatim. Only bridge servers you trust, prefer `tools`/`disabledTools` filters or `gateway` mode to keep the exposed surface small, and set `codexMcp.enabled` to `false` when Codex contains servers that should not be exposed through ChatGPT. A bad `command` path is reported, never silently ignored.
+- **Bridged servers run with your privileges**: an explicit `mcpServers` entry or an automatically imported Codex MCP—including one contributed by a Codex plugin—launches a real process on your machine and forwards the model's calls to it verbatim. Only bridge servers you trust, prefer `tools`/`disabledTools` filters or `gateway` mode to keep the exposed surface small, set `codexMcp.useCli` to `false` to exclude plugin-only discovery, or set `codexMcp.enabled` to `false` to disable all automatic Codex import. A bad `command` path is reported, never silently ignored.
 - **Native OpenAI tunnel is outbound-only**: Codex Free binds its MCP listener to loopback and supervises OpenAI's official runtime-only tunnel client. Startup fails unless the runtime reports `/readyz` and completes a control-plane poll. Failure of either process stops the other, and HTTP shutdown has a bounded grace period before remaining connections are aborted.
 - **The loopback MCP hop is authenticated**: native mode generates a random per-process bearer token and configures the tunnel runtime to send it on MCP requests and discovery probes. The token is never printed, written to the config file, or inherited by model-launched commands and bridged MCP children.
 - **Verified tunnel-client installation**: the managed client is pinned to a specific official release and per-platform archive SHA-256 embedded in Codex Free, extracted by exact filename under size limits, installed atomically with private permissions, and hash-checked against its installation manifest on subsequent starts. Set `clientPath` to opt out of managed installation while retaining compatibility checks.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -142,8 +142,9 @@ intentionally not persisted across reconnects.
 ### `AppConfig` (`types.rs`)
 The fully-resolved config handed to every tool. `config.rs` parses
 `codex.config.json` with camelCase field names for backward compatibility, imports
-user-level Codex MCP definitions through `codex_mcp.rs`, then applies explicit
-`mcpServers` entries as field overlays. Optional sub-configs (`projectDoc`,
+user-level Codex MCP definitions through `codex_mcp.rs`, opportunistically adds
+plugin-provided entries from the Codex CLI's effective catalogue, then applies
+explicit `mcpServers` entries as field overlays. Optional sub-configs (`projectDoc`,
 `output`, `memory`, `skills`, `ignore`) fall back to per-module defaults. In
 multi-project mode, dispatch clones this config per call and substitutes the
 conversation's selected root—or the transport fallback—for `work_dir`; the static
@@ -246,7 +247,7 @@ the original order and rejects duplicate names.
 | `process_env.rs` | Child-process environment boundaries: isolate the tunnel runtime and remove tunnel credentials from model-controlled and upstream subprocesses. |
 | `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. Multi-project mode treats the selected directory as the exact project root and never walks into the common access-root parent. |
 | `skills.rs` | `SKILL.md` discovery (see §8). |
-| `codex_mcp.rs` | Read-only import of local stdio MCP definitions from `$CODEX_HOME/config.toml` or `~/.codex/config.toml`, with secret-safe diagnostics. |
+| `codex_mcp.rs` | Read-only import of local stdio MCP definitions from `$CODEX_HOME/config.toml` or `~/.codex/config.toml`, plus bounded `codex mcp list/get --json` enrichment for plugin-provided servers, with secret-safe diagnostics. |
 | `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc. Multi-project initialization emits a project-neutral selector brief because conversation metadata is available only on subsequent tool calls; `get_agent_brief` builds the full brief after restoring or creating a binding. |
 | `environment.rs` | OS / shell / policy description, shared by `get_environment` and the instructions. |
 
@@ -260,9 +261,16 @@ tools at startup, and re-expose them. Implemented in `bridge.rs`; wired in
 
 ### Discovery
 Before bridging, `config.rs` imports compatible `[mcp_servers.<name>]` entries
-from Codex's user-level config. Explicit `codex.config.json.mcpServers` fields
-overlay imports with the same name; `codexMcp.enabled = false` disables the
-import. HTTP and non-local Codex entries are reported and skipped.
+from Codex's user-level config. Unless `codexMcp.useCli = false`, it then runs
+`codex mcp list --json` and fetches each additional server with `codex mcp get`
+so plugin-provided enablement and tool filters are preserved. `CODEX_CLI_PATH`
+or `codexMcp.cliPath` selects the executable; otherwise `codex` is resolved from
+`PATH`. Missing or incompatible CLI discovery is a warning in the default auto
+mode and a startup error when `--codex-cli` is supplied. Explicit
+`codex.config.json.mcpServers` fields overlay the combined imports with the same
+name; `codexMcp.enabled = false` disables automatic Codex import unless
+`--codex-cli` explicitly requires it. HTTP and non-local entries are reported
+and skipped.
 
 For each resulting server entry (sorted, non-disabled), `connect_one`:
 1. Launches the `command` as a stdio child process (`TokioChildProcess`).

--- a/src/codex_mcp.rs
+++ b/src/codex_mcp.rs
@@ -1,16 +1,337 @@
-//! Import user-level MCP server definitions from Codex's `config.toml`.
+//! Import user-level MCP servers from Codex's `config.toml`, with optional CLI
+//! enrichment for plugin-provided entries in Codex's effective catalogue.
 
 use std::collections::{BTreeSet, HashMap};
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
 
 use crate::types::McpServerSpec;
 use crate::util::home_dir;
+
+const CODEX_CLI_TIMEOUT: Duration = Duration::from_secs(30);
+const CODEX_CLI_MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
 
 #[derive(Debug, Default)]
 pub struct CodexMcpImport {
     pub servers: HashMap<String, McpServerSpec>,
     pub report: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexCliListEntry {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexCliServer {
+    name: String,
+    #[serde(default = "default_true")]
+    enabled: bool,
+    transport: CodexCliTransport,
+    #[serde(default)]
+    enabled_tools: Option<Vec<String>>,
+    #[serde(default)]
+    disabled_tools: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexCliTransport {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    args: Option<Vec<String>>,
+    #[serde(default)]
+    env: Option<HashMap<String, String>>,
+    #[serde(default)]
+    env_vars: Option<Vec<CodexCliEnvVar>>,
+    #[serde(default)]
+    cwd: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CodexCliEnvVar {
+    Name(String),
+    Config {
+        name: String,
+        #[serde(default)]
+        source: Option<String>,
+    },
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn run_codex_command(
+    command: &OsStr,
+    cwd: Option<&Path>,
+    args: &[OsString],
+) -> Result<Vec<u8>, String> {
+    let mut process = Command::new(command);
+    process
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    if let Some(cwd) = cwd.filter(|path| path.is_dir()) {
+        process.current_dir(cwd);
+    }
+
+    let mut child = process.spawn().map_err(|error| {
+        let executable = Path::new(command).display();
+        if error.kind() == std::io::ErrorKind::NotFound {
+            format!("Codex CLI executable `{executable}` was not found")
+        } else {
+            format!("failed to start Codex CLI executable `{executable}`: {error}")
+        }
+    })?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "failed to capture Codex CLI stdout".to_string())?;
+    let (stdout_tx, stdout_rx) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        let mut chunk = [0_u8; 8192];
+        let mut exceeded = false;
+        let result = (|| {
+            loop {
+                let read = stdout.read(&mut chunk)?;
+                if read == 0 {
+                    break;
+                }
+                let remaining = CODEX_CLI_MAX_OUTPUT_BYTES.saturating_sub(output.len());
+                if remaining > 0 {
+                    output.extend_from_slice(&chunk[..read.min(remaining)]);
+                }
+                exceeded |= read > remaining;
+            }
+            Ok::<_, std::io::Error>((output, exceeded))
+        })();
+        let _ = stdout_tx.send(result);
+    });
+
+    let started = Instant::now();
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if started.elapsed() < CODEX_CLI_TIMEOUT => {
+                thread::sleep(Duration::from_millis(25));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "Codex CLI timed out after {} seconds",
+                    CODEX_CLI_TIMEOUT.as_secs()
+                ));
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!("failed while waiting for Codex CLI: {error}"));
+            }
+        }
+    };
+    let remaining = CODEX_CLI_TIMEOUT.saturating_sub(started.elapsed());
+    let stdout_result = stdout_rx
+        .recv_timeout(remaining)
+        .map_err(|error| match error {
+            mpsc::RecvTimeoutError::Timeout => {
+                "Codex CLI stdout did not close before the discovery timeout".to_string()
+            }
+            mpsc::RecvTimeoutError::Disconnected => {
+                "Codex CLI stdout reader stopped unexpectedly".to_string()
+            }
+        })?;
+    let (stdout, output_exceeded) =
+        stdout_result.map_err(|error| format!("failed to read Codex CLI stdout: {error}"))?;
+    if output_exceeded {
+        return Err(format!(
+            "Codex CLI output exceeded {} bytes",
+            CODEX_CLI_MAX_OUTPUT_BYTES
+        ));
+    }
+
+    if !status.success() {
+        let operation = args
+            .iter()
+            .take(2)
+            .map(|arg| arg.to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(" ");
+        return Err(format!(
+            "Codex CLI exited with status {} while running `{operation}`",
+            status
+        ));
+    }
+    Ok(stdout)
+}
+
+pub fn discover_additional_codex_mcp_servers_with_cli(
+    command: &OsStr,
+    cwd: Option<&Path>,
+    existing: &HashMap<String, McpServerSpec>,
+) -> Result<CodexMcpImport, String> {
+    let mut runner = |args: &[OsString]| run_codex_command(command, cwd, args);
+    discover_additional_codex_mcp_servers_with_runner(
+        existing,
+        &|name| std::env::var(name).ok(),
+        &mut runner,
+    )
+}
+
+fn discover_additional_codex_mcp_servers_with_runner<F>(
+    existing: &HashMap<String, McpServerSpec>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+    runner: &mut F,
+) -> Result<CodexMcpImport, String>
+where
+    F: FnMut(&[OsString]) -> Result<Vec<u8>, String>,
+{
+    let list_args = ["mcp", "list", "--json"].map(OsString::from);
+    let list_output = runner(&list_args)?;
+    let mut entries: Vec<CodexCliListEntry> =
+        serde_json::from_slice(&list_output).map_err(|error| {
+            format!("Codex CLI returned invalid JSON for `mcp list --json`: {error}")
+        })?;
+    entries.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let mut outcome = CodexMcpImport::default();
+    let mut seen = BTreeSet::new();
+    for entry in entries {
+        let name = entry.name;
+        if name.trim().is_empty() {
+            outcome
+                .report
+                .push("<unnamed> -> skipped: Codex CLI returned an empty server name".to_string());
+            continue;
+        }
+        if !seen.insert(name.clone()) {
+            outcome.report.push(format!(
+                "{name} -> skipped: Codex CLI returned the name more than once"
+            ));
+            continue;
+        }
+        if existing.contains_key(&name) {
+            continue;
+        }
+
+        let get_args = [
+            OsString::from("mcp"),
+            OsString::from("get"),
+            OsString::from("--json"),
+            OsString::from("--"),
+            OsString::from(&name),
+        ];
+        let get_output = match runner(&get_args) {
+            Ok(output) => output,
+            Err(error) => {
+                outcome.report.push(format!(
+                    "{name} -> skipped: Codex CLI could not return the full server configuration ({error})"
+                ));
+                continue;
+            }
+        };
+        let server: CodexCliServer = match serde_json::from_slice(&get_output) {
+            Ok(server) => server,
+            Err(error) => {
+                outcome.report.push(format!(
+                    "{name} -> skipped: Codex CLI returned invalid JSON for `mcp get` ({error})"
+                ));
+                continue;
+            }
+        };
+        if server.name != name {
+            outcome.report.push(format!(
+                "{name} -> skipped: Codex CLI returned configuration for a different server"
+            ));
+            continue;
+        }
+
+        match codex_cli_server_to_spec(server, env_lookup) {
+            Ok(spec) => {
+                let suffix = if spec.disabled { " (disabled)" } else { "" };
+                outcome.servers.insert(name.clone(), spec);
+                outcome.report.push(format!(
+                    "{name} -> imported from Codex CLI{suffix} (not present in config.toml)"
+                ));
+            }
+            Err(reason) => outcome.report.push(format!("{name} -> skipped: {reason}")),
+        }
+    }
+
+    Ok(outcome)
+}
+
+fn codex_cli_server_to_spec(
+    server: CodexCliServer,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> Result<McpServerSpec, String> {
+    let kind = server.transport.kind.to_ascii_lowercase();
+    if matches!(
+        kind.as_str(),
+        "http" | "sse" | "streamable-http" | "streamable_http" | "websocket" | "ws"
+    ) {
+        return Err("streamable HTTP transport is not supported yet".to_string());
+    }
+    if kind != "stdio" {
+        return Err(format!("unsupported transport type `{kind}`"));
+    }
+
+    let Some(command) = server
+        .transport
+        .command
+        .filter(|command| !command.trim().is_empty())
+    else {
+        return Err("no non-empty stdio `command` is configured".to_string());
+    };
+
+    let mut env = server.transport.env.unwrap_or_default();
+    for env_var in server.transport.env_vars.unwrap_or_default() {
+        let (name, source) = match env_var {
+            CodexCliEnvVar::Name(name) => (name, None),
+            CodexCliEnvVar::Config { name, source } => (name, source),
+        };
+        match source.as_deref() {
+            None | Some("local") => {
+                if !env.contains_key(&name)
+                    && let Some(value) = env_lookup(&name)
+                {
+                    env.insert(name, value);
+                }
+            }
+            Some("remote") => {
+                return Err("remote-sourced `env_vars` are not supported".to_string());
+            }
+            Some(_) => {
+                return Err("`env_vars.source` must be `local` or `remote`".to_string());
+            }
+        }
+    }
+
+    Ok(McpServerSpec {
+        command: Some(command),
+        args: server.transport.args.unwrap_or_default(),
+        env,
+        cwd: server.transport.cwd,
+        disabled: !server.enabled,
+        transport: None,
+        url: None,
+        tools: server.enabled_tools,
+        disabled_tools: server.disabled_tools,
+        mode: None,
+    })
 }
 
 pub fn codex_config_path() -> Result<PathBuf, String> {
@@ -97,9 +418,9 @@ fn parse_codex_mcp_servers(
                 ignored_fields,
             }) => {
                 let mut line = if spec.disabled {
-                    format!("{name} -> imported from Codex (disabled)")
+                    format!("{name} -> imported from Codex config (disabled)")
                 } else {
-                    format!("{name} -> imported from Codex")
+                    format!("{name} -> imported from Codex config")
                 };
                 if !ignored_fields.is_empty() {
                     line.push_str("; unsupported fields ignored: ");
@@ -455,6 +776,114 @@ command = "good-server"
         let contents = format!("[mcp_servers.demo]\ncommand = \\\"{secret}");
         let error = parse_codex_mcp_servers(&contents, &|_| None).unwrap_err();
         assert!(!error.contains(secret));
+    }
+
+    #[test]
+    fn cli_adds_servers_missing_from_config_with_complete_tool_policy() {
+        let existing = HashMap::from([("global".to_string(), McpServerSpec::default())]);
+        let list = br#"[
+            {"name":"global"},
+            {"name":"plugin"}
+        ]"#;
+        let get = br#"{
+            "name":"plugin",
+            "enabled":true,
+            "transport":{
+                "type":"stdio",
+                "command":"uv",
+                "args":["run","plugin-mcp"],
+                "env":null,
+                "env_vars":["TOKEN",{"name":"SECOND_TOKEN","source":"local"}],
+                "cwd":"/plugins/example"
+            },
+            "enabled_tools":["read","write"],
+            "disabled_tools":["write"]
+        }"#;
+        let mut calls = 0;
+        let outcome = {
+            let mut runner = |args: &[OsString]| {
+                calls += 1;
+                match args.get(1).and_then(|value| value.to_str()) {
+                    Some("list") => Ok(list.to_vec()),
+                    Some("get") => Ok(get.to_vec()),
+                    other => panic!("unexpected Codex CLI operation: {other:?}"),
+                }
+            };
+
+            discover_additional_codex_mcp_servers_with_runner(
+                &existing,
+                &|name| match name {
+                    "TOKEN" => Some("secret-one".to_string()),
+                    "SECOND_TOKEN" => Some("secret-two".to_string()),
+                    _ => None,
+                },
+                &mut runner,
+            )
+            .unwrap()
+        };
+
+        assert_eq!(
+            calls, 2,
+            "the existing config server must not trigger mcp get"
+        );
+        assert!(!outcome.servers.contains_key("global"));
+        let plugin = outcome.servers.get("plugin").unwrap();
+        assert_eq!(plugin.command.as_deref(), Some("uv"));
+        assert_eq!(plugin.args, ["run", "plugin-mcp"]);
+        assert_eq!(plugin.cwd.as_deref(), Some("/plugins/example"));
+        assert_eq!(
+            plugin.tools.as_deref(),
+            Some(["read".to_string(), "write".to_string()].as_slice())
+        );
+        assert_eq!(
+            plugin.disabled_tools.as_deref(),
+            Some(["write".to_string()].as_slice())
+        );
+        assert_eq!(
+            plugin.env.get("TOKEN").map(String::as_str),
+            Some("secret-one")
+        );
+        assert_eq!(
+            plugin.env.get("SECOND_TOKEN").map(String::as_str),
+            Some("secret-two")
+        );
+        let report = outcome.report.join("\n");
+        assert!(report.contains("plugin -> imported from Codex CLI"));
+        assert!(!report.contains("secret-one"));
+        assert!(!report.contains("secret-two"));
+    }
+
+    #[test]
+    fn cli_skips_plugin_server_when_full_configuration_cannot_be_read() {
+        let list = br#"[{"name":"plugin"}]"#;
+        let mut runner = |args: &[OsString]| match args.get(1).and_then(|value| value.to_str()) {
+            Some("list") => Ok(list.to_vec()),
+            Some("get") => Err("synthetic get failure".to_string()),
+            other => panic!("unexpected Codex CLI operation: {other:?}"),
+        };
+
+        let outcome = discover_additional_codex_mcp_servers_with_runner(
+            &HashMap::new(),
+            &|_| None,
+            &mut runner,
+        )
+        .unwrap();
+
+        assert!(outcome.servers.is_empty());
+        assert!(outcome.report.join("\n").contains("synthetic get failure"));
+    }
+
+    #[test]
+    fn missing_codex_cli_is_reported_without_requiring_config_parsing() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let missing = temp.path().join("missing-codex-cli");
+        let error = discover_additional_codex_mcp_servers_with_cli(
+            missing.as_os_str(),
+            None,
+            &HashMap::new(),
+        )
+        .unwrap_err();
+        assert!(error.contains("was not found"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@
 //! original camelCase name, absent sections fall back to the same defaults the
 //! TypeScript used, and a missing config file is tolerated.
 
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
@@ -11,7 +12,10 @@ use serde::Deserialize;
 
 use std::collections::HashMap;
 
-use crate::codex_mcp::{codex_config_path, discover_codex_mcp_servers};
+use crate::codex_mcp::{
+    CodexMcpImport, codex_config_path, discover_additional_codex_mcp_servers_with_cli,
+    discover_codex_mcp_servers,
+};
 use crate::types::{
     AppConfig, CommandConfig, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig,
     OpenAiTunnelConfig, OutputConfig, ProjectDocConfig, SkillsConfig, TreeConfig,
@@ -43,6 +47,11 @@ pub struct Cli {
     /// Config file path. Default: ./codex.config.json (tolerated if missing).
     #[arg(long)]
     pub config: Option<String>,
+
+    /// Require Codex CLI-backed MCP discovery. Without this flag, the CLI is
+    /// used automatically when available and config.toml remains the fallback.
+    #[arg(long = "codex-cli")]
+    pub codex_cli: bool,
 
     /// Existing OpenAI Secure MCP Tunnel id. Enables the outbound native tunnel.
     #[arg(long = "openai-tunnel-id")]
@@ -146,11 +155,17 @@ struct PartialOpenAiTunnel {
 #[serde(rename_all = "camelCase")]
 struct CodexMcpConfig {
     enabled: Option<bool>,
+    use_cli: Option<bool>,
+    cli_path: Option<String>,
 }
 
 impl CodexMcpConfig {
     fn enabled(&self) -> bool {
         self.enabled.unwrap_or(true)
+    }
+
+    fn use_cli(&self) -> bool {
+        self.use_cli.unwrap_or(true)
     }
 }
 
@@ -279,45 +294,126 @@ fn merge_mcp_servers(
     (imported, report)
 }
 
-fn resolve_mcp_servers(file: &mut FileConfig) -> HashMap<String, McpServerSpec> {
-    let discovery_enabled = file.codex_mcp.take().unwrap_or_default().enabled();
+fn codex_cli_command(settings: &CodexMcpConfig) -> OsString {
+    let raw = settings
+        .cli_path
+        .as_ref()
+        .filter(|value| !value.trim().is_empty())
+        .map(OsString::from)
+        .or_else(|| std::env::var_os("CODEX_CLI_PATH").filter(|value| !value.is_empty()))
+        .unwrap_or_else(|| OsString::from("codex"));
+    let path = PathBuf::from(&raw);
+    if path.is_absolute() || path.components().count() > 1 {
+        if path.is_absolute() {
+            path.into_os_string()
+        } else {
+            std::env::current_dir()
+                .unwrap_or_default()
+                .join(path)
+                .into_os_string()
+        }
+    } else {
+        raw
+    }
+}
+
+fn print_discovery_report(header: &str, report: &[String]) {
+    if report.is_empty() {
+        return;
+    }
+    println!("{header}");
+    for line in report {
+        println!("  {line}");
+    }
+}
+
+fn resolve_mcp_servers(
+    file: &mut FileConfig,
+    cli: &Cli,
+) -> Result<HashMap<String, McpServerSpec>, String> {
+    resolve_mcp_servers_from(file, cli, codex_config_path(), None)
+}
+
+fn resolve_mcp_servers_from(
+    file: &mut FileConfig,
+    cli: &Cli,
+    config_path_result: Result<PathBuf, String>,
+    command_override: Option<OsString>,
+) -> Result<HashMap<String, McpServerSpec>, String> {
+    let settings = file.codex_mcp.take().unwrap_or_default();
+    let discovery_enabled = cli.codex_cli || settings.enabled();
     let explicit = file.mcp_servers.take().unwrap_or_default();
 
     if !discovery_enabled {
         println!("Codex MCP discovery: disabled by codexMcp.enabled=false");
-        return merge_mcp_servers(HashMap::new(), explicit).0;
+        return Ok(merge_mcp_servers(HashMap::new(), explicit).0);
     }
 
-    let path = match codex_config_path() {
-        Ok(path) => path,
+    let mut imported = CodexMcpImport::default();
+    let config_path = match config_path_result {
+        Ok(path) => Some(path),
         Err(error) => {
-            println!("Codex MCP discovery: skipped ({error})");
-            return merge_mcp_servers(HashMap::new(), explicit).0;
+            println!("Codex MCP config discovery: skipped ({error})");
+            None
         }
     };
 
-    let discovery = match discover_codex_mcp_servers(&path) {
-        Ok(Some(discovery)) => discovery,
-        Ok(None) => return merge_mcp_servers(HashMap::new(), explicit).0,
-        Err(error) => {
-            println!(
-                "Codex MCP discovery: failed for {} ({error})",
-                path.display()
-            );
-            return merge_mcp_servers(HashMap::new(), explicit).0;
+    if let Some(path) = &config_path {
+        match discover_codex_mcp_servers(path) {
+            Ok(Some(discovery)) => imported = discovery,
+            Ok(None) => {}
+            Err(error) => {
+                println!(
+                    "Codex MCP config discovery: failed for {} ({error})",
+                    path.display()
+                );
+            }
         }
-    };
+        print_discovery_report(
+            &format!("Codex MCP config discovery: {}", path.display()),
+            &imported.report,
+        );
+    }
 
-    let (servers, overlay_report) = merge_mcp_servers(discovery.servers, explicit);
-    let mut report = discovery.report;
-    report.extend(overlay_report);
-    if !report.is_empty() {
-        println!("Codex MCP discovery: {}", path.display());
-        for line in report {
-            println!("  {line}");
+    if cli.codex_cli || settings.use_cli() {
+        let command = command_override.unwrap_or_else(|| codex_cli_command(&settings));
+        let cwd = config_path
+            .as_deref()
+            .and_then(Path::parent)
+            .filter(|path| path.is_dir());
+        match discover_additional_codex_mcp_servers_with_cli(&command, cwd, &imported.servers) {
+            Ok(cli_import) => {
+                let command_display = Path::new(&command).display();
+                if cli_import.report.is_empty() {
+                    println!(
+                        "Codex CLI MCP discovery: {command_display} (no additional MCP servers)"
+                    );
+                } else {
+                    print_discovery_report(
+                        &format!("Codex CLI MCP discovery: {command_display}"),
+                        &cli_import.report,
+                    );
+                }
+                for (name, spec) in cli_import.servers {
+                    imported.servers.entry(name).or_insert(spec);
+                }
+            }
+            Err(error) if cli.codex_cli => {
+                return Err(format!(
+                    "Codex CLI MCP discovery was required by --codex-cli, but failed: {error}"
+                ));
+            }
+            Err(error) => {
+                eprintln!(
+                    "Warning: Codex CLI MCP discovery is unavailable ({error}). Continuing without CLI enrichment; only directly parsed config.toml MCP servers are available, so servers contributed by Codex plugins may be missing. Pass --codex-cli to make this a startup error."
+                );
+            }
         }
     }
-    servers
+
+    let (servers, overlay_report) = merge_mcp_servers(imported.servers, explicit);
+    print_discovery_report("Codex MCP overrides:", &overlay_report);
+    Ok(servers)
 }
 
 /// A fully-defaulted config for a given work directory, matching what
@@ -544,7 +640,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
         }
     }
 
-    let mcp_servers = resolve_mcp_servers(&mut file);
+    let mcp_servers = resolve_mcp_servers(&mut file, &cli)?;
     let openai_tunnel = resolve_openai_tunnel(file.openai_tunnel, &cli)?;
     let api_key = cli.api_key.or(file.api_key);
     if api_key.is_some() && openai_tunnel.is_some() {
@@ -603,6 +699,7 @@ mod tests {
             port: None,
             api_key: None,
             config: Some(config.to_string_lossy().into_owned()),
+            codex_cli: false,
             openai_tunnel_id: None,
             openai_tunnel_api_key_ref: None,
             openai_tunnel_client: None,
@@ -661,7 +758,11 @@ mod tests {
     fn json_config_accepts_partial_camel_case_overlay() {
         let file: FileConfig = serde_json::from_str(
             r#"{
-                "codexMcp": { "enabled": false },
+                "codexMcp": {
+                    "enabled": false,
+                    "useCli": false,
+                    "cliPath": "/opt/codex/bin/codex"
+                },
                 "mcpServers": {
                     "demo": {
                         "mode": "gateway",
@@ -672,7 +773,10 @@ mod tests {
         )
         .unwrap();
 
-        assert!(!file.codex_mcp.as_ref().unwrap().enabled());
+        let codex_mcp = file.codex_mcp.as_ref().unwrap();
+        assert!(!codex_mcp.enabled());
+        assert!(!codex_mcp.use_cli());
+        assert_eq!(codex_mcp.cli_path.as_deref(), Some("/opt/codex/bin/codex"));
         let demo = file.mcp_servers.as_ref().unwrap().get("demo").unwrap();
         assert_eq!(demo.mode.as_deref(), Some("gateway"));
         assert_eq!(
@@ -683,12 +787,106 @@ mod tests {
     }
 
     #[test]
+    fn codex_cli_flag_marks_cli_discovery_as_required() {
+        let parsed = Cli::try_parse_from(["codex-free", "--work-dir", ".", "--codex-cli"]).unwrap();
+        assert!(parsed.codex_cli);
+    }
+
+    #[test]
+    fn automatic_cli_failure_falls_back_but_explicit_flag_errors() {
+        let root = tempfile::tempdir().unwrap();
+        let codex_config = root.path().join("config.toml");
+        std::fs::write(
+            &codex_config,
+            "[mcp_servers.global]\ncommand = \"global-server\"\n",
+        )
+        .unwrap();
+        let missing_cli = root.path().join("missing-codex-cli").into_os_string();
+
+        let mut automatic_file = FileConfig {
+            codex_mcp: Some(CodexMcpConfig {
+                enabled: Some(true),
+                use_cli: Some(true),
+                cli_path: None,
+            }),
+            ..Default::default()
+        };
+        let automatic = resolve_mcp_servers_from(
+            &mut automatic_file,
+            &cli(root.path(), &root.path().join("codex.config.json")),
+            Ok(codex_config.clone()),
+            Some(missing_cli.clone()),
+        )
+        .unwrap();
+        assert_eq!(
+            automatic
+                .get("global")
+                .and_then(|server| server.command.as_deref()),
+            Some("global-server")
+        );
+
+        let mut required_file = FileConfig {
+            codex_mcp: Some(CodexMcpConfig {
+                enabled: Some(false),
+                use_cli: Some(false),
+                cli_path: None,
+            }),
+            ..Default::default()
+        };
+        let mut required_cli = cli(root.path(), &root.path().join("codex.config.json"));
+        required_cli.codex_cli = true;
+        let error = resolve_mcp_servers_from(
+            &mut required_file,
+            &required_cli,
+            Ok(codex_config),
+            Some(missing_cli),
+        )
+        .unwrap_err();
+        assert!(error.contains("required by --codex-cli"));
+        assert!(error.contains("was not found"));
+    }
+
+    #[test]
+    fn use_cli_false_keeps_direct_import_without_starting_the_cli() {
+        let root = tempfile::tempdir().unwrap();
+        let codex_config = root.path().join("config.toml");
+        std::fs::write(
+            &codex_config,
+            "[mcp_servers.global]\ncommand = \"global-server\"\n",
+        )
+        .unwrap();
+        let mut file = FileConfig {
+            codex_mcp: Some(CodexMcpConfig {
+                enabled: Some(true),
+                use_cli: Some(false),
+                cli_path: None,
+            }),
+            ..Default::default()
+        };
+
+        let servers = resolve_mcp_servers_from(
+            &mut file,
+            &cli(root.path(), &root.path().join("codex.config.json")),
+            Ok(codex_config),
+            Some(root.path().join("missing-codex-cli").into_os_string()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            servers
+                .get("global")
+                .and_then(|server| server.command.as_deref()),
+            Some("global-server")
+        );
+    }
+
+    #[test]
     fn loads_native_tunnel_with_a_secret_reference_default() {
         let root = tempfile::tempdir().unwrap();
         let config_path = root.path().join("config.json");
         std::fs::write(
             &config_path,
-            r#"{"openaiTunnel":{"tunnelId":"tunnel_0123456789abcdef0123456789abcdef"}}"#,
+            r#"{"codexMcp":{"useCli":false},"openaiTunnel":{"tunnelId":"tunnel_0123456789abcdef0123456789abcdef"}}"#,
         )
         .unwrap();
 
@@ -705,7 +903,7 @@ mod tests {
         let config_path = root.path().join("config.json");
         std::fs::write(
             &config_path,
-            r#"{"openaiTunnel":{"tunnelId":"tunnel_0123456789abcdef0123456789abcdef","apiKeyRef":"sk-literal-secret-value"}}"#,
+            r#"{"codexMcp":{"useCli":false},"openaiTunnel":{"tunnelId":"tunnel_0123456789abcdef0123456789abcdef","apiKeyRef":"sk-literal-secret-value"}}"#,
         )
         .unwrap();
 
@@ -719,7 +917,7 @@ mod tests {
         let config_path = root.path().join("config.json");
         std::fs::write(
             &config_path,
-            r#"{"apiKey":"local-token","openaiTunnel":{"tunnelId":"tunnel_0123456789abcdef0123456789abcdef"}}"#,
+            r#"{"codexMcp":{"useCli":false},"apiKey":"local-token","openaiTunnel":{"tunnelId":"tunnel_0123456789abcdef0123456789abcdef"}}"#,
         )
         .unwrap();
 
@@ -733,7 +931,7 @@ mod tests {
         let config_path = root.path().join("config.json");
         std::fs::write(
             &config_path,
-            r#"{"openaiTunnel":{"tunnelId":"tunnel_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","apiKeyRef":"env:OLD_KEY"}}"#,
+            r#"{"codexMcp":{"useCli":false},"openaiTunnel":{"tunnelId":"tunnel_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","apiKeyRef":"env:OLD_KEY"}}"#,
         )
         .unwrap();
         let mut args = cli(root.path(), &config_path);
@@ -756,7 +954,7 @@ mod tests {
         let config_path = root.path().join("config.json");
         std::fs::write(
             &config_path,
-            r#"{"openaiTunnel":{"tunnelId":"tunnel_NOT_HEX"}}"#,
+            r#"{"codexMcp":{"useCli":false},"openaiTunnel":{"tunnelId":"tunnel_NOT_HEX"}}"#,
         )
         .unwrap();
 
@@ -765,7 +963,7 @@ mod tests {
 
         std::fs::write(
             &config_path,
-            r#"{"openaiTunnel":{"tunnelId":"tunnel_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}}"#,
+            r#"{"codexMcp":{"useCli":false},"openaiTunnel":{"tunnelId":"tunnel_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"}}"#,
         )
         .unwrap();
         let error = load_config(cli(root.path(), &config_path)).unwrap_err();
@@ -773,7 +971,7 @@ mod tests {
 
         std::fs::write(
             &config_path,
-            r#"{"openaiTunnel":{"tunnelId":"tunnel_0123456789abcdefghijklmnopqrstuv"}}"#,
+            r#"{"codexMcp":{"useCli":false},"openaiTunnel":{"tunnelId":"tunnel_0123456789abcdefghijklmnopqrstuv"}}"#,
         )
         .unwrap();
         assert!(load_config(cli(root.path(), &config_path)).is_ok());

--- a/tests/project_selection.rs
+++ b/tests/project_selection.rs
@@ -544,7 +544,11 @@ fn multi_project_mode_can_be_enabled_by_config_or_cli() {
     fs::create_dir_all(&access).unwrap();
 
     let enabled_config = root.path().join("enabled.json");
-    fs::write(&enabled_config, r#"{ "multiProject": true }"#).unwrap();
+    fs::write(
+        &enabled_config,
+        r#"{ "multiProject": true, "codexMcp": { "useCli": false } }"#,
+    )
+    .unwrap();
     let from_file = Cli::try_parse_from([
         "codex-free",
         "--work-dir",
@@ -556,7 +560,11 @@ fn multi_project_mode_can_be_enabled_by_config_or_cli() {
     assert!(load_config(from_file).unwrap().multi_project);
 
     let disabled_config = root.path().join("disabled.json");
-    fs::write(&disabled_config, r#"{ "multiProject": false }"#).unwrap();
+    fs::write(
+        &disabled_config,
+        r#"{ "multiProject": false, "codexMcp": { "useCli": false } }"#,
+    )
+    .unwrap();
     let from_cli = Cli::try_parse_from([
         "codex-free",
         "--work-dir",


### PR DESCRIPTION
## Overview

Codex Free already imports MCP servers declared in Codex's user-level `config.toml`, but enabled Codex plugins can contribute additional MCP servers that are only present in Codex's effective MCP catalogue. This adds optional Codex CLI-backed enrichment while preserving direct TOML parsing as the standalone fallback.

## Behavior

- Parse compatible `[mcp_servers.<name>]` entries directly from `$CODEX_HOME/config.toml` or `~/.codex/config.toml`, as before.
- By default, attempt `codex mcp list --json` and fetch each server absent from the direct config result with `codex mcp get --json -- <name>`.
- Import supported local stdio launch settings, resolved working directories, environment references, enablement, and enabled/disabled tool filters.
- Apply explicit `codex.config.json.mcpServers` overlays after both discovery sources, so bridge-specific settings such as gateway mode still take precedence.
- Treat CLI discovery as optional in the default mode: a missing executable, timeout, non-zero exit, or incompatible JSON produces a warning and startup continues with direct `config.toml` discovery.
- Add `--codex-cli` to require successful CLI-backed discovery and turn the same failures into startup errors.
- Add `codexMcp.useCli` to disable CLI enrichment without disabling direct config import, and `codexMcp.cliPath` to select an explicit executable. Resolution falls back to `CODEX_CLI_PATH`, then `codex` on `PATH`.
- Bound each Codex CLI invocation to 30 seconds and keep diagnostics secret-safe; literal environment values are parsed in memory but never logged.
- Continue reporting and skipping unsupported HTTP transports and non-local execution environments.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all` — 397 tests passed
- Process-level smoke test against an installed Codex CLI, confirming plugin-only `codex_app` and `idalib` servers are discovered and that plugin-resolved working directories are retained
- Process-level fallback test confirming automatic mode warns and continues when the CLI is absent, while `--codex-cli` fails startup
