### PR TITLE
feat: isolate concurrent chats with managed worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ Each release ships a compiled binary per platform — `windows-x64`, `linux-x64`
 |------|----------|---------|-------------|
 | `--work-dir` | Yes | - | Project directory, or the project access root with `--multi-project` |
 | `--multi-project` | No | Disabled | Let each ChatGPT conversation bind once to a project beneath `--work-dir`; other clients fall back to transport-session binding |
+| `--worktree-mode` | No | `auto` | Multi-project worktree policy: `auto`, `always`, or `never` |
+| `--worktree-root` | No | Codex worktree location | Directory for managed conversation worktrees |
 | `--port` | No | `3000` | Server port |
 | `--api-key` | No | - | Bearer token for auth |
 | `--config` | No | `./codex.config.json` | Config file path (tolerated if missing) |
@@ -215,6 +217,13 @@ All project-scoped paths are resolved relative to the active project root: `--wo
 ```json
 {
   "multiProject": false,
+  "worktrees": {
+    "mode": "auto",
+    "root": "/path/to/worktrees",
+    "upstreamRefreshMode": "never",
+    "autoCleanupEnabled": true,
+    "keepCount": 15
+  },
   "allowedCommands": ["bun", "npm", "npx", "node", "git", "python", "pip", "cargo", "make"],
   "port": 3000,
   "tree": {
@@ -285,6 +294,18 @@ Native mode deliberately cannot be combined with a caller-supplied `apiKey` / `-
 The OpenAI runtime key authenticates the outbound control-plane connection. Codex Free resolves the configured `env:NAME` or `file:/path` reference once, passes the value to the tunnel child under a private synthetic environment name, and removes the original environment variable from model-launched commands and bridged MCP children. The tunnel runtime starts with a small allowlist of ordinary OS variables rather than inheriting tunnel-client configuration, proxy, header, or trust-store overrides from the launching shell. On Unix, a referenced key file must not be readable by group or other users. These measures prevent accidental inheritance; they do not create a secret boundary against hostile code running as the same OS user, which can potentially inspect same-user processes or read an accessible key file.
 
 The top-level `multiProject` key is the config-file equivalent of `--multi-project`. In that mode the process still reads one static `codex.config.json`; project selection changes the effective work directory used by project-scoped tools, not the server configuration itself. ChatGPT conversation bindings are independent of the `memory` block and remain enabled even when `memory.enabled` is `false`.
+
+The `worktrees` block controls isolation between conversations selecting the same Git project:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `mode` | `"auto"` | `"auto"` lets the first conversation use the selected checkout and gives later conversations managed worktrees; `"always"` isolates every conversation; `"never"` preserves direct-checkout sharing |
+| `root` | Codex worktree location | Parent directory for managed worktrees; overridden by `--worktree-root` |
+| `upstreamRefreshMode` | Codex setting or `"never"` | `"best-effort"` refreshes a tracked upstream before worktree creation without making fetch failure fatal |
+| `autoCleanupEnabled` | Codex setting or `true` | On startup, remove old unreferenced worktrees only when their working trees are clean |
+| `keepCount` | Codex setting or `15` | Number of newest unreferenced managed worktrees retained before cleanup candidates are considered |
+
+When these values are absent, Codex Free reads Codex Desktop's `[desktop]` worktree settings from `$CODEX_HOME/config.toml`, including `git-worktree-root`, `worktree-upstream-refresh-mode`, `worktree-auto-cleanup-enabled`, and `worktree-keep-count`. The final location falls back to `$CODEX_HOME/worktrees` (normally `~/.codex/worktrees`).
 
 The `exec` block governs `exec_command` and `write_stdin`:
 
@@ -358,12 +379,14 @@ Each conversation binds a project exactly once, through the [`set_project_root`]
 
 - The path is relative to the access root or absolute, but its canonical target must be an existing directory inside that root. Traversal (`..`) and symlink escapes are rejected *after* canonicalisation, so a link pointing outside the root cannot smuggle a selection past the check.
 - The binding belongs to the **ChatGPT conversation**, keyed from `_meta["openai/session"]` (the raw identifier is hashed, never stored), so simultaneous chats can hold different projects and a later turn recovers its own root after MCP reconnects or a server restart. A client that sends no ChatGPT conversation metadata falls back to a binding that lasts only the current MCP transport session.
+- With the default worktree mode, the first conversation selecting a Git project uses the source checkout directly. Once that logical project is already assigned, another conversation receives a detached managed worktree under the configured Codex worktree location, preventing concurrent chats from editing the same checkout. `always` and `never` make either behavior unconditional.
+- Worktree identity uses the repository's Git common directory plus the selected path relative to its Git root. Linked worktrees are therefore recognised as the same repository, while separate subprojects in a monorepo remain distinct.
 - A conversation cannot switch roots once bound — start another chat for a different project. Re-selecting the same canonical path is idempotent.
 - Until a root is selected, project-scoped tools are unavailable and say why; `set_project_root` is the one project tool always present in this mode.
 
 Per-conversation separation extends to saved state: with an explicit `memory.dir`, each selected project gets its own hashed child directory (see the [`memory` block](#config-file)), and conversation bindings stay enabled even when `memory.enabled` is `false`. The end-to-end onboarding flow — select, then request the brief — is in [Starting a chat](#starting-a-chat).
 
-To clear a stray binding, delete its file under `~/.codex-free/conversation-projects/`; there is no tool to re-point an already-bound conversation.
+To clear a stray binding, delete its file under `~/.codex-free/conversation-projects/`; there is no tool to re-point an already-bound conversation. A managed worktree remains referenced while that binding exists. Startup cleanup skips referenced or dirty worktrees and only removes older clean, unreferenced entries beyond `keepCount`.
 
 ## Context and memory
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,8 +14,10 @@ use std::collections::HashMap;
 use crate::codex_mcp::{codex_config_path, discover_codex_mcp_servers};
 use crate::types::{
     AppConfig, CommandConfig, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig,
-    OpenAiTunnelConfig, OutputConfig, ProjectDocConfig, SkillsConfig, TreeConfig,
+    OpenAiTunnelConfig, OutputConfig, ProjectDocConfig, SkillsConfig, TreeConfig, WorktreeConfig,
+    WorktreeMode, WorktreeUpstreamRefreshMode,
 };
+use crate::util::home_dir;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -31,6 +33,14 @@ pub struct Cli {
     /// Other MCP clients fall back to transport-session binding.
     #[arg(long = "multi-project")]
     pub multi_project: bool,
+
+    /// Worktree policy for new multi-project conversation bindings.
+    #[arg(long = "worktree-mode", value_enum)]
+    pub worktree_mode: Option<WorktreeMode>,
+
+    /// Managed-worktree root. Default: Codex's configured Worktree location.
+    #[arg(long = "worktree-root")]
+    pub worktree_root: Option<String>,
 
     /// Server port. Default: 3000 (or the config file's value).
     #[arg(long)]
@@ -144,6 +154,16 @@ struct PartialOpenAiTunnel {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct PartialWorktrees {
+    mode: Option<WorktreeMode>,
+    root: Option<String>,
+    upstream_refresh_mode: Option<WorktreeUpstreamRefreshMode>,
+    auto_cleanup_enabled: Option<bool>,
+    keep_count: Option<usize>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct CodexMcpConfig {
     enabled: Option<bool>,
 }
@@ -243,6 +263,7 @@ struct FileConfig {
     api_key: Option<String>,
     port: Option<u16>,
     multi_project: Option<bool>,
+    worktrees: Option<PartialWorktrees>,
     allowed_commands: Option<Vec<String>>,
     tree: Option<PartialTree>,
     command: Option<PartialCommand>,
@@ -327,6 +348,7 @@ pub fn default_config(work_dir: std::path::PathBuf) -> AppConfig {
     AppConfig {
         work_dir,
         multi_project: false,
+        worktrees: default_worktree_config(),
         api_key: None,
         port: 3000,
         allowed_commands: default_allowed_commands(),
@@ -343,6 +365,117 @@ pub fn default_config(work_dir: std::path::PathBuf) -> AppConfig {
         mcp_servers: HashMap::new(),
         generated_skills_dir: None,
     }
+}
+
+#[derive(Debug, Default)]
+struct NativeWorktreeSettings {
+    root: Option<PathBuf>,
+    upstream_refresh_mode: Option<WorktreeUpstreamRefreshMode>,
+    auto_cleanup_enabled: Option<bool>,
+    keep_count: Option<usize>,
+}
+
+fn codex_home_path() -> PathBuf {
+    codex_config_path()
+        .ok()
+        .and_then(|path| path.parent().map(Path::to_path_buf))
+        .or_else(|| home_dir().map(|path| path.join(".codex")))
+        .unwrap_or_else(|| PathBuf::from(".codex"))
+}
+
+fn default_worktree_config() -> WorktreeConfig {
+    WorktreeConfig {
+        mode: WorktreeMode::Auto,
+        root: codex_home_path().join("worktrees"),
+        upstream_refresh_mode: WorktreeUpstreamRefreshMode::Never,
+        auto_cleanup_enabled: true,
+        keep_count: 15,
+    }
+}
+
+fn native_worktree_settings() -> NativeWorktreeSettings {
+    let Ok(path) = codex_config_path() else {
+        return NativeWorktreeSettings::default();
+    };
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return NativeWorktreeSettings::default();
+        }
+        Err(_) => {
+            println!(
+                "Codex worktree settings: could not read {} — using built-in defaults",
+                path.display()
+            );
+            return NativeWorktreeSettings::default();
+        }
+    };
+    let root: toml::Value = match toml::from_str(&raw) {
+        Ok(root) => root,
+        Err(_) => {
+            println!(
+                "Codex worktree settings: invalid TOML at {} — using built-in defaults",
+                path.display()
+            );
+            return NativeWorktreeSettings::default();
+        }
+    };
+    let Some(desktop) = root.get("desktop").and_then(toml::Value::as_table) else {
+        return NativeWorktreeSettings::default();
+    };
+
+    let root = desktop
+        .get("git-worktree-root")
+        .and_then(toml::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(resolve_path);
+    let upstream_refresh_mode = match desktop
+        .get("worktree-upstream-refresh-mode")
+        .and_then(toml::Value::as_str)
+    {
+        Some("best-effort") => Some(WorktreeUpstreamRefreshMode::BestEffort),
+        Some("never") => Some(WorktreeUpstreamRefreshMode::Never),
+        _ => None,
+    };
+    let auto_cleanup_enabled = desktop
+        .get("worktree-auto-cleanup-enabled")
+        .and_then(toml::Value::as_bool);
+    let keep_count = desktop
+        .get("worktree-keep-count")
+        .and_then(toml::Value::as_integer)
+        .and_then(|value| usize::try_from(value).ok());
+
+    NativeWorktreeSettings {
+        root,
+        upstream_refresh_mode,
+        auto_cleanup_enabled,
+        keep_count,
+    }
+}
+
+fn resolve_worktree_config(file: Option<PartialWorktrees>, cli: &Cli) -> WorktreeConfig {
+    let native = native_worktree_settings();
+    let file = file.unwrap_or_default();
+    let mut config = default_worktree_config();
+    config.mode = cli.worktree_mode.or(file.mode).unwrap_or_default();
+    config.root = cli
+        .worktree_root
+        .as_deref()
+        .map(resolve_path)
+        .or_else(|| file.root.as_deref().map(resolve_path))
+        .or(native.root)
+        .unwrap_or(config.root);
+    config.upstream_refresh_mode = file
+        .upstream_refresh_mode
+        .or(native.upstream_refresh_mode)
+        .unwrap_or_default();
+    config.auto_cleanup_enabled = file
+        .auto_cleanup_enabled
+        .or(native.auto_cleanup_enabled)
+        .unwrap_or(true);
+    config.keep_count = file.keep_count.or(native.keep_count).unwrap_or(15).max(1);
+    config
 }
 
 /// Resolve `work_dir` against the current directory when relative. The path is
@@ -546,6 +679,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
 
     let mcp_servers = resolve_mcp_servers(&mut file);
     let openai_tunnel = resolve_openai_tunnel(file.openai_tunnel, &cli)?;
+    let worktrees = resolve_worktree_config(file.worktrees.take(), &cli);
     let api_key = cli.api_key.or(file.api_key);
     if api_key.is_some() && openai_tunnel.is_some() {
         return Err(
@@ -557,6 +691,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
     Ok(AppConfig {
         work_dir,
         multi_project: cli.multi_project || file.multi_project.unwrap_or(false),
+        worktrees,
         api_key,
         port: cli.port.or(file.port).unwrap_or(3000),
         allowed_commands: file
@@ -600,6 +735,8 @@ mod tests {
         Cli {
             work_dir: work_dir.to_string_lossy().into_owned(),
             multi_project: false,
+            worktree_mode: None,
+            worktree_root: None,
             port: None,
             api_key: None,
             config: Some(config.to_string_lossy().into_owned()),

--- a/src/exec_policy.rs
+++ b/src/exec_policy.rs
@@ -236,43 +236,14 @@ pub fn assert_exec_allowed(cmd: &str, config: &AppConfig) -> Result<(), ExecPoli
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{
-        CommandConfig, ExecConfig, IgnoreConfig, MemoryConfig, OutputConfig, ProjectDocConfig,
-        SkillsConfig, TreeConfig,
-    };
+    use crate::config::default_config;
 
     fn cfg(mode: ExecMode) -> AppConfig {
-        AppConfig {
-            work_dir: std::path::PathBuf::from("/w"),
-            multi_project: false,
-            api_key: None,
-            port: 3000,
-            allowed_commands: vec!["git".into(), "node".into()],
-            tree: TreeConfig {
-                default_depth: 3,
-                ignore: vec![],
-            },
-            command: CommandConfig {
-                default_timeout: 30000,
-                max_timeout: 120000,
-            },
-            exec: ExecConfig {
-                mode,
-                extra_allowed_commands: vec!["ls".into(), "cat".into(), "grep".into()],
-                max_sessions: 8,
-                default_shell: None,
-                idle_timeout_ms: 0,
-            },
-            project_doc: ProjectDocConfig::default(),
-            output: OutputConfig::default(),
-            memory: MemoryConfig::default(),
-            skills: SkillsConfig::default(),
-            ignore: IgnoreConfig::default(),
-            allowed_hosts: vec![],
-            openai_tunnel: None,
-            mcp_servers: std::collections::HashMap::new(),
-            generated_skills_dir: None,
-        }
+        let mut config = default_config(std::path::PathBuf::from("/w"));
+        config.allowed_commands = vec!["git".into(), "node".into()];
+        config.exec.mode = mode;
+        config.exec.extra_allowed_commands = vec!["ls".into(), "cat".into(), "grep".into()];
+        config
     }
 
     #[test]

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -18,7 +18,8 @@ use tokio::sync::{Mutex as TokioMutex, Notify};
 
 use crate::process_env::scrub_untrusted_child_env;
 use crate::project_bindings::{ProjectBindingScope, ProjectRootSelection, resolve_project_root};
-use crate::types::{AppConfig, PlanState};
+use crate::types::{AppConfig, PlanState, WorktreeMode};
+use crate::worktrees::create_managed_worktree;
 
 // Codex constants (shell_spec.rs). Kept as code, not config, because they are
 // part of matching Codex's tool semantics rather than local policy.
@@ -337,7 +338,17 @@ pub struct SessionState {
     pub exec_sessions: Arc<StdMutex<HashMap<u64, Arc<ExecSession>>>>,
     next_exec_id: AtomicU64,
     pub plan: StdMutex<Option<PlanState>>,
-    project_root: StdMutex<Option<PathBuf>>,
+    project_binding: StdMutex<Option<TransportProjectBinding>>,
+    project_selection_lock: TokioMutex<()>,
+}
+
+#[derive(Debug, Clone)]
+struct TransportProjectBinding {
+    source_project_root: PathBuf,
+    project_root: PathBuf,
+    managed_worktree: bool,
+    worktree_git_root: Option<PathBuf>,
+    worktrees_root: Option<PathBuf>,
 }
 
 impl Default for SessionState {
@@ -346,7 +357,8 @@ impl Default for SessionState {
             exec_sessions: Arc::new(StdMutex::new(HashMap::new())),
             next_exec_id: AtomicU64::new(1),
             plan: StdMutex::new(None),
-            project_root: StdMutex::new(None),
+            project_binding: StdMutex::new(None),
+            project_selection_lock: TokioMutex::new(()),
         }
     }
 }
@@ -397,7 +409,7 @@ impl SessionState {
             return Ok(config.clone());
         }
 
-        let Some(project_root) = self.project_root.lock().unwrap().clone() else {
+        let Some(binding) = self.project_binding.lock().unwrap().clone() else {
             return Err(format!(
                 "No project root is selected for this MCP transport session. Call `set_project_root` with a directory relative to the access root `{}`, then call `get_agent_brief` before using project tools.",
                 config.work_dir.display()
@@ -405,11 +417,11 @@ impl SessionState {
         };
 
         let mut effective = config.clone();
-        effective.work_dir = project_root;
+        effective.work_dir = binding.project_root;
         Ok(effective)
     }
 
-    pub fn select_project_root(
+    pub async fn select_project_root(
         &self,
         config: &AppConfig,
         input: &str,
@@ -421,35 +433,78 @@ impl SessionState {
             );
         }
 
-        let (access_root, project_root) = resolve_project_root(config, input)?;
+        let _selection_guard = self.project_selection_lock.lock().await;
+        let (access_root, source_project_root) = resolve_project_root(config, input)?;
 
-        let mut selected = self.project_root.lock().unwrap();
-        match selected.as_ref() {
-            Some(current) if current == &project_root => Ok(ProjectRootSelection {
-                access_root,
-                project_root,
-                newly_selected: false,
-                scope: ProjectBindingScope::McpTransportSession,
-            }),
-            Some(current) => Err(format!(
-                "This MCP transport session is already bound to project root `{}` and cannot switch to `{}`. Open a new session for another project.",
-                current.display(),
-                project_root.display()
-            )),
-            None => {
-                *selected = Some(project_root.clone());
-                Ok(ProjectRootSelection {
+        if let Some(current) = self.project_binding.lock().unwrap().clone() {
+            if current.source_project_root == source_project_root {
+                return Ok(ProjectRootSelection {
                     access_root,
-                    project_root,
-                    newly_selected: true,
+                    source_project_root: current.source_project_root,
+                    project_root: current.project_root,
+                    managed_worktree: current.managed_worktree,
+                    worktree_git_root: current.worktree_git_root,
+                    worktrees_root: current.worktrees_root,
+                    worktree_mode: config.worktrees.mode,
+                    warnings: Vec::new(),
+                    newly_selected: false,
                     scope: ProjectBindingScope::McpTransportSession,
-                })
+                });
             }
+            return Err(format!(
+                "This MCP transport session is already bound to source project `{}` and cannot switch to `{}`. Open a new session for another project.",
+                current.source_project_root.display(),
+                source_project_root.display()
+            ));
         }
+
+        let create_worktree = config.worktrees.mode != WorktreeMode::Never;
+        let managed = if create_worktree {
+            Some(create_managed_worktree(config, &source_project_root).await?)
+        } else {
+            None
+        };
+        let binding = match managed.as_ref() {
+            Some(worktree) => TransportProjectBinding {
+                source_project_root: source_project_root.clone(),
+                project_root: worktree.project_root.clone(),
+                managed_worktree: true,
+                worktree_git_root: Some(worktree.worktree_git_root.clone()),
+                worktrees_root: Some(worktree.worktrees_root.clone()),
+            },
+            None => TransportProjectBinding {
+                source_project_root: source_project_root.clone(),
+                project_root: source_project_root.clone(),
+                managed_worktree: false,
+                worktree_git_root: None,
+                worktrees_root: None,
+            },
+        };
+        *self.project_binding.lock().unwrap() = Some(binding.clone());
+
+        Ok(ProjectRootSelection {
+            access_root,
+            source_project_root: binding.source_project_root,
+            project_root: binding.project_root,
+            managed_worktree: binding.managed_worktree,
+            worktree_git_root: binding.worktree_git_root,
+            worktrees_root: binding.worktrees_root,
+            worktree_mode: config.worktrees.mode,
+            warnings: managed
+                .as_ref()
+                .map(|worktree| worktree.warnings.clone())
+                .unwrap_or_default(),
+            newly_selected: true,
+            scope: ProjectBindingScope::McpTransportSession,
+        })
     }
 
     pub fn selected_project_root(&self) -> Option<PathBuf> {
-        self.project_root.lock().unwrap().clone()
+        self.project_binding
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|binding| binding.project_root.clone())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,3 +28,4 @@ pub mod tool;
 pub mod tools;
 pub mod types;
 pub mod util;
+pub mod worktrees;

--- a/src/project_bindings.rs
+++ b/src/project_bindings.rs
@@ -1,5 +1,4 @@
-//! Durable project selection for clients that provide a stable conversation ID.
-
+use std::collections::HashSet;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -9,15 +8,20 @@ use rmcp::model::RequestMetaObject;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::types::AppConfig;
+use crate::types::{AppConfig, WorktreeMode};
 use crate::util::home_dir;
+use crate::worktrees::{
+    ManagedWorktree, create_managed_worktree, load_metadata, metadata_path_for_worktree,
+    rollback_managed_worktree,
+};
 
 pub const OPENAI_SESSION_META_KEY: &str = "openai/session";
 
-const BINDING_VERSION: u32 = 1;
-const LOCK_STALE_MS: u128 = 10_000;
-const LOCK_TIMEOUT_MS: u128 = 2_000;
-const LOCK_RETRY_MS: u64 = 20;
+const BINDING_VERSION: u32 = 2;
+const LEGACY_BINDING_VERSION: u32 = 1;
+const LOCK_STALE_MS: u128 = 10 * 60 * 1_000;
+const LOCK_TIMEOUT_MS: u128 = 5 * 60 * 1_000;
+const LOCK_RETRY_MS: u64 = 50;
 
 static ATOMIC_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -79,7 +83,13 @@ impl ProjectBindingScope {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectRootSelection {
     pub access_root: PathBuf,
+    pub source_project_root: PathBuf,
     pub project_root: PathBuf,
+    pub managed_worktree: bool,
+    pub worktree_git_root: Option<PathBuf>,
+    pub worktrees_root: Option<PathBuf>,
+    pub worktree_mode: WorktreeMode,
+    pub warnings: Vec<String>,
     pub newly_selected: bool,
     pub scope: ProjectBindingScope,
 }
@@ -95,6 +105,28 @@ struct StoredProjectBinding {
     version: u32,
     access_root: String,
     project_root: String,
+    #[serde(default)]
+    source_project_root: Option<String>,
+    #[serde(default)]
+    managed_worktree: bool,
+    #[serde(default)]
+    worktree_git_root: Option<String>,
+    #[serde(default)]
+    worktrees_root: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ResolvedProjectBinding {
+    source_project_root: PathBuf,
+    project_root: PathBuf,
+    managed_worktree: bool,
+    worktree_git_root: Option<PathBuf>,
+    worktrees_root: Option<PathBuf>,
+}
+
+struct AssignmentScan {
+    assigned: bool,
+    warnings: Vec<String>,
 }
 
 struct BindingLock {
@@ -130,7 +162,7 @@ impl ProjectBindingStore {
             return Ok(config.clone());
         }
 
-        let Some(project_root) = self.selected_project_root(config, identity)? else {
+        let Some(binding) = self.selected_binding(config, identity)? else {
             return Err(format!(
                 "No project root is selected for this ChatGPT conversation. Call `set_project_root` with a directory relative to the access root `{}`, then call `get_agent_brief` before using project tools. The selection is stored by ChatGPT conversation ID and will survive MCP reconnects and server restarts.",
                 config.work_dir.display()
@@ -138,7 +170,7 @@ impl ProjectBindingStore {
         };
 
         let mut effective = config.clone();
-        effective.work_dir = project_root;
+        effective.work_dir = binding.project_root;
         Ok(effective)
     }
 
@@ -147,64 +179,195 @@ impl ProjectBindingStore {
         config: &AppConfig,
         identity: &ConversationIdentity,
     ) -> Result<Option<PathBuf>, String> {
-        let access_root = canonical_access_root(config)?;
-        let path = self.binding_path(&access_root, identity);
-        self.read_binding(&path, &access_root)
+        Ok(self
+            .selected_binding(config, identity)?
+            .map(|binding| binding.project_root))
     }
 
-    pub fn select_project_root(
+    pub async fn select_project_root(
         &self,
         config: &AppConfig,
         identity: &ConversationIdentity,
         input: &str,
     ) -> Result<ProjectRootSelection, String> {
-        let (access_root, project_root) = resolve_project_root(config, input)?;
+        let (access_root, source_project_root) = resolve_project_root(config, input)?;
         let binding_path = self.binding_path(&access_root, identity);
-        let _lock = acquire_lock(&binding_path)?;
+        let binding_lock = acquire_lock(&binding_path).await?;
 
         if let Some(current) = self.read_binding(&binding_path, &access_root)? {
-            if current == project_root {
-                return Ok(ProjectRootSelection {
+            if current.source_project_root == source_project_root {
+                return Ok(selection_from_binding(
                     access_root,
-                    project_root,
-                    newly_selected: false,
-                    scope: ProjectBindingScope::ChatGptConversation,
-                });
+                    current,
+                    config.worktrees.mode,
+                    false,
+                    ProjectBindingScope::ChatGptConversation,
+                    Vec::new(),
+                ));
             }
 
             return Err(format!(
-                "This ChatGPT conversation is already bound to project root `{}` and cannot switch to `{}`. Start a new chat for another project.",
-                current.display(),
-                project_root.display()
+                "This ChatGPT conversation is already bound to source project `{}` and cannot switch to `{}`. Start a new chat for another project.",
+                current.source_project_root.display(),
+                source_project_root.display()
             ));
         }
 
-        let binding = StoredProjectBinding {
+        let assignment_path = self.assignment_path(&access_root, &source_project_root);
+        let assignment_lock = acquire_lock(&assignment_path).await?;
+        let scan = self.scan_source_assignments(&access_root, &source_project_root);
+        let create_worktree = match config.worktrees.mode {
+            WorktreeMode::Auto => scan.assigned,
+            WorktreeMode::Always => true,
+            WorktreeMode::Never => false,
+        };
+        let mut warnings = scan.warnings;
+
+        let managed = if create_worktree {
+            let worktree = create_managed_worktree(config, &source_project_root).await?;
+            warnings.extend(worktree.warnings.iter().cloned());
+            Some(worktree)
+        } else {
+            None
+        };
+
+        let resolved = resolved_from_managed(&source_project_root, managed.as_ref());
+        let stored = StoredProjectBinding {
             version: BINDING_VERSION,
             access_root: access_root.to_string_lossy().into_owned(),
-            project_root: project_root.to_string_lossy().into_owned(),
+            source_project_root: Some(source_project_root.to_string_lossy().into_owned()),
+            project_root: resolved.project_root.to_string_lossy().into_owned(),
+            managed_worktree: resolved.managed_worktree,
+            worktree_git_root: resolved
+                .worktree_git_root
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned()),
+            worktrees_root: resolved
+                .worktrees_root
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned()),
         };
-        self.write_binding(&binding_path, &binding)?;
+        if let Err(error) = self.write_binding(&binding_path, &stored) {
+            let rollback = match managed.as_ref() {
+                Some(worktree) => rollback_managed_worktree(config, worktree).await.err(),
+                None => None,
+            };
+            return Err(match rollback {
+                Some(rollback) => {
+                    format!("{error}\nManaged-worktree rollback also failed: {rollback}")
+                }
+                None => error,
+            });
+        }
 
-        Ok(ProjectRootSelection {
+        drop(assignment_lock);
+        drop(binding_lock);
+
+        Ok(selection_from_binding(
             access_root,
-            project_root,
-            newly_selected: true,
-            scope: ProjectBindingScope::ChatGptConversation,
-        })
+            resolved,
+            config.worktrees.mode,
+            true,
+            ProjectBindingScope::ChatGptConversation,
+            warnings,
+        ))
+    }
+
+    pub fn referenced_managed_project_roots(
+        &self,
+        config: &AppConfig,
+    ) -> Result<HashSet<PathBuf>, String> {
+        if !config.multi_project {
+            return Ok(HashSet::new());
+        }
+        let access_root = canonical_access_root(config)?;
+        let mut roots = HashSet::new();
+        for path in self.binding_files(&access_root) {
+            if let Ok(Some(binding)) = self.read_binding(&path, &access_root)
+                && binding.managed_worktree
+            {
+                roots.insert(binding.project_root);
+            }
+        }
+        Ok(roots)
+    }
+
+    fn selected_binding(
+        &self,
+        config: &AppConfig,
+        identity: &ConversationIdentity,
+    ) -> Result<Option<ResolvedProjectBinding>, String> {
+        let access_root = canonical_access_root(config)?;
+        let path = self.binding_path(&access_root, identity);
+        self.read_binding(&path, &access_root)
+    }
+
+    fn scan_source_assignments(
+        &self,
+        access_root: &Path,
+        source_project_root: &Path,
+    ) -> AssignmentScan {
+        let mut assigned = false;
+        let mut warnings = Vec::new();
+        for path in self.binding_files(access_root) {
+            match self.read_binding(&path, access_root) {
+                Ok(Some(binding)) if binding.source_project_root == source_project_root => {
+                    assigned = true;
+                    break;
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    assigned = true;
+                    warnings.push(format!(
+                        "A stored conversation binding could not be validated, so the shared checkout was treated as assigned: {error}"
+                    ));
+                }
+            }
+        }
+        AssignmentScan { assigned, warnings }
+    }
+
+    fn binding_files(&self, access_root: &Path) -> Vec<PathBuf> {
+        let directory = self.access_root_dir(access_root);
+        let Ok(entries) = std::fs::read_dir(directory) else {
+            return Vec::new();
+        };
+        entries
+            .flatten()
+            .filter_map(|entry| {
+                let path = entry.path();
+                (entry.file_type().ok()?.is_file()
+                    && path
+                        .extension()
+                        .is_some_and(|extension| extension == "json"))
+                .then_some(path)
+            })
+            .collect()
+    }
+
+    fn access_root_dir(&self, access_root: &Path) -> PathBuf {
+        self.base_dir.join(access_root_key(access_root))
     }
 
     fn binding_path(&self, access_root: &Path, identity: &ConversationIdentity) -> PathBuf {
-        let mut hasher = Sha256::new();
-        hasher.update(b"codex-free/access-root/v1\0");
-        hasher.update(access_root.to_string_lossy().as_bytes());
-        let access_key = encode_hex(&hasher.finalize(), 24);
-        self.base_dir
-            .join(access_key)
+        self.access_root_dir(access_root)
             .join(format!("{}.json", identity.key()))
     }
 
-    fn read_binding(&self, path: &Path, access_root: &Path) -> Result<Option<PathBuf>, String> {
+    fn assignment_path(&self, access_root: &Path, source_project_root: &Path) -> PathBuf {
+        let mut hasher = Sha256::new();
+        hasher.update(b"codex-free/source-project/v1\0");
+        hasher.update(source_project_root.to_string_lossy().as_bytes());
+        self.access_root_dir(access_root)
+            .join("assignments")
+            .join(encode_hex(&hasher.finalize(), 64))
+    }
+
+    fn read_binding(
+        &self,
+        path: &Path,
+        access_root: &Path,
+    ) -> Result<Option<ResolvedProjectBinding>, String> {
         let raw = match std::fs::read_to_string(path) {
             Ok(raw) => raw,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
@@ -222,7 +385,7 @@ impl ProjectBindingStore {
                 path.display()
             )
         })?;
-        if binding.version != BINDING_VERSION {
+        if !matches!(binding.version, LEGACY_BINDING_VERSION | BINDING_VERSION) {
             return Err(format!(
                 "The stored ChatGPT conversation project binding at {} uses unsupported version {}. Start a new chat or remove that binding file.",
                 path.display(),
@@ -237,28 +400,130 @@ impl ProjectBindingStore {
             ));
         }
 
-        let stored_root = PathBuf::from(&binding.project_root);
-        let project_root = std::fs::canonicalize(&stored_root).map_err(|error| {
-            format!(
-                "The project bound to this ChatGPT conversation no longer exists or cannot be resolved: {}: {error}. Start a new chat for another project.",
-                stored_root.display()
-            )
-        })?;
-        if !project_root.is_dir() {
+        let source_stored = binding
+            .source_project_root
+            .as_deref()
+            .unwrap_or(&binding.project_root);
+        let source_project_root = canonical_binding_dir(
+            source_stored,
+            "source project",
+            path,
+            "Start a new chat for another project.",
+        )?;
+        if source_project_root != access_root && !source_project_root.starts_with(access_root) {
             return Err(format!(
-                "The project bound to this ChatGPT conversation is no longer a directory: {}. Start a new chat for another project.",
-                project_root.display()
-            ));
-        }
-        if project_root != access_root && !project_root.starts_with(access_root) {
-            return Err(format!(
-                "The project bound to this ChatGPT conversation now resolves outside the configured access root: {}. Start a new chat or remove the binding file at {}.",
-                project_root.display(),
+                "The source project bound to this ChatGPT conversation now resolves outside the configured access root: {}. Start a new chat or remove the binding file at {}.",
+                source_project_root.display(),
                 path.display()
             ));
         }
 
-        Ok(Some(project_root))
+        let project_root = canonical_binding_dir(
+            &binding.project_root,
+            "active project",
+            path,
+            "Start a new chat for another project.",
+        )?;
+        if !binding.managed_worktree {
+            if project_root != source_project_root {
+                return Err(format!(
+                    "The direct project binding at {} has inconsistent source and active roots. Start a new chat or remove that binding file.",
+                    path.display()
+                ));
+            }
+            return Ok(Some(ResolvedProjectBinding {
+                source_project_root,
+                project_root,
+                managed_worktree: false,
+                worktree_git_root: None,
+                worktrees_root: None,
+            }));
+        }
+
+        if binding.version != BINDING_VERSION {
+            return Err(format!(
+                "The stored project binding at {} marks a managed worktree using a legacy format. Start a new chat or remove that binding file.",
+                path.display()
+            ));
+        }
+        let worktree_git_root = canonical_binding_dir(
+            binding.worktree_git_root.as_deref().ok_or_else(|| {
+                format!(
+                    "The managed-worktree binding at {} does not record its Git root. Start a new chat or remove that binding file.",
+                    path.display()
+                )
+            })?,
+            "managed worktree Git root",
+            path,
+            "Start a new chat for another project.",
+        )?;
+        let worktrees_root = canonical_binding_dir(
+            binding.worktrees_root.as_deref().ok_or_else(|| {
+                format!(
+                    "The managed-worktree binding at {} does not record its worktree root. Start a new chat or remove that binding file.",
+                    path.display()
+                )
+            })?,
+            "managed worktree root",
+            path,
+            "Start a new chat for another project.",
+        )?;
+        if worktree_git_root == worktrees_root || !worktree_git_root.starts_with(&worktrees_root) {
+            return Err(format!(
+                "The managed worktree Git root {} is outside its recorded worktree root {}. Start a new chat or remove the binding file at {}.",
+                worktree_git_root.display(),
+                worktrees_root.display(),
+                path.display()
+            ));
+        }
+        if project_root != worktree_git_root && !project_root.starts_with(&worktree_git_root) {
+            return Err(format!(
+                "The active project {} is outside its managed worktree Git root {}. Start a new chat or remove the binding file at {}.",
+                project_root.display(),
+                worktree_git_root.display(),
+                path.display()
+            ));
+        }
+
+        let metadata_path = metadata_path_for_worktree(&worktree_git_root).ok_or_else(|| {
+            format!(
+                "Could not locate managed-worktree metadata for {}",
+                worktree_git_root.display()
+            )
+        })?;
+        let metadata = load_metadata(&metadata_path)?;
+        validate_metadata_path(
+            &metadata.source_project_root,
+            &source_project_root,
+            "source project root",
+            &metadata_path,
+        )?;
+        validate_metadata_path(
+            &metadata.project_root,
+            &project_root,
+            "active project root",
+            &metadata_path,
+        )?;
+        validate_metadata_path(
+            &metadata.worktree_git_root,
+            &worktree_git_root,
+            "worktree Git root",
+            &metadata_path,
+        )?;
+        validate_metadata_path(
+            &metadata.worktrees_root,
+            &worktrees_root,
+            "worktree root",
+            &metadata_path,
+        )?;
+
+        Ok(Some(ResolvedProjectBinding {
+            source_project_root,
+            project_root,
+            managed_worktree: true,
+            worktree_git_root: Some(worktree_git_root),
+            worktrees_root: Some(worktrees_root),
+        }))
     }
 
     fn write_binding(&self, target: &Path, binding: &StoredProjectBinding) -> Result<(), String> {
@@ -284,7 +549,10 @@ impl ProjectBindingStore {
 
         let result = (|| -> std::io::Result<()> {
             {
-                let mut file = std::fs::File::create(&temporary)?;
+                let mut file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&temporary)?;
                 file.write_all(json.as_bytes())?;
                 file.write_all(b"\n")?;
                 file.sync_all()?;
@@ -348,6 +616,96 @@ pub fn resolve_project_root(config: &AppConfig, input: &str) -> Result<(PathBuf,
     Ok((access_root, project_root))
 }
 
+fn resolved_from_managed(
+    source_project_root: &Path,
+    managed: Option<&ManagedWorktree>,
+) -> ResolvedProjectBinding {
+    match managed {
+        Some(worktree) => ResolvedProjectBinding {
+            source_project_root: source_project_root.to_path_buf(),
+            project_root: worktree.project_root.clone(),
+            managed_worktree: true,
+            worktree_git_root: Some(worktree.worktree_git_root.clone()),
+            worktrees_root: Some(worktree.worktrees_root.clone()),
+        },
+        None => ResolvedProjectBinding {
+            source_project_root: source_project_root.to_path_buf(),
+            project_root: source_project_root.to_path_buf(),
+            managed_worktree: false,
+            worktree_git_root: None,
+            worktrees_root: None,
+        },
+    }
+}
+
+fn selection_from_binding(
+    access_root: PathBuf,
+    binding: ResolvedProjectBinding,
+    worktree_mode: WorktreeMode,
+    newly_selected: bool,
+    scope: ProjectBindingScope,
+    warnings: Vec<String>,
+) -> ProjectRootSelection {
+    ProjectRootSelection {
+        access_root,
+        source_project_root: binding.source_project_root,
+        project_root: binding.project_root,
+        managed_worktree: binding.managed_worktree,
+        worktree_git_root: binding.worktree_git_root,
+        worktrees_root: binding.worktrees_root,
+        worktree_mode,
+        warnings,
+        newly_selected,
+        scope,
+    }
+}
+
+fn canonical_binding_dir(
+    stored: &str,
+    label: &str,
+    binding_path: &Path,
+    recovery: &str,
+) -> Result<PathBuf, String> {
+    let stored = PathBuf::from(stored);
+    let canonical = std::fs::canonicalize(&stored).map_err(|error| {
+        format!(
+            "The {label} in the ChatGPT conversation binding no longer exists or cannot be resolved: {}: {error}. {recovery}",
+            stored.display()
+        )
+    })?;
+    if !canonical.is_dir() {
+        return Err(format!(
+            "The {label} in the ChatGPT conversation binding is no longer a directory: {}. Remove the binding file at {} or start a new chat.",
+            canonical.display(),
+            binding_path.display()
+        ));
+    }
+    Ok(canonical)
+}
+
+fn validate_metadata_path(
+    stored: &str,
+    expected: &Path,
+    label: &str,
+    metadata_path: &Path,
+) -> Result<(), String> {
+    let stored_path = PathBuf::from(stored);
+    let canonical = std::fs::canonicalize(&stored_path).map_err(|error| {
+        format!(
+            "The {label} recorded in managed-worktree metadata {} cannot be resolved: {}: {error}",
+            metadata_path.display(),
+            stored_path.display()
+        )
+    })?;
+    if canonical != expected {
+        return Err(format!(
+            "The {label} recorded in managed-worktree metadata {} does not match the conversation binding.",
+            metadata_path.display()
+        ));
+    }
+    Ok(())
+}
+
 fn canonical_access_root(config: &AppConfig) -> Result<PathBuf, String> {
     std::fs::canonicalize(&config.work_dir).map_err(|error| {
         format!(
@@ -357,11 +715,18 @@ fn canonical_access_root(config: &AppConfig) -> Result<PathBuf, String> {
     })
 }
 
-fn acquire_lock(binding_path: &Path) -> Result<BindingLock, String> {
-    let parent = binding_path.parent().ok_or_else(|| {
+fn access_root_key(access_root: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"codex-free/access-root/v1\0");
+    hasher.update(access_root.to_string_lossy().as_bytes());
+    encode_hex(&hasher.finalize(), 24)
+}
+
+async fn acquire_lock(target: &Path) -> Result<BindingLock, String> {
+    let parent = target.parent().ok_or_else(|| {
         format!(
             "Could not determine the directory for project binding {}",
-            binding_path.display()
+            target.display()
         )
     })?;
     std::fs::create_dir_all(parent).map_err(|error| {
@@ -371,7 +736,7 @@ fn acquire_lock(binding_path: &Path) -> Result<BindingLock, String> {
         )
     })?;
 
-    let mut lock_path = binding_path.as_os_str().to_os_string();
+    let mut lock_path = target.as_os_str().to_os_string();
     lock_path.push(".lock");
     let lock_path = PathBuf::from(lock_path);
     let deadline = now_ms() + LOCK_TIMEOUT_MS;
@@ -403,15 +768,15 @@ fn acquire_lock(binding_path: &Path) -> Result<BindingLock, String> {
                 if now_ms() >= deadline {
                     return Err(format!(
                         "Timed out waiting to update project binding {}",
-                        binding_path.display()
+                        target.display()
                     ));
                 }
-                std::thread::sleep(Duration::from_millis(LOCK_RETRY_MS));
+                tokio::time::sleep(Duration::from_millis(LOCK_RETRY_MS)).await;
             }
             Err(error) => {
                 return Err(format!(
                     "Could not lock project binding {}: {error}",
-                    binding_path.display()
+                    target.display()
                 ));
             }
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -137,10 +137,12 @@ impl ServerHandler for CodexHandler {
 
         let mut result = if name == SetProjectRoot::NAME {
             if let Some(identity) = conversation.as_ref() {
-                select_and_render(&args, |path| {
+                select_and_render(&args, |path| async move {
                     self.project_bindings
-                        .select_project_root(&self.config, identity, path)
+                        .select_project_root(&self.config, identity, &path)
+                        .await
                 })
+                .await
             } else {
                 tool.call(args, &self.config, &self.session).await
             }
@@ -210,8 +212,20 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
         .join(config.port.to_string());
     let _ = std::fs::remove_dir_all(&gen_dir);
     config.generated_skills_dir = Some(gen_dir);
-    let config = Arc::new(config);
     let project_bindings = Arc::new(ProjectBindingStore::for_current_user());
+    if config.multi_project && config.worktrees.auto_cleanup_enabled {
+        match project_bindings.referenced_managed_project_roots(&config) {
+            Ok(referenced) => {
+                for warning in
+                    crate::worktrees::cleanup_managed_worktrees(&config, &referenced).await
+                {
+                    tracing::warn!("managed-worktree cleanup: {warning}");
+                }
+            }
+            Err(error) => tracing::warn!("managed-worktree cleanup skipped: {error}"),
+        }
+    }
+    let config = Arc::new(config);
 
     // Connect to any configured upstream MCP servers and merge their tools in.
     // The returned services must stay alive for the whole server lifetime, so

--- a/src/tools/set_project_root.rs
+++ b/src/tools/set_project_root.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+use std::future::Future;
+
 use serde_json::{Value, json};
 
 use crate::exec_sessions::SessionState;
@@ -12,15 +14,16 @@ impl SetProjectRoot {
     pub const NAME: &'static str = "set_project_root";
 }
 
-pub fn select_and_render(
-    args: &Value,
-    select: impl FnOnce(&str) -> Result<ProjectRootSelection, String>,
-) -> ToolResult {
+pub async fn select_and_render<F, Fut>(args: &Value, select: F) -> ToolResult
+where
+    F: FnOnce(String) -> Fut,
+    Fut: Future<Output = Result<ProjectRootSelection, String>>,
+{
     let Some(path) = arg_str(args, "path") else {
         return ToolResult::error("path must be a string");
     };
 
-    let selection = match select(path) {
+    let selection = match select(path.to_string()).await {
         Ok(selection) => selection,
         Err(error) => return ToolResult::error(error),
     };
@@ -32,21 +35,55 @@ pub fn select_and_render(
     };
     let persistence = match selection.scope {
         ProjectBindingScope::ChatGptConversation => {
-            "This ChatGPT conversation is permanently bound to that project. The binding survives MCP reconnects and server restarts; start a new chat for another project."
+            "This ChatGPT conversation is permanently bound to that source project and active checkout. The binding survives MCP reconnects and server restarts; start a new chat for another project."
         }
         ProjectBindingScope::McpTransportSession => {
-            "This MCP transport session is permanently bound to that project. Clients that do not provide a stable conversation identifier must select again after reconnecting."
+            "This MCP transport session is permanently bound to that source project and active checkout. Clients that do not provide a stable conversation identifier must select again after reconnecting."
         }
     };
+    let placement = if selection.managed_worktree {
+        format!(
+            "Active project root: {}\nSource project root: {}\nManaged detached worktree Git root: {}\nManaged-worktree location: {}",
+            selection.project_root.display(),
+            selection.source_project_root.display(),
+            selection
+                .worktree_git_root
+                .as_deref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "<unknown>".to_string()),
+            selection
+                .worktrees_root
+                .as_deref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "<unknown>".to_string())
+        )
+    } else {
+        format!(
+            "Active project root: {}\nSource project root: {}\nThe source checkout is used directly under worktree mode `{}`.",
+            selection.project_root.display(),
+            selection.source_project_root.display(),
+            selection.worktree_mode.as_str()
+        )
+    };
+    let warning_text = if selection.warnings.is_empty() {
+        String::new()
+    } else {
+        format!("\nWarnings:\n- {}", selection.warnings.join("\n- "))
+    };
     let content = format!(
-        "{state}: {}\nAccess root: {}\n{persistence}\nCall `get_agent_brief` now so the environment, saved state, skills, and project instructions are loaded from the selected root.",
-        selection.project_root.display(),
+        "{state}\n{placement}\nAccess root: {}\n{persistence}{warning_text}\nCall `get_agent_brief` now so the environment, saved state, skills, and project instructions are loaded from the active root.",
         selection.access_root.display()
     );
 
     ToolResult::text(content.clone()).with_structured(json!({
         "access_root": selection.access_root.to_string_lossy(),
+        "source_project_root": selection.source_project_root.to_string_lossy(),
         "project_root": selection.project_root.to_string_lossy(),
+        "managed_worktree": selection.managed_worktree,
+        "worktree_git_root": selection.worktree_git_root.as_ref().map(|path| path.to_string_lossy()),
+        "worktrees_root": selection.worktrees_root.as_ref().map(|path| path.to_string_lossy()),
+        "worktree_mode": selection.worktree_mode.as_str(),
+        "warnings": selection.warnings,
         "newly_selected": selection.newly_selected,
         "binding_scope": selection.scope.as_str(),
         "content": content
@@ -60,7 +97,7 @@ impl Tool for SetProjectRoot {
     }
 
     fn description(&self) -> String {
-        "Bind the current ChatGPT conversation to one project directory beneath the server's configured access root. ChatGPT bindings survive MCP reconnects and server restarts and cannot be changed; start a new chat for another project. Clients without ChatGPT's stable conversation metadata fall back to binding the current MCP transport session. In multi-project mode, call this for a new unbound conversation before any filesystem, search, edit, command, git, project-instruction, skill, memory, or plan tool, then call get_agent_brief.".into()
+        "Bind the current ChatGPT conversation to one source project beneath the server's configured access root. Depending on the configured worktree mode and existing assignments, Codex Free either uses that checkout directly or creates a detached managed worktree so concurrent conversations do not edit the same checkout. ChatGPT bindings survive MCP reconnects and server restarts and cannot be changed; start a new chat for another project. Clients without ChatGPT's stable conversation metadata fall back to binding the current MCP transport session. In multi-project mode, call this for a new unbound conversation before any filesystem, search, edit, command, git, project-instruction, skill, memory, or plan tool, then call get_agent_brief.".into()
     }
 
     fn describe(&self, config: &AppConfig) -> String {
@@ -94,12 +131,18 @@ impl Tool for SetProjectRoot {
             "type": "object",
             "properties": {
                 "access_root": { "type": "string" },
+                "source_project_root": { "type": "string" },
                 "project_root": { "type": "string" },
+                "managed_worktree": { "type": "boolean" },
+                "worktree_git_root": { "type": ["string", "null"] },
+                "worktrees_root": { "type": ["string", "null"] },
+                "worktree_mode": { "type": "string", "enum": ["auto", "always", "never"] },
+                "warnings": { "type": "array", "items": { "type": "string" } },
                 "newly_selected": { "type": "boolean" },
                 "binding_scope": { "type": "string", "enum": ["chatgpt_conversation", "mcp_transport_session"] },
                 "content": { "type": "string" }
             },
-            "required": ["access_root", "project_root", "newly_selected", "binding_scope", "content"]
+            "required": ["access_root", "source_project_root", "project_root", "managed_worktree", "worktree_git_root", "worktrees_root", "worktree_mode", "warnings", "newly_selected", "binding_scope", "content"]
         }))
     }
 
@@ -112,6 +155,9 @@ impl Tool for SetProjectRoot {
     }
 
     async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult {
-        select_and_render(&args, |path| session.select_project_root(config, path))
+        select_and_render(&args, |path| async move {
+            session.select_project_root(config, &path).await
+        })
+        .await
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -291,6 +291,54 @@ pub struct OpenAiTunnelConfig {
     pub client_path: Option<std::path::PathBuf>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
+#[value(rename_all = "kebab-case")]
+#[derive(Default)]
+pub enum WorktreeMode {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+impl WorktreeMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auto => "auto",
+            Self::Always => "always",
+            Self::Never => "never",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[derive(Default)]
+pub enum WorktreeUpstreamRefreshMode {
+    #[default]
+    Never,
+    BestEffort,
+}
+
+impl WorktreeUpstreamRefreshMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Never => "never",
+            Self::BestEffort => "best-effort",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorktreeConfig {
+    pub mode: WorktreeMode,
+    pub root: std::path::PathBuf,
+    pub upstream_refresh_mode: WorktreeUpstreamRefreshMode,
+    pub auto_cleanup_enabled: bool,
+    pub keep_count: usize,
+}
+
 /// The fully-resolved server configuration handed to every tool.
 ///
 /// `work_dir` and `port` are always concrete. `projectDoc`, `output`, `memory`,
@@ -300,6 +348,7 @@ pub struct OpenAiTunnelConfig {
 pub struct AppConfig {
     pub work_dir: std::path::PathBuf,
     pub multi_project: bool,
+    pub worktrees: WorktreeConfig,
     pub api_key: Option<String>,
     pub port: u16,
     pub allowed_commands: Vec<String>,

--- a/src/worktrees.rs
+++ b/src/worktrees.rs
@@ -1,0 +1,1379 @@
+use std::collections::{BTreeSet, HashSet};
+use std::ffi::{OsStr, OsString};
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::process::Output;
+use std::time::{Duration, SystemTime};
+
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+use tokio::time::timeout;
+
+use crate::exec_sessions::{resolve_shell, wrap_for_shell};
+use crate::process_env::scrub_untrusted_child_env;
+use crate::types::{AppConfig, WorktreeUpstreamRefreshMode};
+
+const METADATA_VERSION: u32 = 1;
+const METADATA_FILENAME: &str = ".codex-free-worktree.json";
+const LOCAL_ENVIRONMENT_CONFIG_KEY: &str = "codex.localEnvironmentConfigPath";
+const NO_LOCAL_ENVIRONMENT: &str = "__none__";
+const MAX_COMMAND_OUTPUT_BYTES: usize = 16_384;
+const DEFAULT_GIT_TIMEOUT: Duration = Duration::from_secs(120);
+const UPSTREAM_REFRESH_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManagedWorktree {
+    pub source_project_root: PathBuf,
+    pub project_root: PathBuf,
+    pub source_git_root: PathBuf,
+    pub worktree_git_root: PathBuf,
+    pub worktrees_root: PathBuf,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ManagedWorktreeMetadata {
+    pub version: u32,
+    pub source_project_root: String,
+    pub project_root: String,
+    pub source_git_root: String,
+    pub worktree_git_root: String,
+    pub worktrees_root: String,
+    pub created_at_ms: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct LocalEnvironmentConfig {
+    #[serde(default = "default_environment_version")]
+    version: u32,
+    name: String,
+    setup: EnvironmentScript,
+}
+
+#[derive(Debug, Deserialize)]
+struct EnvironmentScript {
+    script: String,
+    darwin: Option<PlatformScript>,
+    linux: Option<PlatformScript>,
+    win32: Option<PlatformScript>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlatformScript {
+    script: String,
+}
+
+fn default_environment_version() -> u32 {
+    1
+}
+
+pub async fn create_managed_worktree(
+    config: &AppConfig,
+    source_project_root: &Path,
+) -> Result<ManagedWorktree, String> {
+    let source_project_root = fs::canonicalize(source_project_root).map_err(|error| {
+        format!(
+            "Could not resolve project root {} before creating a worktree: {error}",
+            source_project_root.display()
+        )
+    })?;
+    let source_git_root = resolve_git_root(config, &source_project_root).await?;
+    let workspace_relative = source_project_root
+        .strip_prefix(&source_git_root)
+        .map_err(|_| {
+            format!(
+                "Selected project {} is outside its Git root {}",
+                source_project_root.display(),
+                source_git_root.display()
+            )
+        })?
+        .to_path_buf();
+
+    let worktrees_root = prepare_worktrees_root(&config.worktrees.root)?;
+    let (shard_root, worktree_git_root) =
+        allocate_worktree_path(&worktrees_root, &source_git_root)?;
+    let project_root = worktree_git_root.join(&workspace_relative);
+    let mut warnings = Vec::new();
+    let starting_commit = resolve_starting_commit(config, &source_git_root, &mut warnings).await?;
+    let filter_overrides = safe_attribute_filter_overrides(config, &source_git_root).await?;
+
+    let creation = async {
+        let mut args = filter_overrides;
+        args.extend([
+            OsString::from("worktree"),
+            OsString::from("add"),
+            OsString::from("--detach"),
+            worktree_git_root.as_os_str().to_owned(),
+            OsString::from(starting_commit),
+        ]);
+        git_success(
+            config,
+            &source_git_root,
+            &args,
+            &[],
+            DEFAULT_GIT_TIMEOUT,
+            "git worktree add",
+        )
+        .await?;
+
+        let metadata = ManagedWorktreeMetadata {
+            version: METADATA_VERSION,
+            source_project_root: source_project_root.to_string_lossy().into_owned(),
+            project_root: project_root.to_string_lossy().into_owned(),
+            source_git_root: source_git_root.to_string_lossy().into_owned(),
+            worktree_git_root: worktree_git_root.to_string_lossy().into_owned(),
+            worktrees_root: worktrees_root.to_string_lossy().into_owned(),
+            created_at_ms: now_ms(),
+        };
+        write_metadata(&shard_root, &metadata)?;
+
+        copy_ignored_agent_overrides(
+            config,
+            &source_git_root,
+            &worktree_git_root,
+            &worktrees_root,
+        )
+        .await?;
+        copy_worktree_includes(
+            config,
+            &source_git_root,
+            &worktree_git_root,
+            &worktrees_root,
+        )
+        .await?;
+        fs::create_dir_all(&project_root).map_err(|error| {
+            format!(
+                "Could not create selected workspace directory {} in the worktree: {error}",
+                project_root.display()
+            )
+        })?;
+
+        if let Some(environment_path) =
+            prepare_local_environment(config, &source_git_root, &worktree_git_root, &shard_root)
+                .await?
+        {
+            run_setup_script(
+                config,
+                &environment_path,
+                &source_project_root,
+                &project_root,
+                &worktree_git_root,
+            )
+            .await?;
+        }
+
+        Ok::<(), String>(())
+    }
+    .await;
+
+    if let Err(error) = creation {
+        cleanup_failed_creation(config, &source_git_root, &worktree_git_root, &shard_root).await;
+        return Err(error);
+    }
+
+    Ok(ManagedWorktree {
+        source_project_root,
+        project_root,
+        source_git_root,
+        worktree_git_root,
+        worktrees_root,
+        warnings,
+    })
+}
+
+pub async fn rollback_managed_worktree(
+    config: &AppConfig,
+    worktree: &ManagedWorktree,
+) -> Result<(), String> {
+    let shard_root = worktree.worktree_git_root.parent().ok_or_else(|| {
+        format!(
+            "Could not determine the managed-worktree directory for {}",
+            worktree.worktree_git_root.display()
+        )
+    })?;
+    let output = git_output(
+        config,
+        &worktree.source_git_root,
+        &[
+            OsString::from("worktree"),
+            OsString::from("remove"),
+            OsString::from("--force"),
+            worktree.worktree_git_root.as_os_str().to_owned(),
+        ],
+        &[],
+        DEFAULT_GIT_TIMEOUT,
+    )
+    .await?;
+    if !output.status.success() {
+        return Err(format!(
+            "Could not roll back managed worktree {}: {}",
+            worktree.worktree_git_root.display(),
+            bounded_output(&output)
+        ));
+    }
+    fs::remove_dir_all(shard_root).map_err(|error| {
+        format!(
+            "Could not remove managed-worktree directory {} after rollback: {error}",
+            shard_root.display()
+        )
+    })?;
+    Ok(())
+}
+
+pub fn metadata_path_for_worktree(worktree_git_root: &Path) -> Option<PathBuf> {
+    worktree_git_root
+        .parent()
+        .map(|parent| parent.join(METADATA_FILENAME))
+}
+
+pub fn load_metadata(path: &Path) -> Result<ManagedWorktreeMetadata, String> {
+    let raw = fs::read_to_string(path).map_err(|error| {
+        format!(
+            "Could not read managed-worktree metadata {}: {error}",
+            path.display()
+        )
+    })?;
+    let metadata: ManagedWorktreeMetadata = serde_json::from_str(&raw).map_err(|error| {
+        format!(
+            "Managed-worktree metadata {} is invalid: {error}",
+            path.display()
+        )
+    })?;
+    if metadata.version != METADATA_VERSION {
+        return Err(format!(
+            "Managed-worktree metadata {} uses unsupported version {}",
+            path.display(),
+            metadata.version
+        ));
+    }
+    Ok(metadata)
+}
+
+pub async fn cleanup_managed_worktrees(
+    config: &AppConfig,
+    referenced_project_roots: &HashSet<PathBuf>,
+) -> Vec<String> {
+    if !config.worktrees.auto_cleanup_enabled {
+        return Vec::new();
+    }
+    let root = match prepare_worktrees_root(&config.worktrees.root) {
+        Ok(root) => root,
+        Err(error) => return vec![error],
+    };
+    let entries = match fs::read_dir(&root) {
+        Ok(entries) => entries,
+        Err(error) => {
+            return vec![format!(
+                "Could not inspect managed-worktree root {}: {error}",
+                root.display()
+            )];
+        }
+    };
+
+    let mut candidates = Vec::new();
+    for entry in entries.flatten() {
+        let shard = entry.path();
+        let Some(name) = shard.file_name().and_then(OsStr::to_str) else {
+            continue;
+        };
+        if !is_native_shard_name(name) {
+            continue;
+        }
+        let metadata_path = shard.join(METADATA_FILENAME);
+        let Ok(metadata) = load_metadata(&metadata_path) else {
+            continue;
+        };
+        let project_root = PathBuf::from(&metadata.project_root);
+        if referenced_project_roots.contains(&project_root) {
+            continue;
+        }
+        candidates.push((metadata.created_at_ms, shard, metadata));
+    }
+
+    candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.0));
+    let mut warnings = Vec::new();
+    for (_, shard, metadata) in candidates.into_iter().skip(config.worktrees.keep_count) {
+        let source_git_root = PathBuf::from(&metadata.source_git_root);
+        let worktree_git_root = PathBuf::from(&metadata.worktree_git_root);
+        if !worktree_git_root.exists() {
+            if let Err(error) = fs::remove_dir_all(&shard) {
+                warnings.push(format!(
+                    "Could not remove stale managed-worktree metadata directory {}: {error}",
+                    shard.display()
+                ));
+            }
+            continue;
+        }
+
+        let status = match git_output(
+            config,
+            &worktree_git_root,
+            &[OsString::from("status"), OsString::from("--porcelain")],
+            &[],
+            DEFAULT_GIT_TIMEOUT,
+        )
+        .await
+        {
+            Ok(output) if output.status.success() => output,
+            Ok(output) => {
+                warnings.push(format!(
+                    "Could not inspect stale managed worktree {}: {}",
+                    worktree_git_root.display(),
+                    bounded_output(&output)
+                ));
+                continue;
+            }
+            Err(error) => {
+                warnings.push(error);
+                continue;
+            }
+        };
+        if !status.stdout.is_empty() {
+            continue;
+        }
+
+        let result = git_output(
+            config,
+            &source_git_root,
+            &[
+                OsString::from("worktree"),
+                OsString::from("remove"),
+                worktree_git_root.as_os_str().to_owned(),
+            ],
+            &[],
+            DEFAULT_GIT_TIMEOUT,
+        )
+        .await;
+        match result {
+            Ok(output) if output.status.success() => {
+                let _ = fs::remove_dir_all(&shard);
+            }
+            Ok(output) => warnings.push(format!(
+                "Could not remove stale managed worktree {}: {}",
+                worktree_git_root.display(),
+                bounded_output(&output)
+            )),
+            Err(error) => warnings.push(error),
+        }
+    }
+    warnings
+}
+
+async fn resolve_git_root(config: &AppConfig, project_root: &Path) -> Result<PathBuf, String> {
+    let output = git_success(
+        config,
+        project_root,
+        &[
+            OsString::from("rev-parse"),
+            OsString::from("--path-format=absolute"),
+            OsString::from("--show-toplevel"),
+        ],
+        &[],
+        DEFAULT_GIT_TIMEOUT,
+        "git rev-parse --show-toplevel",
+    )
+    .await?;
+    let path = path_from_git_output(&output.stdout)?;
+    fs::canonicalize(&path).map_err(|error| {
+        format!(
+            "Could not resolve Git root returned for {}: {}: {error}",
+            project_root.display(),
+            path.display()
+        )
+    })
+}
+
+fn prepare_worktrees_root(configured: &Path) -> Result<PathBuf, String> {
+    fs::create_dir_all(configured).map_err(|error| {
+        format!(
+            "Could not create managed-worktree root {}: {error}",
+            configured.display()
+        )
+    })?;
+    fs::canonicalize(configured).map_err(|error| {
+        format!(
+            "Could not resolve managed-worktree root {}: {error}",
+            configured.display()
+        )
+    })
+}
+
+fn allocate_worktree_path(
+    worktrees_root: &Path,
+    source_git_root: &Path,
+) -> Result<(PathBuf, PathBuf), String> {
+    let repository_name = source_git_root
+        .file_name()
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| OsStr::new("repository"));
+
+    for _ in 0..256 {
+        let shard_name = random_shard()?;
+        let shard_root = worktrees_root.join(shard_name);
+        match fs::create_dir(&shard_root) {
+            Ok(()) => {
+                let worktree_git_root = shard_root.join(repository_name);
+                return Ok((shard_root, worktree_git_root));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(format!(
+                    "Could not reserve a managed-worktree directory under {}: {error}",
+                    worktrees_root.display()
+                ));
+            }
+        }
+    }
+
+    Err(format!(
+        "Could not allocate a unique managed-worktree directory under {}",
+        worktrees_root.display()
+    ))
+}
+
+fn random_shard() -> Result<String, String> {
+    let mut bytes = [0_u8; 2];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|error| format!("Could not generate a managed-worktree identifier: {error}"))?;
+    Ok(format!("{:02x}{:02x}", bytes[0], bytes[1]))
+}
+
+async fn resolve_starting_commit(
+    config: &AppConfig,
+    source_git_root: &Path,
+    warnings: &mut Vec<String>,
+) -> Result<String, String> {
+    let branch = optional_git_text(
+        config,
+        source_git_root,
+        &[
+            OsString::from("symbolic-ref"),
+            OsString::from("--quiet"),
+            OsString::from("--short"),
+            OsString::from("HEAD"),
+        ],
+    )
+    .await?;
+
+    if config.worktrees.upstream_refresh_mode == WorktreeUpstreamRefreshMode::BestEffort
+        && let Some(branch) = branch.as_deref()
+    {
+        refresh_upstream(config, source_git_root, branch, warnings).await;
+    }
+
+    let head = required_git_text(
+        config,
+        source_git_root,
+        &[
+            OsString::from("rev-parse"),
+            OsString::from("--verify"),
+            OsString::from("HEAD^{commit}"),
+        ],
+        "resolve the current commit",
+    )
+    .await?;
+
+    let Some(_) = branch else {
+        return Ok(head);
+    };
+    let Some(upstream_ref) = optional_git_text(
+        config,
+        source_git_root,
+        &[
+            OsString::from("rev-parse"),
+            OsString::from("--symbolic-full-name"),
+            OsString::from("@{upstream}"),
+        ],
+    )
+    .await?
+    else {
+        return Ok(head);
+    };
+    let Some(upstream) = optional_git_text(
+        config,
+        source_git_root,
+        &[
+            OsString::from("rev-parse"),
+            OsString::from("--verify"),
+            OsString::from(format!("{upstream_ref}^{{commit}}")),
+        ],
+    )
+    .await?
+    else {
+        return Ok(head);
+    };
+    if upstream == head {
+        return Ok(head);
+    }
+
+    let output = git_output(
+        config,
+        source_git_root,
+        &[
+            OsString::from("merge-base"),
+            OsString::from("--is-ancestor"),
+            OsString::from(&head),
+            OsString::from(&upstream),
+        ],
+        &[],
+        DEFAULT_GIT_TIMEOUT,
+    )
+    .await?;
+    match output.status.code() {
+        Some(0) => Ok(upstream),
+        Some(1) => Ok(head),
+        _ => {
+            warnings.push(format!(
+                "Could not compare the current commit with its upstream; using local HEAD: {}",
+                bounded_output(&output)
+            ));
+            Ok(head)
+        }
+    }
+}
+
+async fn refresh_upstream(
+    config: &AppConfig,
+    source_git_root: &Path,
+    branch: &str,
+    warnings: &mut Vec<String>,
+) {
+    let remote_key = format!("branch.{branch}.remote");
+    let merge_key = format!("branch.{branch}.merge");
+    let Ok(Some(remote)) = git_config_value(config, source_git_root, &remote_key).await else {
+        return;
+    };
+    let Ok(Some(merge_ref)) = git_config_value(config, source_git_root, &merge_key).await else {
+        return;
+    };
+    if remote == "." {
+        return;
+    }
+    let Ok(Some(remote_url)) =
+        git_config_value(config, source_git_root, &format!("remote.{remote}.url")).await
+    else {
+        return;
+    };
+    let Ok(Some(upstream_ref)) = optional_git_text(
+        config,
+        source_git_root,
+        &[
+            OsString::from("for-each-ref"),
+            OsString::from("--format=%(upstream)"),
+            OsString::from("--count=1"),
+            OsString::from(format!("refs/heads/{branch}")),
+        ],
+    )
+    .await
+    else {
+        return;
+    };
+    if upstream_ref.is_empty() {
+        return;
+    }
+
+    let null_config = if cfg!(windows) { "NUL" } else { "/dev/null" };
+    let env = [
+        (OsString::from("GIT_CONFIG"), OsString::from(null_config)),
+        (OsString::from("GIT_CONFIG_NOSYSTEM"), OsString::from("1")),
+        (
+            OsString::from("GIT_PROTOCOL_FROM_USER"),
+            OsString::from("0"),
+        ),
+    ];
+    let output = git_output(
+        config,
+        source_git_root,
+        &[
+            OsString::from("-c"),
+            OsString::from("protocol.file.allow=always"),
+            OsString::from("fetch"),
+            OsString::from("--progress"),
+            OsString::from("--no-tags"),
+            OsString::from("--no-recurse-submodules"),
+            OsString::from("--"),
+            OsString::from(&remote_url),
+            OsString::from(format!("+{merge_ref}:{upstream_ref}")),
+        ],
+        &env,
+        UPSTREAM_REFRESH_TIMEOUT,
+    )
+    .await;
+
+    match output {
+        Ok(output) if output.status.success() => {}
+        Ok(output) => warnings.push(format!(
+            "Could not refresh the upstream before creating the worktree; cached Git state was used: {}",
+            bounded_output(&output).replace(&remote_url, "<remote-url>")
+        )),
+        Err(error) => warnings.push(format!(
+            "Could not refresh the upstream before creating the worktree; cached Git state was used: {error}"
+        )),
+    }
+}
+
+async fn safe_attribute_filter_overrides(
+    config: &AppConfig,
+    source_git_root: &Path,
+) -> Result<Vec<OsString>, String> {
+    let output = git_output(
+        config,
+        source_git_root,
+        &[
+            OsString::from("config"),
+            OsString::from("--name-only"),
+            OsString::from("--get-regexp"),
+            OsString::from(r"^filter\..*\.(clean|smudge|process|required)$"),
+        ],
+        &[],
+        DEFAULT_GIT_TIMEOUT,
+    )
+    .await?;
+    if !output.status.success() && output.status.code() != Some(1) {
+        return Err(format!(
+            "Could not inspect Git attribute filters before creating a worktree: {}",
+            bounded_output(&output)
+        ));
+    }
+
+    let mut names = BTreeSet::new();
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("filter.") else {
+            continue;
+        };
+        let Some((name, field)) = rest.rsplit_once('.') else {
+            continue;
+        };
+        if matches!(field, "clean" | "smudge" | "process" | "required")
+            && !name.is_empty()
+            && !name.chars().any(char::is_control)
+        {
+            names.insert(name.to_string());
+        }
+    }
+
+    let mut args = vec![
+        OsString::from("-c"),
+        OsString::from("attr.tree="),
+        OsString::from("-c"),
+        OsString::from("core.attributesFile="),
+    ];
+    for name in names {
+        for assignment in [
+            format!("filter.{name}.clean="),
+            format!("filter.{name}.smudge="),
+            format!("filter.{name}.process="),
+            format!("filter.{name}.required=false"),
+        ] {
+            args.push(OsString::from("-c"));
+            args.push(OsString::from(assignment));
+        }
+    }
+    Ok(args)
+}
+
+async fn copy_ignored_agent_overrides(
+    config: &AppConfig,
+    source_git_root: &Path,
+    worktree_git_root: &Path,
+    worktrees_root: &Path,
+) -> Result<(), String> {
+    let paths = git_null_paths(
+        config,
+        source_git_root,
+        &[
+            OsString::from("ls-files"),
+            OsString::from("--others"),
+            OsString::from("--ignored"),
+            OsString::from("--exclude-standard"),
+            OsString::from("-z"),
+            OsString::from("--"),
+            OsString::from(":(glob)**/AGENTS.override.md"),
+        ],
+        "locate ignored AGENTS.override.md files",
+    )
+    .await?;
+    copy_relative_files(
+        source_git_root,
+        worktree_git_root,
+        worktrees_root,
+        paths,
+        "ignored AGENTS.override.md",
+    )
+}
+
+async fn copy_worktree_includes(
+    config: &AppConfig,
+    source_git_root: &Path,
+    worktree_git_root: &Path,
+    worktrees_root: &Path,
+) -> Result<(), String> {
+    let include_file = source_git_root.join(".worktreeinclude");
+    match fs::metadata(&include_file) {
+        Ok(metadata) if metadata.is_file() => {}
+        Ok(_) => {
+            return Err(format!(
+                "{} exists but is not a regular file",
+                include_file.display()
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "Could not inspect {}: {error}",
+                include_file.display()
+            ));
+        }
+    }
+
+    let ignored = git_null_paths(
+        config,
+        source_git_root,
+        &[
+            OsString::from("ls-files"),
+            OsString::from("--others"),
+            OsString::from("--ignored"),
+            OsString::from("--exclude-standard"),
+            OsString::from("-z"),
+        ],
+        "locate ignored files",
+    )
+    .await?;
+    let included = git_null_paths(
+        config,
+        source_git_root,
+        &[
+            OsString::from("ls-files"),
+            OsString::from("--others"),
+            OsString::from("--ignored"),
+            OsString::from("--exclude-from=.worktreeinclude"),
+            OsString::from("-z"),
+        ],
+        "evaluate .worktreeinclude",
+    )
+    .await?;
+    let ignored: HashSet<PathBuf> = ignored.into_iter().collect();
+    let selected = included
+        .into_iter()
+        .filter(|path| ignored.contains(path))
+        .collect::<BTreeSet<_>>();
+    copy_relative_files(
+        source_git_root,
+        worktree_git_root,
+        worktrees_root,
+        selected,
+        ".worktreeinclude",
+    )
+}
+
+fn copy_relative_files(
+    source_git_root: &Path,
+    worktree_git_root: &Path,
+    worktrees_root: &Path,
+    paths: impl IntoIterator<Item = PathBuf>,
+    label: &str,
+) -> Result<(), String> {
+    let excluded_managed_root = worktrees_root
+        .strip_prefix(source_git_root)
+        .ok()
+        .map(Path::to_path_buf);
+
+    for relative in paths {
+        validate_relative_git_path(&relative, label)?;
+        if excluded_managed_root
+            .as_ref()
+            .is_some_and(|excluded| relative == *excluded || relative.starts_with(excluded))
+        {
+            continue;
+        }
+        let source = source_git_root.join(&relative);
+        let destination = worktree_git_root.join(&relative);
+        copy_regular_file(&source, &destination, worktree_git_root, label)?;
+    }
+    Ok(())
+}
+
+fn validate_relative_git_path(path: &Path, label: &str) -> Result<(), String> {
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        return Err(format!(
+            "{label} selected an invalid path: {}",
+            path.display()
+        ));
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(name) if name != OsStr::new(".git") => {}
+            _ => {
+                return Err(format!(
+                    "{label} selected a path outside the Git worktree: {}",
+                    path.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn copy_regular_file(
+    source: &Path,
+    destination: &Path,
+    worktree_git_root: &Path,
+    label: &str,
+) -> Result<bool, String> {
+    let metadata = match fs::symlink_metadata(source) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "Could not inspect {label} source {}: {error}",
+                source.display()
+            ));
+        }
+    };
+    if !metadata.file_type().is_file() {
+        return Ok(false);
+    }
+
+    let parent = destination.parent().ok_or_else(|| {
+        format!(
+            "Could not determine destination directory for {}",
+            destination.display()
+        )
+    })?;
+    create_safe_parent_directories(worktree_git_root, parent, label)?;
+
+    let mut input = fs::File::open(source)
+        .map_err(|error| format!("Could not read {}: {error}", source.display()))?;
+    let mut output = match OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(destination)
+    {
+        Ok(output) => output,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => return Ok(false),
+        Err(error) => {
+            return Err(format!(
+                "Could not create {} from {label}: {error}",
+                destination.display()
+            ));
+        }
+    };
+    std::io::copy(&mut input, &mut output).map_err(|error| {
+        format!(
+            "Could not copy {} to {}: {error}",
+            source.display(),
+            destination.display()
+        )
+    })?;
+    fs::set_permissions(destination, metadata.permissions()).map_err(|error| {
+        format!(
+            "Could not preserve permissions on {}: {error}",
+            destination.display()
+        )
+    })?;
+    Ok(true)
+}
+
+fn create_safe_parent_directories(
+    worktree_git_root: &Path,
+    parent: &Path,
+    label: &str,
+) -> Result<(), String> {
+    let relative = parent.strip_prefix(worktree_git_root).map_err(|_| {
+        format!(
+            "Refusing to copy {label} outside managed worktree {}",
+            worktree_git_root.display()
+        )
+    })?;
+    let mut current = worktree_git_root.to_path_buf();
+    for component in relative.components() {
+        let Component::Normal(name) = component else {
+            return Err(format!(
+                "Refusing to copy {label} through an invalid workspace path"
+            ));
+        };
+        current.push(name);
+        match fs::symlink_metadata(&current) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(format!(
+                    "Refusing to copy {label} through symlinked workspace path {}",
+                    current.display()
+                ));
+            }
+            Ok(metadata) if metadata.is_dir() => {}
+            Ok(_) => {
+                return Err(format!(
+                    "Refusing to copy {label} through non-directory path {}",
+                    current.display()
+                ));
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                fs::create_dir(&current).map_err(|error| {
+                    format!(
+                        "Could not create workspace directory {} for {label}: {error}",
+                        current.display()
+                    )
+                })?;
+            }
+            Err(error) => {
+                return Err(format!(
+                    "Could not inspect workspace path {} for {label}: {error}",
+                    current.display()
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn prepare_local_environment(
+    config: &AppConfig,
+    source_git_root: &Path,
+    worktree_git_root: &Path,
+    shard_root: &Path,
+) -> Result<Option<PathBuf>, String> {
+    let Some(configured) = git_config_value(config, source_git_root, LOCAL_ENVIRONMENT_CONFIG_KEY)
+        .await?
+        .filter(|value| value != NO_LOCAL_ENVIRONMENT)
+    else {
+        set_worktree_config(
+            config,
+            source_git_root,
+            worktree_git_root,
+            LOCAL_ENVIRONMENT_CONFIG_KEY,
+            NO_LOCAL_ENVIRONMENT,
+        )
+        .await?;
+        return Ok(None);
+    };
+
+    let source = {
+        let path = PathBuf::from(&configured);
+        if path.is_absolute() {
+            path
+        } else {
+            source_git_root.join(path)
+        }
+    };
+    let metadata = fs::symlink_metadata(&source).map_err(|error| {
+        format!(
+            "Could not inspect selected Codex environment {}: {error}",
+            source.display()
+        )
+    })?;
+    if !metadata.file_type().is_file() {
+        return Err(format!(
+            "Selected Codex environment {} is not a regular file",
+            source.display()
+        ));
+    }
+
+    let target = if let Ok(relative) = source.strip_prefix(source_git_root) {
+        validate_relative_git_path(relative, "selected Codex environment")?;
+        let target = worktree_git_root.join(relative);
+        if !target.exists() {
+            copy_regular_file(
+                &source,
+                &target,
+                worktree_git_root,
+                "selected Codex environment",
+            )?;
+        }
+        target
+    } else {
+        let target = shard_root.join("environment.toml");
+        let mut input = fs::File::open(&source)
+            .map_err(|error| format!("Could not read {}: {error}", source.display()))?;
+        let mut output = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&target)
+            .map_err(|error| format!("Could not copy {}: {error}", source.display()))?;
+        std::io::copy(&mut input, &mut output).map_err(|error| {
+            format!(
+                "Could not copy selected Codex environment {}: {error}",
+                source.display()
+            )
+        })?;
+        target
+    };
+
+    set_worktree_config(
+        config,
+        source_git_root,
+        worktree_git_root,
+        LOCAL_ENVIRONMENT_CONFIG_KEY,
+        &target.to_string_lossy(),
+    )
+    .await?;
+    Ok(Some(target))
+}
+
+async fn set_worktree_config(
+    config: &AppConfig,
+    source_git_root: &Path,
+    worktree_git_root: &Path,
+    key: &str,
+    value: &str,
+) -> Result<(), String> {
+    let args = [
+        OsString::from("config"),
+        OsString::from("--worktree"),
+        OsString::from(key),
+        OsString::from(value),
+    ];
+    let first = git_output(config, worktree_git_root, &args, &[], DEFAULT_GIT_TIMEOUT).await?;
+    if first.status.success() {
+        return Ok(());
+    }
+    if !bounded_output(&first)
+        .to_ascii_lowercase()
+        .contains("worktreeconfig")
+    {
+        return Err(format!(
+            "Could not store worktree-scoped Codex setting {key}: {}",
+            bounded_output(&first)
+        ));
+    }
+
+    git_success(
+        config,
+        source_git_root,
+        &[
+            OsString::from("config"),
+            OsString::from("extensions.worktreeConfig"),
+            OsString::from("true"),
+        ],
+        &[],
+        DEFAULT_GIT_TIMEOUT,
+        "enable Git worktree-specific configuration",
+    )
+    .await?;
+    git_success(
+        config,
+        worktree_git_root,
+        &args,
+        &[],
+        DEFAULT_GIT_TIMEOUT,
+        "store worktree-scoped Codex configuration",
+    )
+    .await?;
+    Ok(())
+}
+
+async fn run_setup_script(
+    config: &AppConfig,
+    environment_path: &Path,
+    source_project_root: &Path,
+    project_root: &Path,
+    worktree_git_root: &Path,
+) -> Result<(), String> {
+    let raw = fs::read_to_string(environment_path).map_err(|error| {
+        format!(
+            "Could not read Codex environment {}: {error}",
+            environment_path.display()
+        )
+    })?;
+    let environment: LocalEnvironmentConfig = toml::from_str(&raw).map_err(|error| {
+        format!(
+            "Codex environment {} is invalid: {error}",
+            environment_path.display()
+        )
+    })?;
+    if environment.version == 0 {
+        return Err(format!(
+            "Codex environment {} has invalid version 0",
+            environment_path.display()
+        ));
+    }
+    let script = platform_script(&environment.setup);
+    if script.trim().is_empty() {
+        return Ok(());
+    }
+
+    let mut shell = resolve_shell(config.exec.default_shell.as_deref());
+    let shell_bin = shell.remove(0);
+    let command_text = wrap_for_shell(script, &shell_bin);
+    let mut command = Command::new(&shell_bin);
+    command
+        .args(shell)
+        .arg(command_text)
+        .current_dir(worktree_git_root)
+        .env("CODEX_SOURCE_TREE_PATH", source_project_root)
+        .env("CODEX_WORKTREE_PATH", project_root)
+        .kill_on_drop(true);
+    scrub_untrusted_child_env(&mut command, config);
+    let duration = Duration::from_millis(config.command.max_timeout.max(1));
+    let output = timeout(duration, command.output())
+        .await
+        .map_err(|_| {
+            format!(
+                "Codex environment setup '{}' timed out after {} ms",
+                environment.name, config.command.max_timeout
+            )
+        })?
+        .map_err(|error| {
+            format!(
+                "Could not run Codex environment setup '{}': {error}",
+                environment.name
+            )
+        })?;
+    if !output.status.success() {
+        return Err(format!(
+            "Codex environment setup '{}' failed: {}",
+            environment.name,
+            bounded_output(&output)
+        ));
+    }
+    Ok(())
+}
+
+fn platform_script(script: &EnvironmentScript) -> &str {
+    if cfg!(target_os = "macos") {
+        script
+            .darwin
+            .as_ref()
+            .map(|platform| platform.script.as_str())
+            .filter(|script| !script.is_empty())
+            .unwrap_or(&script.script)
+    } else if cfg!(windows) {
+        script
+            .win32
+            .as_ref()
+            .map(|platform| platform.script.as_str())
+            .filter(|script| !script.is_empty())
+            .unwrap_or(&script.script)
+    } else {
+        script
+            .linux
+            .as_ref()
+            .map(|platform| platform.script.as_str())
+            .filter(|script| !script.is_empty())
+            .unwrap_or(&script.script)
+    }
+}
+
+fn write_metadata(shard_root: &Path, metadata: &ManagedWorktreeMetadata) -> Result<(), String> {
+    let target = shard_root.join(METADATA_FILENAME);
+    let temporary = shard_root.join(format!(
+        "{METADATA_FILENAME}.tmp.{}.{}",
+        std::process::id(),
+        now_ms()
+    ));
+    let json = serde_json::to_vec_pretty(metadata)
+        .map_err(|error| format!("Could not serialize managed-worktree metadata: {error}"))?;
+    let result = (|| -> std::io::Result<()> {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temporary)?;
+        file.write_all(&json)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        fs::rename(&temporary, &target)?;
+        Ok(())
+    })();
+    if let Err(error) = result {
+        let _ = fs::remove_file(&temporary);
+        return Err(format!(
+            "Could not persist managed-worktree metadata at {}: {error}",
+            target.display()
+        ));
+    }
+    Ok(())
+}
+
+async fn cleanup_failed_creation(
+    config: &AppConfig,
+    source_git_root: &Path,
+    worktree_git_root: &Path,
+    shard_root: &Path,
+) {
+    if worktree_git_root.exists() {
+        let _ = git_output(
+            config,
+            source_git_root,
+            &[
+                OsString::from("worktree"),
+                OsString::from("remove"),
+                OsString::from("--force"),
+                worktree_git_root.as_os_str().to_owned(),
+            ],
+            &[],
+            DEFAULT_GIT_TIMEOUT,
+        )
+        .await;
+    }
+    let _ = fs::remove_dir_all(shard_root);
+}
+
+async fn git_config_value(
+    config: &AppConfig,
+    cwd: &Path,
+    key: &str,
+) -> Result<Option<String>, String> {
+    optional_git_text(
+        config,
+        cwd,
+        &[
+            OsString::from("config"),
+            OsString::from("--get"),
+            OsString::from(key),
+        ],
+    )
+    .await
+}
+
+async fn required_git_text(
+    config: &AppConfig,
+    cwd: &Path,
+    args: &[OsString],
+    operation: &str,
+) -> Result<String, String> {
+    let output = git_success(config, cwd, args, &[], DEFAULT_GIT_TIMEOUT, operation).await?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+async fn optional_git_text(
+    config: &AppConfig,
+    cwd: &Path,
+    args: &[OsString],
+) -> Result<Option<String>, String> {
+    let output = git_output(config, cwd, args, &[], DEFAULT_GIT_TIMEOUT).await?;
+    if output.status.success() {
+        let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Ok((!text.is_empty()).then_some(text));
+    }
+    if output.status.code() == Some(1) || output.status.code() == Some(128) {
+        return Ok(None);
+    }
+    Err(format!(
+        "Git command failed while inspecting the project: {}",
+        bounded_output(&output)
+    ))
+}
+
+async fn git_null_paths(
+    config: &AppConfig,
+    cwd: &Path,
+    args: &[OsString],
+    operation: &str,
+) -> Result<BTreeSet<PathBuf>, String> {
+    let output = git_success(config, cwd, args, &[], DEFAULT_GIT_TIMEOUT, operation).await?;
+    split_null_paths(&output.stdout)
+}
+
+async fn git_success(
+    config: &AppConfig,
+    cwd: &Path,
+    args: &[OsString],
+    env: &[(OsString, OsString)],
+    duration: Duration,
+    operation: &str,
+) -> Result<Output, String> {
+    let output = git_output(config, cwd, args, env, duration).await?;
+    if output.status.success() {
+        return Ok(output);
+    }
+    Err(format!("{operation} failed: {}", bounded_output(&output)))
+}
+
+async fn git_output(
+    config: &AppConfig,
+    cwd: &Path,
+    args: &[OsString],
+    env: &[(OsString, OsString)],
+    duration: Duration,
+) -> Result<Output, String> {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GCM_INTERACTIVE", "Never")
+        .envs(env.iter().cloned())
+        .kill_on_drop(true);
+    scrub_untrusted_child_env(&mut command, config);
+    timeout(duration, command.output())
+        .await
+        .map_err(|_| {
+            format!(
+                "Git command in {} timed out after {} seconds",
+                cwd.display(),
+                duration.as_secs()
+            )
+        })?
+        .map_err(|error| format!("Could not run Git in {}: {error}", cwd.display()))
+}
+
+fn bounded_output(output: &Output) -> String {
+    let mut bytes = Vec::with_capacity(output.stderr.len() + output.stdout.len() + 1);
+    bytes.extend_from_slice(&output.stdout);
+    if !output.stdout.is_empty() && !output.stderr.is_empty() {
+        bytes.push(b'\n');
+    }
+    bytes.extend_from_slice(&output.stderr);
+    if bytes.len() > MAX_COMMAND_OUTPUT_BYTES {
+        bytes.truncate(MAX_COMMAND_OUTPUT_BYTES);
+        bytes.extend_from_slice(b"\n[output truncated]");
+    }
+    let text = String::from_utf8_lossy(&bytes).trim().to_string();
+    if text.is_empty() {
+        format!("exit status {}", output.status)
+    } else {
+        text
+    }
+}
+
+fn path_from_git_output(bytes: &[u8]) -> Result<PathBuf, String> {
+    let trimmed = trim_ascii_newlines(bytes);
+    if trimmed.is_empty() {
+        return Err("Git returned an empty filesystem path".to_string());
+    }
+    bytes_to_path(trimmed)
+}
+
+fn split_null_paths(bytes: &[u8]) -> Result<BTreeSet<PathBuf>, String> {
+    bytes
+        .split(|byte| *byte == 0)
+        .filter(|part| !part.is_empty())
+        .map(bytes_to_path)
+        .collect()
+}
+
+fn trim_ascii_newlines(mut bytes: &[u8]) -> &[u8] {
+    while bytes
+        .last()
+        .is_some_and(|byte| matches!(byte, b'\n' | b'\r'))
+    {
+        bytes = &bytes[..bytes.len() - 1];
+    }
+    bytes
+}
+
+#[cfg(unix)]
+fn bytes_to_path(bytes: &[u8]) -> Result<PathBuf, String> {
+    use std::os::unix::ffi::OsStringExt;
+    Ok(PathBuf::from(OsString::from_vec(bytes.to_vec())))
+}
+
+#[cfg(not(unix))]
+fn bytes_to_path(bytes: &[u8]) -> Result<PathBuf, String> {
+    String::from_utf8(bytes.to_vec())
+        .map(PathBuf::from)
+        .map_err(|_| "Git returned a filesystem path that is not valid UTF-8".to_string())
+}
+
+fn is_native_shard_name(name: &str) -> bool {
+    name.len() == 4 && name.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(u64::MAX as u128) as u64)
+        .unwrap_or(0)
+}

--- a/tests/project_selection.rs
+++ b/tests/project_selection.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::sync::{Arc, Barrier};
+use std::sync::Arc;
 
 use clap::Parser;
 use codex_free::config::{Cli, default_config, load_config};
@@ -16,6 +16,7 @@ use codex_free::tools::recall::Recall;
 use codex_free::tools::remember::Remember;
 use codex_free::tools::run_command::RunCommand;
 use codex_free::tools::set_project_root::SetProjectRoot;
+use codex_free::types::WorktreeMode;
 use rmcp::model::RequestMetaObject;
 use serde_json::json;
 use tempfile::TempDir;
@@ -23,6 +24,7 @@ use tempfile::TempDir;
 fn multi_project_config(access_root: &std::path::Path) -> codex_free::types::AppConfig {
     let mut config = default_config(access_root.to_path_buf());
     config.multi_project = true;
+    config.worktrees.mode = WorktreeMode::Never;
     config.skills.enabled = Some(false);
     config
 }
@@ -209,8 +211,8 @@ fn openai_conversation_identity_is_read_from_request_metadata() {
     assert!(ConversationIdentity::from_request_meta(&meta).is_none());
 }
 
-#[test]
-fn chatgpt_project_binding_survives_transport_reconnect_and_server_restart() {
+#[tokio::test]
+async fn chatgpt_project_binding_survives_transport_reconnect_and_server_restart() {
     let root = TempDir::new().unwrap();
     let access = root.path().join("projects");
     let project = access.join("alpha");
@@ -224,6 +226,7 @@ fn chatgpt_project_binding_survives_transport_reconnect_and_server_restart() {
     let first_process = ProjectBindingStore::new(state_dir.clone());
     let selected = first_process
         .select_project_root(&config, &identity, "alpha")
+        .await
         .unwrap();
     assert!(selected.newly_selected);
     assert_eq!(selected.scope, ProjectBindingScope::ChatGptConversation);
@@ -240,12 +243,13 @@ fn chatgpt_project_binding_survives_transport_reconnect_and_server_restart() {
 
     let repeated = restarted_process
         .select_project_root(&config, &identity, "alpha/.")
+        .await
         .unwrap();
     assert!(!repeated.newly_selected);
 }
 
-#[test]
-fn chatgpt_conversations_keep_independent_project_bindings() {
+#[tokio::test]
+async fn chatgpt_conversations_keep_independent_project_bindings() {
     let root = TempDir::new().unwrap();
     let access = root.path().join("projects");
     let alpha = access.join("alpha");
@@ -258,8 +262,14 @@ fn chatgpt_conversations_keep_independent_project_bindings() {
     let first = conversation_identity("conversation-alpha");
     let second = conversation_identity("conversation-beta");
 
-    store.select_project_root(&config, &first, "alpha").unwrap();
-    store.select_project_root(&config, &second, "beta").unwrap();
+    store
+        .select_project_root(&config, &first, "alpha")
+        .await
+        .unwrap();
+    store
+        .select_project_root(&config, &second, "beta")
+        .await
+        .unwrap();
 
     assert_eq!(
         store.effective_config(&config, &first).unwrap().work_dir,
@@ -271,8 +281,8 @@ fn chatgpt_conversations_keep_independent_project_bindings() {
     );
 }
 
-#[test]
-fn chatgpt_conversation_cannot_switch_projects_after_restart() {
+#[tokio::test]
+async fn chatgpt_conversation_cannot_switch_projects_after_restart() {
     let root = TempDir::new().unwrap();
     let access = root.path().join("projects");
     fs::create_dir_all(access.join("alpha")).unwrap();
@@ -283,17 +293,19 @@ fn chatgpt_conversation_cannot_switch_projects_after_restart() {
     let identity = conversation_identity("immutable-conversation");
     ProjectBindingStore::new(state_dir.clone())
         .select_project_root(&config, &identity, "alpha")
+        .await
         .unwrap();
 
     let error = ProjectBindingStore::new(state_dir)
         .select_project_root(&config, &identity, "beta")
+        .await
         .unwrap_err();
     assert!(error.contains("already bound"));
     assert!(error.contains("Start a new chat"));
 }
 
-#[test]
-fn concurrent_chatgpt_bindings_choose_one_project_without_overwriting() {
+#[tokio::test]
+async fn concurrent_chatgpt_bindings_choose_one_project_without_overwriting() {
     let root = TempDir::new().unwrap();
     let access = root.path().join("projects");
     let alpha = access.join("alpha");
@@ -304,21 +316,23 @@ fn concurrent_chatgpt_bindings_choose_one_project_without_overwriting() {
     let config = multi_project_config(&access);
     let state_dir = root.path().join("bindings");
     let identity = conversation_identity("concurrent-conversation");
-    let barrier = Arc::new(Barrier::new(3));
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
 
     let attempts = ["alpha", "beta"].map(|project| {
         let barrier = barrier.clone();
         let config = config.clone();
         let identity = identity.clone();
         let store = ProjectBindingStore::new(state_dir.clone());
-        std::thread::spawn(move || {
-            barrier.wait();
-            store.select_project_root(&config, &identity, project)
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store.select_project_root(&config, &identity, project).await
         })
     });
-    barrier.wait();
+    barrier.wait().await;
 
-    let results = attempts.map(|attempt| attempt.join().unwrap());
+    let [first, second] = attempts;
+    let (first, second) = tokio::join!(first, second);
+    let results = [first.unwrap(), second.unwrap()];
     assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
     assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
 
@@ -331,8 +345,8 @@ fn concurrent_chatgpt_bindings_choose_one_project_without_overwriting() {
     );
 }
 
-#[test]
-fn missing_bound_project_fails_closed_instead_of_rebinding() {
+#[tokio::test]
+async fn missing_bound_project_fails_closed_instead_of_rebinding() {
     let root = TempDir::new().unwrap();
     let access = root.path().join("projects");
     let alpha = access.join("alpha");
@@ -344,6 +358,7 @@ fn missing_bound_project_fails_closed_instead_of_rebinding() {
     let identity = conversation_identity("missing-project-conversation");
     store
         .select_project_root(&config, &identity, "alpha")
+        .await
         .unwrap();
     fs::remove_dir_all(alpha).unwrap();
 
@@ -352,12 +367,13 @@ fn missing_bound_project_fails_closed_instead_of_rebinding() {
 
     let rebind_error = store
         .select_project_root(&config, &identity, "beta")
+        .await
         .unwrap_err();
     assert!(rebind_error.contains("no longer exists"));
 }
 
-#[test]
-fn conversation_binding_is_namespaced_by_access_root_and_hides_the_session_id() {
+#[tokio::test]
+async fn conversation_binding_is_namespaced_by_access_root_and_hides_the_session_id() {
     let root = TempDir::new().unwrap();
     let first_access = root.path().join("first");
     let second_access = root.path().join("second");
@@ -373,6 +389,7 @@ fn conversation_binding_is_namespaced_by_access_root_and_hides_the_session_id() 
 
     store
         .select_project_root(&first_config, &identity, "project")
+        .await
         .unwrap();
     assert!(
         store
@@ -382,6 +399,7 @@ fn conversation_binding_is_namespaced_by_access_root_and_hides_the_session_id() 
     );
     store
         .select_project_root(&second_config, &identity, "project")
+        .await
         .unwrap();
 
     let mut pending = vec![state_dir];

--- a/tests/worktree_selection.rs
+++ b/tests/worktree_selection.rs
@@ -1,0 +1,187 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+use codex_free::config::default_config;
+use codex_free::project_bindings::{ConversationIdentity, ProjectBindingStore};
+use codex_free::types::{AppConfig, WorktreeMode};
+use tempfile::TempDir;
+
+fn git(root: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .expect("git must be installed to run these tests");
+    assert!(
+        output.status.success(),
+        "git {} failed:\nstdout: {}\nstderr: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn repository(root: &TempDir) -> (PathBuf, PathBuf) {
+    let access_root = root.path().join("projects");
+    let project_root = access_root.join("demo");
+    fs::create_dir_all(&project_root).unwrap();
+    fs::write(project_root.join("tracked.txt"), "tracked\n").unwrap();
+    git(&project_root, &["init", "--quiet"]);
+    git(&project_root, &["add", "tracked.txt"]);
+    git(
+        &project_root,
+        &[
+            "-c",
+            "user.email=codex-free@example.invalid",
+            "-c",
+            "user.name=Codex Free Tests",
+            "commit",
+            "--quiet",
+            "-m",
+            "initial",
+        ],
+    );
+    (access_root, project_root)
+}
+
+fn config(root: &TempDir, access_root: PathBuf, mode: WorktreeMode) -> AppConfig {
+    let mut config = default_config(access_root);
+    config.multi_project = true;
+    config.skills.enabled = Some(false);
+    config.worktrees.mode = mode;
+    config.worktrees.root = root.path().join("managed-worktrees");
+    config.worktrees.auto_cleanup_enabled = false;
+    config
+}
+
+fn identity(name: &str) -> ConversationIdentity {
+    ConversationIdentity::from_openai_session(name).unwrap()
+}
+
+#[tokio::test]
+async fn auto_mode_uses_the_source_checkout_once_then_creates_a_worktree() {
+    let root = TempDir::new().unwrap();
+    let (access_root, project_root) = repository(&root);
+    let config = config(&root, access_root, WorktreeMode::Auto);
+    let bindings = root.path().join("bindings");
+    let store = ProjectBindingStore::new(bindings.clone());
+
+    let first = store
+        .select_project_root(&config, &identity("first"), "demo")
+        .await
+        .unwrap();
+    assert!(!first.managed_worktree);
+    assert_eq!(first.project_root, fs::canonicalize(&project_root).unwrap());
+
+    let second_identity = identity("second");
+    let second = store
+        .select_project_root(&config, &second_identity, "demo")
+        .await
+        .unwrap();
+    assert!(second.managed_worktree);
+    assert_ne!(second.project_root, first.project_root);
+    assert_eq!(
+        fs::read_to_string(second.project_root.join("tracked.txt")).unwrap(),
+        "tracked\n"
+    );
+    assert_eq!(
+        second.worktrees_root.as_ref().unwrap(),
+        &fs::canonicalize(&config.worktrees.root).unwrap()
+    );
+    assert_eq!(
+        git(
+            second.worktree_git_root.as_ref().unwrap(),
+            &["rev-parse", "--is-inside-work-tree"]
+        ),
+        "true"
+    );
+
+    let restarted = ProjectBindingStore::new(bindings);
+    assert_eq!(
+        restarted
+            .selected_project_root(&config, &second_identity)
+            .unwrap(),
+        Some(second.project_root)
+    );
+}
+
+#[tokio::test]
+async fn explicit_modes_override_auto_allocation() {
+    let root = TempDir::new().unwrap();
+    let (access_root, project_root) = repository(&root);
+
+    let always = config(&root, access_root.clone(), WorktreeMode::Always);
+    let always_selection = ProjectBindingStore::new(root.path().join("always-bindings"))
+        .select_project_root(&always, &identity("always"), "demo")
+        .await
+        .unwrap();
+    assert!(always_selection.managed_worktree);
+
+    let never = config(&root, access_root, WorktreeMode::Never);
+    let never_store = ProjectBindingStore::new(root.path().join("never-bindings"));
+    let first = never_store
+        .select_project_root(&never, &identity("never-first"), "demo")
+        .await
+        .unwrap();
+    let second = never_store
+        .select_project_root(&never, &identity("never-second"), "demo")
+        .await
+        .unwrap();
+    let canonical_project = fs::canonicalize(project_root).unwrap();
+    assert!(!first.managed_worktree);
+    assert!(!second.managed_worktree);
+    assert_eq!(first.project_root, canonical_project);
+    assert_eq!(second.project_root, canonical_project);
+}
+
+#[tokio::test]
+async fn concurrent_auto_bindings_claim_one_source_checkout_and_one_worktree() {
+    let root = TempDir::new().unwrap();
+    let (access_root, project_root) = repository(&root);
+    let config = config(&root, access_root, WorktreeMode::Auto);
+    let store = ProjectBindingStore::new(root.path().join("bindings"));
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+    let attempts = ["first", "second"].map(|name| {
+        let barrier = barrier.clone();
+        let config = config.clone();
+        let store = store.clone();
+        tokio::spawn(async move {
+            barrier.wait().await;
+            store
+                .select_project_root(&config, &identity(name), "demo")
+                .await
+                .unwrap()
+        })
+    });
+    barrier.wait().await;
+    let [first, second] = attempts;
+    let (first, second) = tokio::join!(first, second);
+    let selections = [first.unwrap(), second.unwrap()];
+
+    assert_eq!(
+        selections
+            .iter()
+            .filter(|selection| selection.managed_worktree)
+            .count(),
+        1
+    );
+    assert_eq!(
+        selections
+            .iter()
+            .filter(|selection| !selection.managed_worktree)
+            .count(),
+        1
+    );
+    assert_eq!(
+        selections
+            .iter()
+            .find(|selection| !selection.managed_worktree)
+            .unwrap()
+            .project_root,
+        fs::canonicalize(project_root).unwrap()
+    );
+}


### PR DESCRIPTION
## Overview

Add managed Git worktrees to multi-project conversation binding so concurrent ChatGPT conversations can work on the same logical project without editing the same checkout.

The default `auto` policy keeps the first conversation on the selected source checkout and creates a detached managed worktree only when another conversation already owns that project. `always` isolates every newly bound conversation, while `never` preserves the previous direct-checkout behavior.

## Behavior

- Serializes project assignment so simultaneous conversations cannot both claim the source checkout.
- Identifies a logical project by its Git common directory and its selected path relative to the repository root, preserving monorepo subdirectories while recognizing linked worktrees as the same repository.
- Persists source-project and managed-worktree metadata in conversation bindings and validates that metadata before restoring a conversation after reconnects or restarts.
- Creates detached worktrees at the selected checkout's current commit and follows Codex-compatible setup behavior for optional upstream refresh, safe Git attribute filters, ignored agent overrides, `.worktreeinclude` files, and local environment setup scripts.
- Cleans up only old, unreferenced, clean managed worktrees; referenced or dirty worktrees are retained.
- Scrubs protected tunnel credentials from Git subprocesses and hooks through the existing child-environment policy.

## Configuration

```json
{
  "multiProject": true,
  "worktrees": {
    "mode": "auto",
    "root": "/path/to/worktrees",
    "upstreamRefreshMode": "never",
    "autoCleanupEnabled": true,
    "keepCount": 15
  }
}
```

CLI overrides are available through `--worktree-mode auto|always|never` and `--worktree-root <path>`.

When explicit worktree settings are absent, Codex Free reads the corresponding Codex Desktop `[desktop]` settings from `$CODEX_HOME/config.toml` and otherwise falls back to `$CODEX_HOME/worktrees`.

## Validation

- `cargo fmt --all --check`
- `git diff --check`
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --all-targets --quiet`

The test suite includes real temporary Git repositories covering default first-versus-later allocation, explicit `always`/`never` policies, concurrent assignment, and restoration of persisted managed-worktree bindings.
