### PR TITLE
fix: preserve resident exec sessions across ChatGPT reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Resident `exec_command` processes now belong to the stable ChatGPT
+  conversation identity instead of the replaceable MCP transport, so a later
+  `write_stdin` call in the same chat can resume or poll the process after a
+  connector reconnect. Generic MCP clients retain transport-owned process
+  cleanup; conversation-owned processes remain bounded by the configured idle
+  timeout and are killed when the server stops.
+
 ## [1.2.0] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ flowchart LR
     WorkDir[("Project root\nper-conversation in\nmulti-project mode")]
     State[("~/.codex-free\nmemory (per project)")]
     Bindings[("~/.codex-free\nconversation-projects")]
+    ExecSessions[("Conversation exec sessions\n(in memory, idle-reaped)")]
     SkillDirs[(".agents/skills\n.codex/skills\n.claude/skills")]
     CodexCfg[("$CODEX_HOME\nconfig.toml")]
     Upstream[("Upstream MCP\nservers (stdio)")]
@@ -67,6 +68,7 @@ flowchart LR
     Mem --> State
     Skills --> SkillDirs
     SetRoot --> Bindings
+    Exec --> ExecSessions
     SetRoot -.->|"selects"| WorkDir
     CodexCfg -.->|"auto-import"| Bridge
     Bridge --> Upstream
@@ -202,6 +204,14 @@ Two deliberate differences from Codex:
 - **`apply_patch` takes a JSON string.** In Codex it is a *freeform* tool whose entire body is the raw patch. MCP has no freeform tools, so the patch goes in an `input` string parameter. The patch format itself is unchanged.
 - **`exec_command` runs with plain pipes, not a PTY.** Codex's own `tty` parameter documents pipes as the default, so ordinary commands behave the same; `tty: true` is rejected rather than silently ignored. Programs that only enable interactive behaviour when attached to a terminal will act as if piped.
 
+For ChatGPT calls carrying `_meta["openai/session"]`, an `exec_command` process
+belongs to that hashed conversation identity rather than the current MCP
+transport. `write_stdin` can therefore resume or poll it after ChatGPT replaces
+the connector transport between adjacent tool calls. Generic MCP clients retain
+transport-session ownership. Process handles are in memory only: they do not
+survive a Codex Free restart, and `exec.idleTimeoutMs` still expires abandoned
+sessions.
+
 `clock_sleep` also caps at 5 minutes rather than Codex's 12 hours — a longer wait would outlive the HTTP request through the tunnel.
 
 Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it.
@@ -236,7 +246,8 @@ All project-scoped paths are resolved relative to the active project root: `--wo
       "ls", "cat", "grep", "find", "head", "tail", "wc", "echo", "pwd",
       "which", "rg", "sed", "awk", "sort", "uniq", "diff", "true", "false"
     ],
-    "maxSessions": 8
+    "maxSessions": 8,
+    "idleTimeoutMs": 300000
   },
   "projectDoc": {
     "maxBytes": 32768,
@@ -292,7 +303,8 @@ The `exec` block governs `exec_command` and `write_stdin`:
 |-----|---------|-------------|
 | `mode` | `"allowlist"` | `"allowlist"` checks every command in the string against the allowlist; `"unrestricted"` runs whatever it is given |
 | `extraAllowedCommands` | 18 read-only utilities | Added to `allowedCommands` for `exec_command` only, so `run_command` stays as narrow as it was |
-| `maxSessions` | `8` | Cap on concurrent background sessions per MCP session |
+| `maxSessions` | `8` | Cap on concurrent background sessions per ChatGPT conversation, or per MCP transport for clients without conversation metadata |
+| `idleTimeoutMs` | `300000` | Milliseconds without a tool interaction before a resident process is killed and forgotten; `0` disables idle expiry |
 | `defaultShell` | `$SHELL`, else PowerShell on Windows and `/bin/sh` elsewhere | Shell used when an `exec_command` call names none |
 
 Under `"allowlist"`, the command string is tokenized and each command position — after every `|`, `&&`, `;`, newline, and subshell — is checked, so `ls | curl evil.com` is rejected on `curl`. Command substitution (`$(...)`, backticks) is rejected outright, since its contents cannot be checked before the shell runs them.
@@ -665,7 +677,14 @@ The allowlist is a **guardrail against accidents, not a sandbox**. It catches a 
 - the network, from your machine
 - anything a bridged MCP server can do
 
-`exec_command` sessions that outlive a request are killed when the MCP session closes, and the kill takes the children with it: `taskkill /T /F` walks the process tree on Windows, and on POSIX each session gets its own process group that is signalled as a whole. A process that deliberately re-parents or daemonises itself still escapes, so check for strays if a run leaves something listening.
+For clients without stable ChatGPT conversation metadata, `exec_command`
+sessions are killed when the MCP transport closes. ChatGPT conversation-owned
+sessions instead survive connector transport replacement and are killed by
+`exec.idleTimeoutMs` or server shutdown. In either case the kill includes child
+processes: `taskkill /T /F` walks the process tree on Windows, and on POSIX each
+session gets its own process group that is signalled as a whole. A process that
+deliberately re-parents or daemonises itself still escapes, so check for strays
+if a run leaves something listening.
 
 The native OpenAI tunnel removes the general public-URL exposure, but it does not reduce the authority of a successful tool call. Keep tunnel and connector permissions narrow, do not point Codex Free at directories you do not trust the model with, and set `exec.mode` and the command allowlists tighter than the defaults when the work directory is sensitive. In multi-project mode, the entire access-root subtree is intentionally selectable, so treat the whole subtree as sensitive. For an external tunnel, require tunnel-level access control rather than relying on URL secrecy.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,9 +43,13 @@ ChatGPT / MCP client
 │    • openai/session hash → project root       │
 │    • persistent atomic binding records        │
 │                                               │
+│  shared ConversationExecSessionStore          │
+│    • openai/session hash → resident commands  │
+│    • in-memory ownership + idle cleanup       │
+│                                               │
 │  per-transport SessionState                   │
 │    • fallback root for generic MCP clients    │
-│    • exec sessions + current plan             │
+│    • generic-client exec sessions + plan      │
 └──────────────────────────────────────────────┘
         │ reads/writes           │ stdio child processes
         ▼                        ▼
@@ -87,9 +91,15 @@ Three surfaces reach the model:
    the transport-session fallback when no conversation identity exists, then
    receive an effective clone of `AppConfig` whose `work_dir` is that root. The
    server fills in default `structuredContent` when appropriate.
-7. When the transport session ends, rmcp drops the `CodexHandler`; its
-   `SessionState::Drop` kills resident `exec_command` shells. The conversation
-   binding remains on disk and is restored by a later transport or server process.
+7. `exec_command` and `write_stdin` opt into resident-process routing. With a
+   ChatGPT conversation identity, dispatch substitutes the shared conversation's
+   exec state while retaining the transport's other mutable state. Without one,
+   the ordinary transport-owned state is used.
+8. When a transport ends, its generic-client exec state loses its last owner and
+   kills resident process trees. Conversation-owned process state remains in the
+   server for later connector calls, subject to idle cleanup; server shutdown
+   drops the shared store and kills anything still running. Project bindings are
+   independently durable across server restarts, but process handles are not.
 
 Cross-cutting HTTP concerns live in the axum layer: a `/health` route, a
 bearer-auth middleware that bypasses `/health`, and—in externally exposed
@@ -113,6 +123,7 @@ trait Tool: Send + Sync {
     fn output_schema(&self) -> Option<Value>;
     fn fills_structured_content(&self) -> bool;         // opt out of default-fill
     fn requires_project_root(&self) -> bool;            // true by default
+    fn uses_exec_session_state(&self) -> bool;          // false by default
     async fn call(&self, args: Value, cfg: &AppConfig, session: &SessionState) -> ToolResult;
 }
 ```
@@ -132,12 +143,18 @@ hash, written atomically under a per-record lock, and validated again on every
 load so a deleted project or changed symlink fails closed. A new store instance
 can recover the same binding after a server restart.
 
-### `SessionState` (`exec_sessions.rs`)
-Per-MCP-transport mutable state: the optional fallback project root used only when
-the client provides no stable ChatGPT conversation identity, the map of resident
-`exec_command` shells, and the current plan. Created fresh by the service factory;
-the fallback root is immutable and `Drop` disposes shells. Live process handles are
-intentionally not persisted across reconnects.
+### `ConversationExecSessionStore` and `SessionState` (`exec_sessions.rs`)
+`SessionState` is the per-MCP-transport view: it owns the optional fallback
+project root for generic clients, the current plan, and a transport-owned exec
+state. The exec state is reference-counted and kills running process trees when
+its last owner disappears.
+
+`ConversationExecSessionStore` is shared by all handlers in the server process.
+For the two unified-exec tools, dispatch uses the hashed `openai/session` identity
+to substitute conversation-owned exec state into a temporary `SessionState`
+view. That state survives replacement transports, is isolated from other
+conversations, and is removed after its sessions finish or expire. It is not
+written to disk and therefore does not survive server restart.
 
 ### `AppConfig` (`types.rs`)
 The fully-resolved config handed to every tool. `config.rs` parses
@@ -161,11 +178,13 @@ server policy and bridge configuration remain shared.
   loopback authorities, omits permissive CORS, and requires a random
   process-private bearer token generated at startup.
 - **Session model**: the factory runs per MCP transport session. `SessionState`
-  therefore owns only transport-lifetime resources such as resident commands and
-  the generic-client root fallback. ChatGPT project identity is taken from
-  `RequestContext::meta["openai/session"]` and resolved through the shared,
-  persistent `ProjectBindingStore`. Upstream MCP connections, the binding store,
-  and the tool registry are shared (`Arc`) across transports.
+  owns the generic-client root fallback, current plan, and generic-client
+  resident commands. ChatGPT identity is taken from
+  `RequestContext::meta["openai/session"]`: the persistent
+  `ProjectBindingStore` resolves its project, while the in-memory
+  `ConversationExecSessionStore` resolves resident commands across replacement
+  transports. Upstream MCP connections, both stores, and the tool registry are
+  shared (`Arc`) across transports.
 - **`get_info`** advertises server name `codex-free` (wire-compatible identity),
   version, `tools` capability, and the `instructions`.
 - **Errors**: a tool that fails returns `Ok(CallToolResult::error(...))`
@@ -239,7 +258,7 @@ the original order and rejects duplicate names.
 | `ignore_rules.rs` | One `.gitignore`-accurate matcher (the `ignore` crate) shared by glob/grep/tree/list_directory. |
 | `exec_policy.rs` | Shell-string allowlist guard for `exec_command` (a guardrail, not a sandbox). |
 | `project_bindings.rs` | Canonical project-root validation plus durable ChatGPT conversation bindings keyed by a hash of `openai/session`, namespaced by access root, locked per record, and atomically written. |
-| `exec_sessions.rs` | Generic-client transport fallback plus unified-exec sessions: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, output truncation (UTF-16 units to match the TS). |
+| `exec_sessions.rs` | Generic-client transport fallback plus conversation-owned unified-exec sessions: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, idle cleanup, and output truncation (UTF-16 units to match the TS). |
 | `apply_patch.rs` | The Codex patch format: parse then apply, atomically, with fuzzy context matching and CRLF preservation. |
 | `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized active root, with `O_EXCL` locking and atomic writes. In multi-project mode, a configured `memory.dir` is a base containing one hashed child per project. |
 | `openai_tunnel.rs` | Verified installation and lifecycle supervision for OpenAI's outbound Secure MCP Tunnel runtime. |

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -17,7 +17,9 @@ use tokio::process::{ChildStdin, Command};
 use tokio::sync::{Mutex as TokioMutex, Notify};
 
 use crate::process_env::scrub_untrusted_child_env;
-use crate::project_bindings::{ProjectBindingScope, ProjectRootSelection, resolve_project_root};
+use crate::project_bindings::{
+    ConversationIdentity, ProjectBindingScope, ProjectRootSelection, resolve_project_root,
+};
 use crate::types::{AppConfig, PlanState};
 
 // Codex constants (shell_spec.rs). Kept as code, not config, because they are
@@ -328,25 +330,198 @@ impl ExecSession {
     }
 }
 
-/// Per-MCP-transport mutable state. A fresh instance is created for every MCP
-/// transport session so concurrent transports never share exec sessions or
-/// in-memory plans.
-/// Project-root state here is the fallback for clients without a durable
-/// conversation identifier.
+/// The resident-process portion of a session. Keeping this behind an `Arc`
+/// separates process lifetime from the lightweight per-call [`SessionState`]
+/// view used by tools. The last owner kills any still-running process trees.
+struct ExecSessionState {
+    sessions: StdMutex<HashMap<u64, Arc<ExecSession>>>,
+    next_id: AtomicU64,
+}
+
+impl ExecSessionState {
+    fn new() -> Self {
+        Self {
+            sessions: StdMutex::new(HashMap::new()),
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    fn session(&self, id: u64) -> Option<Arc<ExecSession>> {
+        self.sessions.lock().unwrap().get(&id).cloned()
+    }
+
+    fn session_ids(&self) -> Vec<u64> {
+        let mut ids = self
+            .sessions
+            .lock()
+            .unwrap()
+            .keys()
+            .copied()
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        ids
+    }
+
+    fn remove(&self, id: u64) -> Option<Arc<ExecSession>> {
+        self.sessions.lock().unwrap().remove(&id)
+    }
+
+    fn len(&self) -> usize {
+        self.sessions.lock().unwrap().len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.sessions.lock().unwrap().is_empty()
+    }
+
+    fn next_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn insert(&self, session: Arc<ExecSession>) {
+        self.sessions.lock().unwrap().insert(session.id, session);
+    }
+
+    fn reap(&self, idle_timeout: Duration) -> Vec<Arc<ExecSession>> {
+        reap_sessions(&mut self.sessions.lock().unwrap(), idle_timeout)
+    }
+
+    /// Starts a transport-owned reaper. It holds only a weak reference, so it
+    /// exits when the transport's last [`SessionState`] view is dropped.
+    fn spawn_idle_reaper(self: &Arc<Self>, idle_timeout: Duration) {
+        if idle_timeout.is_zero() || tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let weak = Arc::downgrade(self);
+        let interval = reaper_interval(idle_timeout);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let Some(state) = weak.upgrade() else {
+                    break;
+                };
+                for session in state.reap(idle_timeout) {
+                    kill_exec_session(&session);
+                }
+            }
+        });
+    }
+}
+
+impl Drop for ExecSessionState {
+    fn drop(&mut self) {
+        if let Ok(sessions) = self.sessions.lock() {
+            for session in sessions.values() {
+                if session.exit_code().is_none() {
+                    kill_pid(session.pid);
+                }
+            }
+        }
+    }
+}
+
+type ConversationExecStates = HashMap<ConversationIdentity, Arc<ExecSessionState>>;
+
+/// Server-process ownership for ChatGPT resident commands. ChatGPT can replace
+/// its MCP transport between adjacent tool calls while retaining the same
+/// `_meta["openai/session"]`; this store makes that stable identity, rather than
+/// the transient transport, own `exec_command` sessions.
+#[derive(Default)]
+pub struct ConversationExecSessionStore {
+    states: Arc<StdMutex<ConversationExecStates>>,
+}
+
+impl ConversationExecSessionStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Return a tool-call view that shares the transport's non-exec state but
+    /// substitutes the resident-process state owned by this conversation.
+    pub fn session_for(
+        &self,
+        identity: &ConversationIdentity,
+        transport_session: &SessionState,
+    ) -> SessionState {
+        let exec = self
+            .states
+            .lock()
+            .unwrap()
+            .entry(identity.clone())
+            .or_insert_with(|| Arc::new(ExecSessionState::new()))
+            .clone();
+        transport_session.with_exec_state(exec)
+    }
+
+    /// Reap inactive conversation-owned processes and discard empty ownership
+    /// records. Unlike transport state, this task persists across MCP reconnects
+    /// and stops only when the server drops the store.
+    pub fn spawn_idle_reaper(&self, idle_timeout: Duration) {
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let weak = Arc::downgrade(&self.states);
+        let interval = if idle_timeout.is_zero() {
+            Duration::from_secs(30)
+        } else {
+            reaper_interval(idle_timeout)
+        };
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let Some(states) = weak.upgrade() else {
+                    break;
+                };
+                let killed = reap_conversation_states(&states, idle_timeout);
+                for session in killed {
+                    kill_exec_session(&session);
+                }
+            }
+        });
+    }
+}
+
+fn reaper_interval(idle_timeout: Duration) -> Duration {
+    idle_timeout
+        .min(Duration::from_secs(30))
+        .max(Duration::from_secs(1))
+}
+
+fn reap_conversation_states(
+    states: &StdMutex<ConversationExecStates>,
+    idle_timeout: Duration,
+) -> Vec<Arc<ExecSession>> {
+    let mut killed = Vec::new();
+    let mut states = states.lock().unwrap();
+    states.retain(|_, state| {
+        killed.extend(state.reap(idle_timeout));
+        // A concurrent tool call owns another Arc. Keep the map entry until that
+        // call finishes so it cannot publish a session into a detached state.
+        !(state.is_empty() && Arc::strong_count(state) == 1)
+    });
+    killed
+}
+
+/// Per-MCP-transport mutable state. The fallback project root and current plan
+/// remain transport-scoped. Resident commands use this transport-owned exec
+/// state for generic MCP clients, while ChatGPT calls receive a temporary view
+/// backed by [`ConversationExecSessionStore`].
 pub struct SessionState {
-    pub exec_sessions: Arc<StdMutex<HashMap<u64, Arc<ExecSession>>>>,
-    next_exec_id: AtomicU64,
-    pub plan: StdMutex<Option<PlanState>>,
-    project_root: StdMutex<Option<PathBuf>>,
+    exec: Arc<ExecSessionState>,
+    pub plan: Arc<StdMutex<Option<PlanState>>>,
+    project_root: Arc<StdMutex<Option<PathBuf>>>,
 }
 
 impl Default for SessionState {
     fn default() -> Self {
         Self {
-            exec_sessions: Arc::new(StdMutex::new(HashMap::new())),
-            next_exec_id: AtomicU64::new(1),
-            plan: StdMutex::new(None),
-            project_root: StdMutex::new(None),
+            exec: Arc::new(ExecSessionState::new()),
+            plan: Arc::new(StdMutex::new(None)),
+            project_root: Arc::new(StdMutex::new(None)),
         }
     }
 }
@@ -356,40 +531,37 @@ impl SessionState {
         Self::default()
     }
 
-    /// Starts a background task that kills and reaps exec sessions idle beyond
-    /// `idle_timeout`. The task holds only a weak reference to the session map,
-    /// so it exits on its own once this `SessionState` is dropped (the MCP
-    /// transport closed). A zero timeout, or the absence of a Tokio runtime
-    /// (as in unit tests), is a no-op.
-    pub fn spawn_idle_reaper(&self, idle_timeout: Duration) {
-        if idle_timeout.is_zero() || tokio::runtime::Handle::try_current().is_err() {
-            return;
+    fn with_exec_state(&self, exec: Arc<ExecSessionState>) -> Self {
+        Self {
+            exec,
+            plan: self.plan.clone(),
+            project_root: self.project_root.clone(),
         }
-        let weak = Arc::downgrade(&self.exec_sessions);
-        // Check often enough to enforce the timeout promptly, but never busier
-        // than once a second nor rarer than every 30s.
-        let interval = idle_timeout
-            .min(Duration::from_secs(30))
-            .max(Duration::from_secs(1));
-        tokio::spawn(async move {
-            let mut ticker = tokio::time::interval(interval);
-            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-            loop {
-                ticker.tick().await;
-                let Some(map) = weak.upgrade() else {
-                    break; // SessionState dropped — nothing left to reap.
-                };
-                // Kill outside the lock: terminating a process can block
-                // (Windows `taskkill`), and other tools take this same lock.
-                let killed = {
-                    let mut guard = map.lock().unwrap();
-                    reap_sessions(&mut guard, idle_timeout)
-                };
-                for session in killed {
-                    kill_exec_session(&session);
-                }
-            }
-        });
+    }
+
+    /// Starts cleanup for generic-client, transport-owned resident commands.
+    pub fn spawn_idle_reaper(&self, idle_timeout: Duration) {
+        self.exec.spawn_idle_reaper(idle_timeout);
+    }
+
+    pub fn exec_session(&self, id: u64) -> Option<Arc<ExecSession>> {
+        self.exec.session(id)
+    }
+
+    pub fn exec_session_ids(&self) -> Vec<u64> {
+        self.exec.session_ids()
+    }
+
+    pub fn remove_exec_session(&self, id: u64) -> Option<Arc<ExecSession>> {
+        self.exec.remove(id)
+    }
+
+    fn exec_session_count(&self) -> usize {
+        self.exec.len()
+    }
+
+    fn reap_exec_sessions(&self, idle_timeout: Duration) -> Vec<Arc<ExecSession>> {
+        self.exec.reap(idle_timeout)
     }
 
     pub fn effective_config(&self, config: &AppConfig) -> Result<AppConfig, String> {
@@ -453,22 +625,10 @@ impl SessionState {
     }
 }
 
-impl Drop for SessionState {
-    fn drop(&mut self) {
-        // Kill any exec_command processes still resident so a disconnecting
-        // client cannot leave orphaned shells behind (TS `transport.onclose`).
-        if let Ok(map) = self.exec_sessions.lock() {
-            for session in map.values() {
-                kill_pid(session.pid);
-            }
-        }
-    }
-}
-
 /// Removes finished-and-empty sessions and, when `idle_timeout` is non-zero,
-/// selects sessions idle beyond it for termination. Returns the idle sessions
-/// removed so the caller can kill them without holding the map lock (killing
-/// can block, e.g. Windows `taskkill`). Finished sessions need no kill.
+/// removes every session idle beyond it. Running idle sessions are returned so
+/// the caller can kill them without holding the map lock; completed sessions
+/// whose final output was never polled are simply expired.
 fn reap_sessions(
     map: &mut HashMap<u64, Arc<ExecSession>>,
     idle_timeout: Duration,
@@ -478,8 +638,10 @@ fn reap_sessions(
         if s.exit_code().is_some() && s.pending.lock().unwrap().is_empty() {
             return false;
         }
-        if !idle_timeout.is_zero() && s.exit_code().is_none() && s.idle_for() >= idle_timeout {
-            killed.push(s.clone());
+        if !idle_timeout.is_zero() && s.idle_for() >= idle_timeout {
+            if s.exit_code().is_none() {
+                killed.push(s.clone());
+            }
             return false;
         }
         true
@@ -491,8 +653,7 @@ fn reap_sessions(
 /// Idle enforcement is the background reaper's job (see `spawn_idle_reaper`),
 /// so this opportunistic pass never kills a running session.
 pub fn reap_finished_sessions(state: &SessionState) {
-    let mut map = state.exec_sessions.lock().unwrap();
-    let _ = reap_sessions(&mut map, Duration::ZERO);
+    let _ = state.reap_exec_sessions(Duration::ZERO);
 }
 
 /// Spawns `cmd` through a shell and registers it as a resident session. The
@@ -506,7 +667,7 @@ pub fn start_exec_session(
 ) -> Result<Arc<ExecSession>, String> {
     reap_finished_sessions(state);
     {
-        let live = state.exec_sessions.lock().unwrap().len();
+        let live = state.exec_session_count();
         if live >= config.exec.max_sessions {
             return Err(format!(
                 "Too many live exec sessions ({}). Finish or terminate an existing session before starting another.",
@@ -582,7 +743,7 @@ pub fn start_exec_session(
         *exit_for_waiter.lock().unwrap() = Some(code);
     });
 
-    let id = state.next_exec_id.fetch_add(1, Ordering::SeqCst);
+    let id = state.exec.next_id();
     let session = Arc::new(ExecSession {
         id,
         command: cmd.to_string(),
@@ -595,11 +756,7 @@ pub fn start_exec_session(
         last_activity: StdMutex::new(Instant::now()),
     });
 
-    state
-        .exec_sessions
-        .lock()
-        .unwrap()
-        .insert(id, session.clone());
+    state.exec.insert(session.clone());
     Ok(session)
 }
 
@@ -656,7 +813,9 @@ pub fn kill_pid(pid: Option<u32>) {
 
 /// Kills a session's process tree.
 pub fn kill_exec_session(session: &ExecSession) {
-    kill_pid(session.pid);
+    if session.exit_code().is_none() {
+        kill_pid(session.pid);
+    }
 }
 
 static CHUNK_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -669,6 +828,11 @@ pub fn generate_chunk_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tool::Tool;
+    use crate::tools::exec_command::ExecCommand;
+    use crate::tools::write_stdin::WriteStdin;
+    use crate::types::ExecMode;
+    use serde_json::json;
 
     #[test]
     fn classifies_shells() {
@@ -764,6 +928,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn conversation_owned_exec_session_survives_replacement_transport() {
+        let dir = std::env::temp_dir();
+        let mut config = crate::config::default_config(dir.clone());
+        config.exec.mode = ExecMode::Unrestricted;
+        let store = ConversationExecSessionStore::new();
+        let identity =
+            ConversationIdentity::from_openai_session("conversation-resident-process").unwrap();
+
+        let first_transport = SessionState::new();
+        let first_call = store.session_for(&identity, &first_transport);
+        let started = ExecCommand
+            .call(
+                json!({
+                    "cmd": resident_sleep_command(),
+                    "yield_time_ms": EXEC_MIN_YIELD_MS
+                }),
+                &config,
+                &first_call,
+            )
+            .await;
+        assert!(!started.is_error, "{}", started.joined_text());
+        let session_id = started
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("session_id"))
+            .and_then(serde_json::Value::as_u64)
+            .expect("resident command should return a session id");
+        let resident = first_call.exec_session(session_id).unwrap();
+
+        drop(first_call);
+        drop(first_transport);
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(resident.exit_code().is_none());
+
+        let replacement_transport = SessionState::new();
+        let replacement_call = store.session_for(&identity, &replacement_transport);
+        let resumed = WriteStdin
+            .call(
+                json!({
+                    "session_id": session_id,
+                    "chars": "x",
+                    "yield_time_ms": 1
+                }),
+                &config,
+                &replacement_call,
+            )
+            .await;
+        assert!(!resumed.is_error, "{}", resumed.joined_text());
+        assert_eq!(
+            resumed
+                .structured_content
+                .as_ref()
+                .and_then(|value| value.get("session_id"))
+                .and_then(serde_json::Value::as_u64),
+            Some(session_id)
+        );
+
+        replacement_call.remove_exec_session(session_id);
+        kill_exec_session(&resident);
+    }
+
+    #[test]
+    fn conversation_exec_states_are_isolated_and_empty_states_are_reclaimed() {
+        let store = ConversationExecSessionStore::new();
+        let transport = SessionState::new();
+        let first = ConversationIdentity::from_openai_session("first-conversation").unwrap();
+        let second = ConversationIdentity::from_openai_session("second-conversation").unwrap();
+
+        let first_call = store.session_for(&first, &transport);
+        let second_call = store.session_for(&second, &transport);
+        assert!(!Arc::ptr_eq(&first_call.exec, &second_call.exec));
+        assert_eq!(store.states.lock().unwrap().len(), 2);
+
+        assert!(reap_conversation_states(&store.states, Duration::ZERO).is_empty());
+        assert_eq!(store.states.lock().unwrap().len(), 2);
+
+        drop(first_call);
+        drop(second_call);
+        assert!(reap_conversation_states(&store.states, Duration::ZERO).is_empty());
+        assert!(store.states.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn reap_sessions_only_kills_running_sessions_past_the_idle_timeout() {
         let dir = std::env::temp_dir();
         let config = crate::config::default_config(dir.clone());
@@ -771,32 +1018,27 @@ mod tests {
         let session =
             start_exec_session(&state, &config, &resident_sleep_command(), &dir, None).unwrap();
         assert!(session.exit_code().is_none());
-        assert_eq!(state.exec_sessions.lock().unwrap().len(), 1);
+        assert_eq!(state.exec_session_count(), 1);
 
         // Disabled (0) never touches a running session.
-        {
-            let mut map = state.exec_sessions.lock().unwrap();
-            assert!(reap_sessions(&mut map, Duration::ZERO).is_empty());
-            assert_eq!(map.len(), 1);
-        }
+        assert!(state.reap_exec_sessions(Duration::ZERO).is_empty());
+        assert_eq!(state.exec_session_count(), 1);
         // Still well within a generous timeout.
-        {
-            let mut map = state.exec_sessions.lock().unwrap();
-            assert!(reap_sessions(&mut map, Duration::from_secs(3600)).is_empty());
-            assert_eq!(map.len(), 1);
-        }
+        assert!(
+            state
+                .reap_exec_sessions(Duration::from_secs(3600))
+                .is_empty()
+        );
+        assert_eq!(state.exec_session_count(), 1);
 
         // Once idle past a tiny timeout, it is selected, killed and removed.
         tokio::time::sleep(Duration::from_millis(80)).await;
-        let killed = {
-            let mut map = state.exec_sessions.lock().unwrap();
-            reap_sessions(&mut map, Duration::from_millis(50))
-        };
+        let killed = state.reap_exec_sessions(Duration::from_millis(50));
         assert_eq!(killed.len(), 1);
         for session in &killed {
             kill_exec_session(session);
         }
-        assert!(state.exec_sessions.lock().unwrap().is_empty());
+        assert_eq!(state.exec_session_count(), 0);
     }
 
     #[tokio::test]
@@ -809,11 +1051,11 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(80)).await;
         session.touch(); // a fresh write_stdin/yield would do this
-        {
-            let mut map = state.exec_sessions.lock().unwrap();
-            // Idle clock reset, so a 50ms timeout must not reap it.
-            assert!(reap_sessions(&mut map, Duration::from_millis(50)).is_empty());
-        }
+        assert!(
+            state
+                .reap_exec_sessions(Duration::from_millis(50))
+                .is_empty()
+        );
         kill_exec_session(&session);
     }
 
@@ -833,7 +1075,7 @@ mod tests {
         let mut reaped = false;
         for _ in 0..40 {
             tokio::time::sleep(Duration::from_millis(100)).await;
-            if state.exec_sessions.lock().unwrap().is_empty() {
+            if state.exec_session_count() == 0 {
                 reaped = true;
                 break;
             }

--- a/src/project_bindings.rs
+++ b/src/project_bindings.rs
@@ -21,7 +21,7 @@ const LOCK_RETRY_MS: u64 = 20;
 
 static ATOMIC_COUNTER: AtomicU64 = AtomicU64::new(0);
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ConversationIdentity {
     key: String,
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,10 +2,9 @@
 //! the axum wiring (`/mcp` Streamable HTTP, `/health`, CORS, bearer auth).
 //!
 //! Ports `src/server.ts`. rmcp's `StreamableHttpService` owns the transport and
-//! MCP session lifecycle: the service factory runs once per transport session,
-//! so a fresh [`SessionState`] owns resident exec processes and drops them when
-//! that session ends. ChatGPT project selection is stored separately by its
-//! stable conversation metadata and survives transport replacement.
+//! MCP session lifecycle. Generic clients keep resident commands in their
+//! transport [`SessionState`], while ChatGPT's stable conversation metadata
+//! selects server-owned command state that survives transport replacement.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -28,7 +27,7 @@ use tokio_util::sync::CancellationToken;
 use tower_http::cors::{Any, CorsLayer};
 
 use crate::auth::{generate_internal_bearer_token, require_auth};
-use crate::exec_sessions::SessionState;
+use crate::exec_sessions::{ConversationExecSessionStore, SessionState};
 use crate::instructions::build_initial_instructions;
 use crate::openai_tunnel::TunnelHealth;
 use crate::project_bindings::{ConversationIdentity, ProjectBindingStore};
@@ -62,6 +61,7 @@ pub struct CodexHandler {
     config: Arc<AppConfig>,
     tools: Arc<Vec<Box<dyn Tool>>>,
     project_bindings: Arc<ProjectBindingStore>,
+    conversation_exec_sessions: Arc<ConversationExecSessionStore>,
     session: SessionState,
 }
 
@@ -135,6 +135,16 @@ impl ServerHandler for CodexHandler {
             return Ok(result.into());
         };
 
+        let conversation_exec_session = if tool.uses_exec_session_state() {
+            conversation.as_ref().map(|identity| {
+                self.conversation_exec_sessions
+                    .session_for(identity, &self.session)
+            })
+        } else {
+            None
+        };
+        let session = conversation_exec_session.as_ref().unwrap_or(&self.session);
+
         let mut result = if name == SetProjectRoot::NAME {
             if let Some(identity) = conversation.as_ref() {
                 select_and_render(&args, |path| {
@@ -142,7 +152,7 @@ impl ServerHandler for CodexHandler {
                         .select_project_root(&self.config, identity, path)
                 })
             } else {
-                tool.call(args, &self.config, &self.session).await
+                tool.call(args, &self.config, session).await
             }
         } else {
             let effective_config = if tool.requires_project_root() {
@@ -150,7 +160,7 @@ impl ServerHandler for CodexHandler {
                     Some(identity) => self
                         .project_bindings
                         .effective_config(&self.config, identity),
-                    None => self.session.effective_config(&self.config),
+                    None => session.effective_config(&self.config),
                 };
                 match resolved {
                     Ok(config) => Some(config),
@@ -166,7 +176,7 @@ impl ServerHandler for CodexHandler {
             let call_config = effective_config
                 .as_ref()
                 .unwrap_or_else(|| self.config.as_ref());
-            tool.call(args, call_config, &self.session).await
+            tool.call(args, call_config, session).await
         };
 
         // Fill in the `structuredContent` the MCP spec expects from any tool that
@@ -212,6 +222,9 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     config.generated_skills_dir = Some(gen_dir);
     let config = Arc::new(config);
     let project_bindings = Arc::new(ProjectBindingStore::for_current_user());
+    let conversation_exec_sessions = Arc::new(ConversationExecSessionStore::new());
+    conversation_exec_sessions
+        .spawn_idle_reaper(Duration::from_millis(config.exec.idle_timeout_ms));
 
     // Connect to any configured upstream MCP servers and merge their tools in.
     // The returned services must stay alive for the whole server lifetime, so
@@ -259,6 +272,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     let factory_config = config.clone();
     let factory_tools = tools.clone();
     let factory_project_bindings = project_bindings.clone();
+    let factory_conversation_exec_sessions = conversation_exec_sessions.clone();
     let service = StreamableHttpService::new(
         move || {
             let session = SessionState::new();
@@ -267,6 +281,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
                 config: factory_config.clone(),
                 tools: factory_tools.clone(),
                 project_bindings: factory_project_bindings.clone(),
+                conversation_exec_sessions: factory_conversation_exec_sessions.clone(),
                 session,
             })
         },

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -49,6 +49,13 @@ pub trait Tool: Send + Sync {
         true
     }
 
+    /// Whether resident command state should follow a stable ChatGPT conversation
+    /// across replacement MCP transports. Only the unified exec pair opts in;
+    /// other mutable tool state retains transport-session ownership.
+    fn uses_exec_session_state(&self) -> bool {
+        false
+    }
+
     /// Run the tool. `args` is the arguments object (or `Value::Null` when the
     /// call named none).
     async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult;

--- a/src/tools/exec_command.rs
+++ b/src/tools/exec_command.rs
@@ -107,6 +107,10 @@ impl Tool for ExecCommand {
         Some(unified_exec_output_schema())
     }
 
+    fn uses_exec_session_state(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult {
         let cmd = arg_str(&args, "cmd").unwrap_or("");
         if cmd.trim().is_empty() {
@@ -172,11 +176,7 @@ impl Tool for ExecCommand {
         let is_error = if exited {
             let code = exec_session.exit_code();
             result.exit_code = code;
-            session
-                .exec_sessions
-                .lock()
-                .unwrap()
-                .remove(&exec_session.id);
+            session.remove_exec_session(exec_session.id);
             code.unwrap_or(0) != 0
         } else {
             result.session_id = Some(exec_session.id);

--- a/src/tools/write_stdin.rs
+++ b/src/tools/write_stdin.rs
@@ -40,21 +40,20 @@ impl Tool for WriteStdin {
         Some(unified_exec_output_schema())
     }
 
+    fn uses_exec_session_state(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, _config: &AppConfig, session: &SessionState) -> ToolResult {
         let Some(session_id) = arg_u64(&args, "session_id") else {
             return ToolResult::error("session_id must be a number");
         };
 
-        let exec_session = {
-            let map = session.exec_sessions.lock().unwrap();
-            map.get(&session_id).cloned()
-        };
+        let exec_session = session.exec_session(session_id);
         let Some(exec_session) = exec_session else {
             let live: Vec<String> = session
-                .exec_sessions
-                .lock()
-                .unwrap()
-                .keys()
+                .exec_session_ids()
+                .into_iter()
                 .map(|k| k.to_string())
                 .collect();
             let suffix = if live.is_empty() {
@@ -112,7 +111,7 @@ impl Tool for WriteStdin {
         let is_error = if exited {
             let code = exec_session.exit_code();
             result.exit_code = code;
-            session.exec_sessions.lock().unwrap().remove(&session_id);
+            session.remove_exec_session(session_id);
             code.unwrap_or(0) != 0
         } else {
             result.session_id = Some(session_id);


### PR DESCRIPTION
## Overview

ChatGPT can replace its Streamable HTTP MCP transport between adjacent tool calls while preserving the stable `_meta["openai/session"]` conversation identity. Codex Free previously stored resident `exec_command` processes inside the transport-scoped `SessionState`, whose drop handler killed them. As a result, `exec_command` could return a `session_id`, but the next `write_stdin` call from the same ChatGPT conversation would report that the session no longer existed.

This changes resident process ownership for ChatGPT from the replaceable MCP transport to the stable conversation identity.

## Behavior

- Add a server-owned in-memory `ConversationExecSessionStore`, keyed by the hashed `openai/session` identity already used for project bindings.
- Route only `exec_command` and `write_stdin` through conversation-owned process state; other mutable tool state remains transport-scoped.
- Preserve per-conversation isolation and the configured `exec.maxSessions` limit.
- Keep generic MCP clients without stable ChatGPT metadata transport-scoped, including process cleanup when their transport closes.
- Continue enforcing `exec.idleTimeoutMs` for both ownership modes; abandoned running processes are killed, completed sessions with uncollected output expire, and empty conversation records are reclaimed.
- Kill any remaining conversation-owned process trees when the Codex Free server stops.
- Keep process state intentionally in memory only; resident commands do not survive a Codex Free restart.
- Update the README, architecture documentation, and changelog to describe the revised lifecycle.

## Tests

- Added an end-to-end tool-level regression test that starts a resident command through `exec_command`, drops the original transport state, creates a replacement transport for the same ChatGPT conversation, and resumes the process through `write_stdin`.
- Added coverage for conversation isolation and empty ownership-record reclamation.

Validation:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — 394 tests passed
- `git diff --check`
