### PR TITLE
feat: bridge Streamable HTTP MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Upstream MCP Streamable HTTP support alongside stdio. Codex Free now imports
+  compatible `url` entries from Codex configuration and accepts remote entries in
+  `codex.config.json`, including bearer-token environment variables, static and
+  environment-backed HTTP headers, startup timeouts, per-tool cancellable
+  timeouts, the existing tool filters, and gateway mode.
+
+### Security
+
+- Remote bearer tokens and environment-backed headers are resolved only when the
+  upstream connection is created and are never included in discovery reports.
+  Configured tool-call timeouts use RMCP cancellation rather than abandoning an
+  in-flight request. Legacy SSE/WebSocket transports, literal Codex
+  `bearer_token` values, mixed stdio/HTTP settings, and ambiguous duplicate
+  Authorization configuration are rejected explicitly.
+
 ## [1.2.0] - 2026-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,29 +115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -245,8 +222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -326,15 +301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "codex-free"
 version = "1.2.0"
 dependencies = [
@@ -352,6 +318,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rmcp",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -531,12 +498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,12 +549,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1080,16 +1035,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
-dependencies = [
- "getrandom 0.4.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,12 +1228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
-
-[[package]]
 name = "potential_utf"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,7 +1285,6 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
- "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -1534,7 +1472,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -1649,7 +1586,6 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1713,7 +1649,6 @@ version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +245,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -301,6 +326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codex-free"
 version = "1.2.0"
 dependencies = [
@@ -316,7 +350,7 @@ dependencies = [
  "ignore",
  "libc",
  "regex",
- "reqwest",
+ "reqwest 0.12.28",
  "rmcp",
  "serde",
  "serde_json",
@@ -341,6 +375,26 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -477,6 +531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +588,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -965,6 +1031,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,6 +1236,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1281,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "potential_utf"
@@ -1209,6 +1346,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -1377,6 +1515,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1587,7 @@ dependencies = [
  "pin-project-lite",
  "process-wrap",
  "rand",
+ "reqwest 0.13.4",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -1443,6 +1622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,12 +1649,25 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1480,11 +1681,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1509,6 +1738,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1542,6 +1780,35 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1683,6 +1950,22 @@ name = "simd-adler32"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2214,6 +2497,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2527,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "codex-free"
 path = "src/main.rs"
 
 [dependencies]
-rmcp = { version = "3.1.3", features = ["client", "reqwest", "server", "transport-child-process", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
+rmcp = { version = "3.1.3", features = ["client", "reqwest-tls-no-provider", "server", "transport-child-process", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
 tokio = { version = "1", features = ["full"] }
 axum = "0.8"
 tower = "0.5"
@@ -34,6 +34,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 async-trait = "0.1.92"
 toml = "1.1.4"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tempfile = "3"
 zip = { version = "4", default-features = false, features = ["deflate"] }
 getrandom = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "codex-free"
 path = "src/main.rs"
 
 [dependencies]
-rmcp = { version = "3.1.3", features = ["client", "server", "transport-child-process", "transport-streamable-http-server"] }
+rmcp = { version = "3.1.3", features = ["client", "reqwest", "server", "transport-child-process", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
 tokio = { version = "1", features = ["full"] }
 axum = "0.8"
 tower = "0.5"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In native-tunnel mode, Codex Free listens only on `127.0.0.1`, protects the MCP 
 
 The tool set covers the ones [Codex](https://github.com/openai/codex) gives its own agent — `apply_patch`, `exec_command`/`write_stdin`, `view_image`, `update_plan`, `clock_curr_time`/`clock_sleep` — so ChatGPT Web can work the way Codex does: patch files in place instead of rewriting them, drive interactive and long-running processes, and keep a plan across a task. It carries the project's `AGENTS.md` and Codex's own agent brief, so the client is told how to behave and not just what it can call. It bounds what a tool call can return and keeps a plan and notes on disk across conversations, addressing the one thing Codex never had to solve — a context window far smaller than the task. And it loads Codex's skills: a `SKILL.md` in the repo or your home directory teaches the client how *you* do a recurring task, and only the ones that apply are ever read. Schemas and prompt are ported from the Codex source, not reimplemented from guesswork.
 
-Beyond the port, Codex Free can **aggregate other MCP servers** — connecting to your local stdio MCP servers and re-exposing their tools through its own endpoint, so the ChatGPT-side agent can call them too.
+Beyond the port, Codex Free can **aggregate other MCP servers** — connecting to local stdio servers or remote Streamable HTTP endpoints and re-exposing their tools through its own endpoint, so the ChatGPT-side agent can call them too.
 
 ## Architecture
 
@@ -37,7 +37,7 @@ flowchart LR
     Bindings[("~/.codex-free\nconversation-projects")]
     SkillDirs[(".agents/skills\n.codex/skills\n.claude/skills")]
     CodexCfg[("$CODEX_HOME\nconfig.toml")]
-    Upstream[("Upstream MCP\nservers (stdio)")]
+    Upstream[("Upstream MCP servers\nstdio / Streamable HTTP")]
 
     ChatGPT <-->|"connector calls"| OpenAITunnel
     TunnelClient <-->|"outbound HTTPS"| OpenAITunnel
@@ -72,7 +72,7 @@ flowchart LR
     Bridge --> Upstream
 ```
 
-Dotted edges are conditional: `set_project_root` appears only in [multi-project mode](#multi-project-mode) and binds this conversation's project root, and the aggregator [auto-imports](#automatic-discovery-from-codex) the stdio MCP servers configured in Codex's own `config.toml` on top of any declared in `codex.config.json`.
+Dotted edges are conditional: `set_project_root` appears only in [multi-project mode](#multi-project-mode) and binds this conversation's project root, and the aggregator [auto-imports](#automatic-discovery-from-codex) compatible stdio and Streamable HTTP MCP servers configured in Codex's own `config.toml` on top of any declared in `codex.config.json`.
 
 ## Quick start
 
@@ -515,7 +515,7 @@ Discovery runs per MCP session, so adding a skill takes effect on the next conne
 
 ## Bridging other MCP servers
 
-Codex Free can also act as an **MCP aggregator**: it connects to your other local MCP servers as a client, discovers their tools at startup, and re-exposes them through its own `/mcp` endpoint — so the ChatGPT-side agent sees and can call them too.
+Codex Free can also act as an **MCP aggregator**: it connects to local stdio or remote Streamable HTTP MCP servers as a client, discovers their tools at startup, and re-exposes them through its own `/mcp` endpoint — so the ChatGPT-side agent sees and can call them too.
 
 ### Automatic discovery from Codex
 
@@ -525,10 +525,13 @@ For each `[mcp_servers.<name>]` entry, Codex Free imports the fields it can pres
 
 - `command`, `args`, `env` and `cwd` for local stdio launch;
 - local `env_vars`, resolved from Codex Free's process environment;
+- `url` for Streamable HTTP;
+- `bearer_token_env_var`, `http_headers`, and `env_http_headers` for HTTP authentication and request headers;
+- `startup_timeout_sec` (or legacy `startup_timeout_ms`) and `tool_timeout_sec`;
 - `enabled = false` as a disabled upstream;
 - `enabled_tools` as an allow-list and `disabled_tools` as a deny-list applied afterwards.
 
-Streamable-HTTP entries (`url`) and non-local execution environments are skipped because the bridge currently supports only local stdio children. Other Codex-only fields are ignored explicitly: the startup report names those fields, but never prints environment values or other configuration values. A missing or unreadable Codex config does not prevent servers declared directly in `codex.config.json` from loading.
+Non-local execution environments remain unsupported: Codex Free itself opens the HTTP connection and cannot delegate header resolution or stdio launch into a Codex executor. `http_headers_helper` is also unsupported. Other Codex-only fields are ignored explicitly: the startup report names those fields, but never prints header values, environment values, or bearer tokens. A missing or unreadable Codex config does not prevent servers declared directly in `codex.config.json` from loading.
 
 Disable discovery while retaining explicit upstreams with:
 
@@ -541,7 +544,7 @@ Disable discovery while retaining explicit upstreams with:
 
 ### Explicit servers and overrides
 
-The `mcpServers` map in `codex.config.json` remains supported. Each entry is a stdio command that Codex Free launches and drives over stdin/stdout:
+The `mcpServers` map in `codex.config.json` remains supported. A local entry is a stdio command that Codex Free launches and drives over stdin/stdout:
 
 ```json
 {
@@ -554,6 +557,29 @@ The `mcpServers` map in `codex.config.json` remains supported. Each entry is a s
   }
 }
 ```
+
+A remote entry uses MCP Streamable HTTP. Secret values should come from environment variables rather than the JSON file:
+
+```json
+{
+  "mcpServers": {
+    "remote-docs": {
+      "url": "https://mcp.example.com/mcp",
+      "bearerTokenEnvVar": "REMOTE_MCP_TOKEN",
+      "httpHeaders": {
+        "X-Client": "codex-free"
+      },
+      "envHttpHeaders": {
+        "X-Tenant": "REMOTE_MCP_TENANT"
+      },
+      "startupTimeoutSec": 20,
+      "toolTimeoutSec": 60
+    }
+  }
+}
+```
+
+`bearerTokenEnvVar` is required to exist and be non-empty when configured. Missing or empty values referenced by `envHttpHeaders` are omitted, matching Codex. Environment-backed headers override a same-named static header. Do not configure both `bearerTokenEnvVar` and an `Authorization` entry in `httpHeaders`/`envHttpHeaders`.
 
 An explicit entry with the same name as an imported Codex server is a field-by-field overlay. That makes Codex-specific launch settings reusable while adding bridge-only settings without copying the command, arguments or environment:
 
@@ -580,7 +606,7 @@ bridged MCP server 'idasql': 12 tool(s)
 Tools loaded (37): 25 native + 12 bridged from upstream MCP servers
 ```
 
-Each upstream tool is offered as `<server>__<tool>` (for example `remote_exec__docker_ps`), and calls are forwarded to the upstream verbatim — text, images, structured content and error flags all pass through. An upstream that fails to launch or answer is skipped; it never blocks startup or the native tools.
+Each upstream tool is offered as `<server>__<tool>` (for example `remote_exec__docker_ps`), and calls are forwarded to the upstream verbatim — text, images, structured content and error flags all pass through. An upstream that fails to launch, connect, authenticate, or answer is skipped; it never blocks startup or the native tools.
 
 Every configured server is reported in the startup banner, so a bad path or a failed handshake is never silent:
 
@@ -594,9 +620,14 @@ Upstream MCP servers:
 - `tools: ["exec", "machine_list", ...]` limits which upstream tools are bridged (an allow-list on the upstream's own names).
 - `disabledTools: ["dangerous_write", ...]` removes tools after the allow-list has been applied.
 - `cwd` selects the child process's working directory.
+- `startupTimeoutSec` bounds initialization plus the initial `tools/list`; the default is 20 seconds.
+- `toolTimeoutSec` bounds each forwarded call and sends MCP cancellation when the limit expires.
 - Bridged names are sanitised to `[A-Za-z0-9_]` (e.g. `remote_exec__exec`) so function-calling layers that reject hyphens don't drop them.
 - A bridged name that would collide with a native tool is skipped with a warning.
-- `type` may be `"stdio"` (default). Only stdio (command-launched) upstreams are bridged today; `type: "sse"`/`"http"` (or a bare `url`) entries are recognised and reported as `not supported yet` rather than failing the whole config.
+- `type` is inferred: `command` means `"stdio"`, while `url` means Streamable HTTP. Explicit HTTP aliases `"http"`, `"streamable-http"`, and `"streamable_http"` are accepted.
+- Legacy SSE and WebSocket transports are rejected explicitly because current Codex supports stdio and Streamable HTTP, not those legacy protocols.
+
+OAuth authorization-code login and credential persistence are not implemented by this bridge. An OAuth-protected upstream must therefore be supplied a usable bearer token through `bearerTokenEnvVar` or an environment-backed `Authorization` header. MCP resources, resource templates, prompts, upstream initialization instructions, and dynamic `tools/list_changed` forwarding remain separate capability work; this transport support continues to expose tools only.
 
 If your server doesn't show up, **check the banner first** — the most common cause is a wrong `command` path.
 
@@ -649,7 +680,7 @@ Native tunnel mode ignores `allowedHosts` and forces the accepted authorities to
 - **Bounded state writes outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/projects/`. Multi-project mode also writes one small project-binding record under `~/.codex-free/conversation-projects/` for each ChatGPT conversation and access root. Both use atomic replacement and per-record locks. The binding filename is derived from a hash of `openai/session`; the raw identifier is not stored. Set `memory.enabled` to `false` to disable plans and notes; delete `~/.codex-free/conversation-projects/` separately to forget conversation bindings. See [Context and memory](#context-and-memory).
 - **Bounded reads outside the work directory**: [skills](#skills) may live in `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` or an installed Claude Code plugin. `skills_read` opens files there, but only inside a skill package that already exists — the `resource` path is checked against the skill's own directory, so it cannot walk out into the rest of your home directory. `skills_list` reports the absolute path of every skill it found. Set `skills.enabled` to `false` to switch it off, or `skills.dirs` to point the user scope somewhere you choose.
 - **Command allowlist**: `run_command` only runs binaries listed in `allowedCommands`; everything else is rejected. `exec_command` checks the same list plus `exec.extraAllowedCommands`, at every command position in the string.
-- **Bridged servers run with your privileges**: an explicit `mcpServers` entry or an automatically imported Codex MCP launches a real process on your machine and forwards the model's calls to it verbatim. Only bridge servers you trust, prefer `tools`/`disabledTools` filters or `gateway` mode to keep the exposed surface small, and set `codexMcp.enabled` to `false` when Codex contains servers that should not be exposed through ChatGPT. A bad `command` path is reported, never silently ignored.
+- **Bridged servers carry delegated authority**: a stdio upstream runs as your OS user, while a Streamable HTTP upstream receives model-directed calls plus its configured bearer token and HTTP headers. Only bridge servers you trust, prefer `tools`/`disabledTools` filters or `gateway` mode to keep the exposed surface small, keep secrets in `bearerTokenEnvVar`/`envHttpHeaders` rather than static JSON, and set `codexMcp.enabled` to `false` when Codex contains servers that should not be exposed through ChatGPT. Launch, connection, authentication, and handshake failures are reported rather than silently ignored.
 - **Native OpenAI tunnel is outbound-only**: Codex Free binds its MCP listener to loopback and supervises OpenAI's official runtime-only tunnel client. Startup fails unless the runtime reports `/readyz` and completes a control-plane poll. Failure of either process stops the other, and HTTP shutdown has a bounded grace period before remaining connections are aborted.
 - **The loopback MCP hop is authenticated**: native mode generates a random per-process bearer token and configures the tunnel runtime to send it on MCP requests and discovery probes. The token is never printed, written to the config file, or inherited by model-launched commands and bridged MCP children.
 - **Verified tunnel-client installation**: the managed client is pinned to a specific official release and per-platform archive SHA-256 embedded in Codex Free, extracted by exact filename under size limits, installed atomically with private permissions, and hash-checked against its installation manifest on subsequent starts. Set `clientPath` to opt out of managed installation while retaining compatibility checks.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ A Rust port of the `codex-free` MCP bridge. codex-free is a local [Model Context
 Protocol](https://modelcontextprotocol.io) server that exposes Codex-style agent
 tools over **Streamable HTTP**, scoped either to one configured working directory
 or to a project root selected independently by each ChatGPT conversation, and can
-additionally **aggregate other local MCP servers** and **surface local skills**.
+additionally **aggregate local or remote MCP servers** and **surface local skills**.
 Clients without ChatGPT conversation metadata use an MCP-transport-session fallback.
 
 This document explains how it is put together and why. For usage, see
@@ -47,9 +47,9 @@ ChatGPT / MCP client
 │    • fallback root for generic MCP clients    │
 │    • exec sessions + current plan             │
 └──────────────────────────────────────────────┘
-        │ reads/writes           │ stdio child processes
+        │ reads/writes           │ stdio / Streamable HTTP
         ▼                        ▼
-   active project root     upstream MCP servers (idasql, remote-exec, …)
+   active project root     upstream MCP servers (idasql, remote-docs, …)
 ```
 
 Three surfaces reach the model:
@@ -246,7 +246,7 @@ the original order and rejects duplicate names.
 | `process_env.rs` | Child-process environment boundaries: isolate the tunnel runtime and remove tunnel credentials from model-controlled and upstream subprocesses. |
 | `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. Multi-project mode treats the selected directory as the exact project root and never walks into the common access-root parent. |
 | `skills.rs` | `SKILL.md` discovery (see §8). |
-| `codex_mcp.rs` | Read-only import of local stdio MCP definitions from `$CODEX_HOME/config.toml` or `~/.codex/config.toml`, with secret-safe diagnostics. |
+| `codex_mcp.rs` | Read-only import of local stdio and remote Streamable HTTP MCP definitions from `$CODEX_HOME/config.toml` or `~/.codex/config.toml`, with secret-safe diagnostics. |
 | `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc. Multi-project initialization emits a project-neutral selector brief because conversation metadata is available only on subsequent tool calls; `get_agent_brief` builds the full brief after restoring or creating a binding. |
 | `environment.rs` | OS / shell / policy description, shared by `get_environment` and the instructions. |
 
@@ -254,26 +254,32 @@ the original order and rejects duplicate names.
 
 ## 7. MCP bridging (aggregator)
 
-codex-free can act as an MCP **client** to other local MCP servers, discover their
-tools at startup, and re-expose them. Implemented in `bridge.rs`; wired in
+codex-free can act as an MCP **client** to local stdio and remote Streamable HTTP
+servers, discover their tools at startup, and re-expose them. Implemented in `bridge.rs`; wired in
 `server.rs::start_http_server` before the HTTP server starts.
 
 ### Discovery
 Before bridging, `config.rs` imports compatible `[mcp_servers.<name>]` entries
 from Codex's user-level config. Explicit `codex.config.json.mcpServers` fields
 overlay imports with the same name; `codexMcp.enabled = false` disables the
-import. HTTP and non-local Codex entries are reported and skipped.
+import. Non-local Codex execution environments and `http_headers_helper` are
+reported and skipped because Codex Free cannot delegate transport execution to a
+Codex executor or helper process.
 
 For each resulting server entry (sorted, non-disabled), `connect_one`:
-1. Launches the `command` as a stdio child process (`TokioChildProcess`).
-2. Runs the MCP handshake (`().serve(transport)`), then `list_all_tools()`,
-   under a 20 s timeout.
-3. Applies the optional `tools` allow-list, then `disabledTools` deny-list.
+1. Selects stdio from `command`, or Streamable HTTP from `url`.
+2. For stdio, launches the child through `TokioChildProcess`; for HTTP, resolves
+   the bearer-token environment variable and environment-backed headers, then
+   builds `StreamableHttpClientTransport` with RMCP's redirect-disabled reqwest client.
+3. Runs the MCP handshake (`().serve(transport)`), then `list_all_tools()`, under
+   `startupTimeoutSec` (20 s by default).
+4. Applies the optional `tools` allow-list, then `disabledTools` deny-list.
 
 Failures are **reported, not fatal** — each server appears in the startup banner
 as `-> N tool(s)`, `-> FAILED: <reason>`, `-> disabled`, or
 `-> gateway (N functions via <tool>)`. The `RunningService` handles are kept in
-`Bridge.services` for the whole server lifetime (dropping one kills its child).
+`Bridge.services` for the whole server lifetime (dropping one closes the HTTP
+session or kills its child).
 
 ### Direct mode (default)
 Each upstream tool becomes its own `BridgedTool`, named `<server>__<tool>`
@@ -302,9 +308,22 @@ returns `false` so the server never synthesises a `{content}` structured result
 that would not match the upstream's own schema.
 
 ### Transports
-Only **stdio** (command-launched) upstreams are bridged. `type: "sse"` / `"http"`
-or a bare `url` are recognised and reported as *not supported yet* rather than
-failing the whole config.
+The upstream client supports the two transports exposed by current Codex:
+
+- **stdio**, inferred from `command`;
+- **Streamable HTTP**, inferred from `url`, with `http`, `streamable-http`, and
+  `streamable_http` accepted as explicit aliases.
+
+HTTP configuration supports `bearerTokenEnvVar`, static `httpHeaders`,
+environment-backed `envHttpHeaders`, `startupTimeoutSec`, and `toolTimeoutSec`.
+Environment-backed headers override static headers. Tool timeouts use RMCP's
+cancellable request handle so timeout cleanup sends MCP cancellation and removes
+request bookkeeping. Legacy SSE and WebSocket types are rejected explicitly.
+
+OAuth login/token persistence, `http_headers_helper`, remote Codex execution
+environments, MCP resources/templates/prompts, upstream initialization
+instructions, and dynamic capability forwarding are not part of this
+tool-transport bridge.
 
 ---
 
@@ -366,13 +385,21 @@ startup banner prints the exact file with `Config:`). All fields optional.
   "skills": { "enabled": true, "dirs": ["…"], "includePlugins": true },
 
   "mcpServers": {
-    "remote-exec": {
-      "command": "D:\\mcphub\\mcp-server-windows-x86_64.exe",  // stdio only
+    "local-exec": {
+      "command": "D:\\mcphub\\mcp-server-windows-x86_64.exe",
       "args": [], "env": {},
-      "type": "stdio",                 // "sse"/"http" recognised but not bridged
+      "type": "stdio",
       "disabled": false,
       "tools": ["exec", "machine_list"],   // optional allow-list of upstream names
       "mode": "gateway"                // or omit for "direct"
+    },
+    "remote-docs": {
+      "url": "https://mcp.example.com/mcp",
+      "bearerTokenEnvVar": "REMOTE_MCP_TOKEN",
+      "httpHeaders": { "X-Client": "codex-free" },
+      "envHttpHeaders": { "X-Tenant": "REMOTE_MCP_TENANT" },
+      "startupTimeoutSec": 20,
+      "toolTimeoutSec": 60
     }
   }
 }
@@ -425,7 +452,7 @@ units to match the TS `text.length` / `text.slice`.
 
 ## 12. Testing
 
-- **381 tests** — unit tests inside modules plus integration tests under `tests/`
+- **403 tests** — unit tests inside modules plus integration tests under `tests/`
   (`tempfile`-isolated), ported from the TS Bun suite.
 - Memory / skills tests pin `memory.dir` / `skills.dirs` to temp dirs so they never
   touch the real home; plugin discovery is suppressed when `skills.dirs` is set.
@@ -440,6 +467,8 @@ units to match the TS `text.length` / `text.slice`.
   fixed with regression tests in `bridge.rs` / `skills.rs`.
 - `examples/mock_mcp.rs` is a minimal stdio MCP server used to exercise the bridge
   end-to-end.
+- `bridge.rs` starts a loopback Streamable HTTP MCP server to verify bearer and
+  custom headers, remote discovery/calls, and cancellable tool deadlines.
 
 Run: `cargo test`. Build a standalone binary: `cargo build --release`.
 
@@ -449,10 +478,10 @@ Run: `cargo test`. Build a standalone binary: `cargo build --release`.
 
 | Symptom | Cause / fix |
 |---------|-------------|
-| Bridged tools don't appear; banner shows `-> FAILED` | The `command` path isn't a runnable stdio binary **on the machine where codex-free runs**. Fix the path or run the server locally. |
+| Bridged tools don't appear; banner shows `-> FAILED` | For stdio, verify that `command` is runnable on the machine where Codex Free runs. For Streamable HTTP, verify the URL, TLS trust, bearer/header environment variables, and upstream authentication. |
 | Banner shows a server you didn't configure (e.g. `idasql -> disabled`) | codex-free loaded a *different* `codex.config.json` than you edited. Check the `Config:` line and edit that file, or pass `--config`. |
 | codex-free exposes the tools (`Tools loaded (109)`) but the client shows only 25 | The client caches the tool manifest — **remove and re-add the connector** so it re-fetches `tools/list`. There is no tool-count cap at 109 (the hard API cap is 128). |
 | A client won't surface a large bridged set at all | Use `"mode": "gateway"` to collapse the server into one tool + a skill, or `"tools": [...]` to expose a curated few. |
-| Upstream `type: "sse"`/`"http"` | Not bridged yet (stdio only); reported as unsupported instead of breaking the config. |
+| Upstream uses `type: "sse"` or `"websocket"` | Current Codex transport parity is stdio plus Streamable HTTP. Point the entry at a Streamable HTTP endpoint and use `url` (or an HTTP type alias). |
 | Native tunnel never becomes ready | Check the banner's loopback `/readyz` and `/metrics` URLs and the redacted startup error. Codex Free requires runtime readiness plus one successful control-plane poll; the runtime key needs the applicable Tunnels **Read** + **Use** permissions. The runtime-only binary has no `/ui` or `/api/status` surface. |
 | Native tunnel key is rejected before startup | `apiKeyRef` must be `env:NAME` or `file:/path`. The referenced value must exist; on Unix, key files must not grant group/other access. |

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -708,6 +708,11 @@ fn configures_authorization_header(spec: &crate::types::McpServerSpec) -> bool {
         .any(|name| name.eq_ignore_ascii_case(AUTHORIZATION.as_str()))
 }
 
+fn ensure_rustls_crypto_provider() {
+    // RMCP avoids bundling AWS-LC; install the ring provider already used by Codex Free.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 async fn connect_one_with_env(
     server_name: &str,
     spec: &crate::types::McpServerSpec,
@@ -765,6 +770,7 @@ async fn connect_one_with_env(
                         .to_string(),
                 );
             }
+            ensure_rustls_crypto_provider();
             let headers = build_http_headers(spec, env_lookup);
 
             let mut transport_config = StreamableHttpClientTransportConfig::with_uri(url);

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,23 +1,28 @@
 //! Bridge to upstream MCP servers.
 //!
-//! codex-free can act as an MCP *client* to other local MCP servers (e.g. `idasql`),
-//! discover their tools at startup, and re-expose them through its own
+//! codex-free can act as an MCP *client* to other MCP servers, discover their
+//! tools at startup, and re-expose them through its own
 //! `tools/list` / `tools/call` so the ChatGPT-side agent can use them too. Each
 //! upstream tool is offered under a `<server>__<tool>` name and calls are
 //! forwarded to the upstream verbatim.
 //!
-//! Only stdio (command-launched) upstreams are supported: the server is spawned
-//! as a child process and driven over its stdin/stdout, which is how most local
-//! MCP servers run.
+//! Local servers use stdio; remote servers use MCP Streamable HTTP.
 
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
+use http::{HeaderName, HeaderValue, header::AUTHORIZATION};
 use rmcp::{
     RoleClient, ServiceExt,
-    model::{CallToolRequestParams, CallToolResult, ContentBlock},
-    service::{Peer, RunningService},
-    transport::TokioChildProcess,
+    model::{
+        CallToolRequest, CallToolRequestParams, CallToolResult, ClientRequest, ContentBlock,
+        ServerResult,
+    },
+    service::{Peer, PeerRequestOptions, RunningService, ServiceError},
+    transport::{
+        StreamableHttpClientTransport, TokioChildProcess,
+        streamable_http_client::StreamableHttpClientTransportConfig,
+    },
 };
 use serde_json::{Value, json};
 use tokio::process::Command;
@@ -33,11 +38,10 @@ const CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// The result of connecting to every configured upstream: the tools to merge
 /// into the registry, plus the running services kept alive for the server's
-/// lifetime (dropping a service tears down its child process).
+/// lifetime (dropping one closes its transport and any child process).
 pub struct Bridge {
     pub tools: Vec<Box<dyn Tool>>,
-    /// Held only to keep the upstream connections (and their child processes)
-    /// alive; never read directly.
+    /// Held only to keep upstream transports alive; never read directly.
     pub services: Vec<RunningService<RoleClient, ()>>,
     /// One human-readable line per configured server (connected or failed),
     /// printed in the startup banner so a bad path or handshake is never silent.
@@ -57,6 +61,7 @@ struct BridgedTool {
     input_schema: Value,
     output_schema: Option<Value>,
     peer: Peer<RoleClient>,
+    tool_timeout: Option<Duration>,
 }
 
 #[async_trait]
@@ -95,13 +100,66 @@ impl Tool for BridgedTool {
             params = params.with_arguments(obj.clone());
         }
 
-        match self.peer.call_tool(params).await {
-            Ok(result) => map_call_result(result),
-            Err(e) => ToolResult::error(format!(
-                "Upstream MCP server '{}' failed to run '{}': {e}",
-                self.server, self.original_name
-            )),
+        forward_tool_call(
+            &self.peer,
+            params,
+            &self.server,
+            &self.original_name,
+            self.tool_timeout,
+        )
+        .await
+    }
+}
+
+async fn forward_tool_call(
+    peer: &Peer<RoleClient>,
+    params: CallToolRequestParams,
+    server: &str,
+    tool: &str,
+    tool_timeout: Option<Duration>,
+) -> ToolResult {
+    let result = if let Some(limit) = tool_timeout {
+        call_tool_with_timeout(peer, params, limit).await
+    } else {
+        peer.call_tool(params)
+            .await
+            .map_err(|error| error.to_string())
+    };
+
+    match result {
+        Ok(result) => map_call_result(result),
+        Err(error) => ToolResult::error(format!(
+            "Upstream MCP server '{server}' failed to run '{tool}': {error}"
+        )),
+    }
+}
+
+async fn call_tool_with_timeout(
+    peer: &Peer<RoleClient>,
+    params: CallToolRequestParams,
+    timeout: Duration,
+) -> Result<CallToolResult, String> {
+    let request = ClientRequest::CallToolRequest(CallToolRequest::new(params));
+    let handle = peer
+        .send_cancellable_request(request, PeerRequestOptions::with_timeout(timeout))
+        .await
+        .map_err(|error| error.to_string())?;
+    let response = match handle.await_response().await {
+        Ok(response) => response,
+        Err(ServiceError::Timeout { .. }) => {
+            return Err(format!("timed out after {}s", timeout.as_secs_f64()));
         }
+        Err(error) => return Err(error.to_string()),
+    };
+    match response {
+        ServerResult::CallToolResult(result) => Ok(result),
+        ServerResult::InputRequiredResult(_) => {
+            Err("requested additional interactive input, which Codex Free cannot provide".into())
+        }
+        ServerResult::CreateTaskResult(_) => {
+            Err("returned an asynchronous MCP task, which Codex Free does not poll".into())
+        }
+        _ => Err("returned an unexpected response type".into()),
     }
 }
 
@@ -200,7 +258,7 @@ pub async fn connect_upstreams(config: &AppConfig) -> Bridge {
         let is_gateway = spec.mode.as_deref() == Some("gateway");
 
         match connect_one(server_name, spec, config).await {
-            Ok((service, upstream_tools)) => {
+            Ok((service, upstream_tools, tool_timeout)) => {
                 let peer = service.peer().clone();
                 let count = upstream_tools.len();
 
@@ -229,6 +287,7 @@ pub async fn connect_upstreams(config: &AppConfig) -> Bridge {
                         description: gateway_description(server_name, &functions),
                         function_names: functions.iter().map(|f| f.name.clone()).collect(),
                         peer: peer.clone(),
+                        tool_timeout,
                     }));
                     report.push(format!(
                         "{server_name} -> gateway ({count} functions via `{sanitized}`)"
@@ -258,6 +317,7 @@ pub async fn connect_upstreams(config: &AppConfig) -> Bridge {
                             input_schema: Value::Object((*tool.input_schema).clone()),
                             output_schema: tool.output_schema.map(|s| Value::Object((*s).clone())),
                             peer: peer.clone(),
+                            tool_timeout,
                         }));
                     }
                     tracing::info!("bridged MCP server '{server_name}': {count} tool(s)");
@@ -373,6 +433,7 @@ struct GatewayTool {
     description: String,
     function_names: Vec<String>,
     peer: Peer<RoleClient>,
+    tool_timeout: Option<Duration>,
 }
 
 #[async_trait]
@@ -441,13 +502,14 @@ impl Tool for GatewayTool {
             }
         }
 
-        match self.peer.call_tool(params).await {
-            Ok(result) => map_call_result(result),
-            Err(e) => ToolResult::error(format!(
-                "Upstream MCP server '{}' failed to run '{function}': {e}",
-                self.server
-            )),
-        }
+        forward_tool_call(
+            &self.peer,
+            params,
+            &self.server,
+            function,
+            self.tool_timeout,
+        )
+        .await
     }
 }
 
@@ -456,65 +518,284 @@ async fn connect_one(
     server_name: &str,
     spec: &crate::types::McpServerSpec,
     config: &AppConfig,
-) -> Result<(RunningService<RoleClient, ()>, Vec<rmcp::model::Tool>), String> {
+) -> Result<
+    (
+        RunningService<RoleClient, ()>,
+        Vec<rmcp::model::Tool>,
+        Option<Duration>,
+    ),
+    String,
+> {
+    connect_one_with_env(server_name, spec, config, &|name| std::env::var(name).ok()).await
+}
+
+#[derive(Debug)]
+enum UpstreamTransport<'a> {
+    Stdio(&'a str),
+    StreamableHttp(&'a str),
+}
+
+fn select_transport(spec: &crate::types::McpServerSpec) -> Result<UpstreamTransport<'_>, String> {
     if spec.command.is_some() && spec.url.is_some() {
         return Err("both \"command\" and \"url\" are configured".to_string());
     }
-    // Recognise url-based transports and report them clearly instead of failing
-    // to launch a nonexistent command.
-    let kind = spec
-        .transport
-        .as_deref()
-        .unwrap_or("stdio")
-        .to_ascii_lowercase();
-    if matches!(
-        kind.as_str(),
-        "sse" | "http" | "streamable-http" | "streamable_http" | "websocket" | "ws"
-    ) {
+    if spec.command.is_some() {
+        let mut incompatible = Vec::new();
+        if spec.bearer_token_env_var.is_some() {
+            incompatible.push("bearerTokenEnvVar");
+        }
+        if !spec.http_headers.is_empty() {
+            incompatible.push("httpHeaders");
+        }
+        if !spec.env_http_headers.is_empty() {
+            incompatible.push("envHttpHeaders");
+        }
+        if !incompatible.is_empty() {
+            return Err(format!(
+                "stdio transport cannot configure {}",
+                incompatible.join(", ")
+            ));
+        }
+    }
+    if spec.url.is_some() {
+        let mut incompatible = Vec::new();
+        if !spec.args.is_empty() {
+            incompatible.push("args");
+        }
+        if !spec.env.is_empty() {
+            incompatible.push("env");
+        }
+        if spec.cwd.is_some() {
+            incompatible.push("cwd");
+        }
+        if !incompatible.is_empty() {
+            return Err(format!(
+                "Streamable HTTP transport cannot configure {}",
+                incompatible.join(", ")
+            ));
+        }
+    }
+
+    let kind = spec.transport.as_deref().map(str::to_ascii_lowercase);
+    match kind.as_deref() {
+        None | Some("stdio") if spec.command.is_some() => spec
+            .command
+            .as_deref()
+            .filter(|command| !command.trim().is_empty())
+            .map(UpstreamTransport::Stdio)
+            .ok_or_else(|| "a stdio server needs a non-empty \"command\"".to_string()),
+        None | Some("http" | "streamable-http" | "streamable_http")
+            if spec.url.is_some() =>
+        {
+            spec.url
+                .as_deref()
+                .filter(|url| !url.trim().is_empty())
+                .map(UpstreamTransport::StreamableHttp)
+                .ok_or_else(|| {
+                    "a Streamable HTTP server needs a non-empty \"url\"".to_string()
+                })
+        }
+        Some("sse") => Err(
+            "legacy SSE transport is not supported by current Codex; configure a Streamable HTTP endpoint"
+                .to_string(),
+        ),
+        Some("websocket" | "ws") => Err(
+            "WebSocket transport is not supported by current Codex; configure stdio or Streamable HTTP"
+                .to_string(),
+        ),
+        Some("stdio") => Err("type \"stdio\" requires \"command\", not \"url\"".to_string()),
+        Some("http" | "streamable-http" | "streamable_http") => Err(
+            "Streamable HTTP transport requires \"url\", not \"command\"".to_string(),
+        ),
+        Some(other) => Err(format!("unsupported MCP transport type \"{other}\"")),
+        None => Err("neither \"command\" nor \"url\" is configured".to_string()),
+    }
+}
+
+fn configured_timeout(
+    value: Option<f64>,
+    field: &str,
+    default: Option<Duration>,
+) -> Result<Option<Duration>, String> {
+    match value {
+        Some(seconds) => Duration::try_from_secs_f64(seconds)
+            .map(Some)
+            .map_err(|_| format!("{field} must be a non-negative finite number")),
+        None => Ok(default),
+    }
+}
+
+fn resolve_bearer_token(
+    server_name: &str,
+    env_var: Option<&str>,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> Result<Option<String>, String> {
+    let Some(env_var) = env_var else {
+        return Ok(None);
+    };
+    let value = env_lookup(env_var).ok_or_else(|| {
+        format!("environment variable {env_var} for MCP server '{server_name}' is not set")
+    })?;
+    if value.is_empty() {
         return Err(format!(
-            "type \"{kind}\" (url transport) is not supported yet; only stdio (command) servers are bridged"
+            "environment variable {env_var} for MCP server '{server_name}' is empty"
         ));
     }
-    if spec.command.is_none() && spec.url.is_some() {
-        return Err(
-            "url-based (sse/http) servers are not supported yet; only stdio (command) servers are bridged"
-                .to_string(),
-        );
+    Ok(Some(value))
+}
+
+fn insert_header(
+    headers: &mut HashMap<HeaderName, HeaderValue>,
+    name: &str,
+    value: &str,
+    source: &str,
+) {
+    let header_name = match HeaderName::from_bytes(name.as_bytes()) {
+        Ok(name) => name,
+        Err(error) => {
+            tracing::warn!("invalid upstream MCP HTTP header name `{name}` from {source}: {error}");
+            return;
+        }
+    };
+    let header_value = match HeaderValue::from_str(value) {
+        Ok(value) => value,
+        Err(error) => {
+            tracing::warn!(
+                "invalid upstream MCP HTTP header value for `{name}` from {source}: {error}"
+            );
+            return;
+        }
+    };
+    headers.insert(header_name, header_value);
+}
+
+fn build_http_headers(
+    spec: &crate::types::McpServerSpec,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> HashMap<HeaderName, HeaderValue> {
+    let mut headers = HashMap::new();
+    insert_header(
+        &mut headers,
+        "user-agent",
+        concat!("codex-free/", env!("CARGO_PKG_VERSION")),
+        "Codex Free",
+    );
+
+    let mut static_headers: Vec<_> = spec.http_headers.iter().collect();
+    static_headers.sort_by(|left, right| left.0.cmp(right.0));
+    for (name, value) in static_headers {
+        insert_header(&mut headers, name, value, "httpHeaders");
     }
-    let Some(command_path) = spec.command.as_deref().filter(|c| !c.is_empty()) else {
-        return Err("no \"command\" specified (a stdio server needs a command path)".to_string());
+
+    let mut env_headers: Vec<_> = spec.env_http_headers.iter().collect();
+    env_headers.sort_by(|left, right| left.0.cmp(right.0));
+    for (name, env_var) in env_headers {
+        let Some(value) = env_lookup(env_var) else {
+            continue;
+        };
+        if value.trim().is_empty() {
+            continue;
+        }
+        insert_header(&mut headers, name, &value, env_var);
+    }
+    headers
+}
+
+fn configures_authorization_header(spec: &crate::types::McpServerSpec) -> bool {
+    spec.http_headers
+        .keys()
+        .chain(spec.env_http_headers.keys())
+        .any(|name| name.eq_ignore_ascii_case(AUTHORIZATION.as_str()))
+}
+
+async fn connect_one_with_env(
+    server_name: &str,
+    spec: &crate::types::McpServerSpec,
+    config: &AppConfig,
+    env_lookup: &dyn Fn(&str) -> Option<String>,
+) -> Result<
+    (
+        RunningService<RoleClient, ()>,
+        Vec<rmcp::model::Tool>,
+        Option<Duration>,
+    ),
+    String,
+> {
+    let startup_timeout = configured_timeout(
+        spec.startup_timeout_sec,
+        "startupTimeoutSec",
+        Some(CONNECT_TIMEOUT),
+    )?
+    .expect("startup timeout has a default");
+    let tool_timeout = configured_timeout(spec.tool_timeout_sec, "toolTimeoutSec", None)?;
+
+    let connect = match select_transport(spec)? {
+        UpstreamTransport::Stdio(command_path) => {
+            let mut command = Command::new(command_path);
+            command.args(&spec.args);
+            for (key, value) in &spec.env {
+                command.env(key, value);
+            }
+            if let Some(cwd) = spec.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
+                command.current_dir(cwd);
+            }
+            scrub_untrusted_child_env(&mut command, config);
+
+            let transport = TokioChildProcess::new(command)
+                .map_err(|error| format!("could not launch '{command_path}': {error}"))?;
+            let connect = async {
+                let service = ().serve(transport).await.map_err(|error| error.to_string())?;
+                let tools = service
+                    .list_all_tools()
+                    .await
+                    .map_err(|error| error.to_string())?;
+                Ok::<_, String>((service, tools))
+            };
+            tokio::time::timeout(startup_timeout, connect).await
+        }
+        UpstreamTransport::StreamableHttp(url) => {
+            let bearer_token = resolve_bearer_token(
+                server_name,
+                spec.bearer_token_env_var.as_deref(),
+                env_lookup,
+            )?;
+            if bearer_token.is_some() && configures_authorization_header(spec) {
+                return Err(
+                    "configure either bearerTokenEnvVar or an Authorization HTTP header, not both"
+                        .to_string(),
+                );
+            }
+            let headers = build_http_headers(spec, env_lookup);
+
+            let mut transport_config = StreamableHttpClientTransportConfig::with_uri(url);
+            if let Some(token) = bearer_token {
+                transport_config = transport_config.auth_header(token);
+            }
+            transport_config = transport_config.custom_headers(headers);
+            let transport = StreamableHttpClientTransport::from_config(transport_config);
+            let connect = async {
+                let service = ().serve(transport).await.map_err(|error| error.to_string())?;
+                let tools = service
+                    .list_all_tools()
+                    .await
+                    .map_err(|error| error.to_string())?;
+                Ok::<_, String>((service, tools))
+            };
+            tokio::time::timeout(startup_timeout, connect).await
+        }
     };
 
-    let mut command = Command::new(command_path);
-    command.args(&spec.args);
-    for (key, value) in &spec.env {
-        command.env(key, value);
-    }
-    if let Some(cwd) = spec.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
-        command.current_dir(cwd);
-    }
-    scrub_untrusted_child_env(&mut command, config);
-
-    let transport = TokioChildProcess::new(command)
-        .map_err(|e| format!("could not launch '{command_path}': {e}"))?;
-
-    let connect = async {
-        let service = ().serve(transport).await.map_err(|e| e.to_string())?;
-        let tools = service.list_all_tools().await.map_err(|e| e.to_string())?;
-        Ok::<_, String>((service, tools))
-    };
-
-    match tokio::time::timeout(CONNECT_TIMEOUT, connect).await {
+    match connect {
         Ok(Ok((service, mut tools))) => {
             // Codex applies the deny-list after the allow-list; use the same
             // order so imported filtering has identical results.
             tools.retain(|tool| tool_is_enabled(spec, tool.name.as_ref()));
-            Ok((service, tools))
+            Ok((service, tools, tool_timeout))
         }
-        Ok(Err(e)) => Err(e),
+        Ok(Err(error)) => Err(error),
         Err(_) => Err(format!(
             "timed out after {}s waiting for '{server_name}' to initialise",
-            CONNECT_TIMEOUT.as_secs()
+            startup_timeout.as_secs_f64()
         )),
     }
 }
@@ -535,8 +816,124 @@ fn tool_is_enabled(spec: &crate::types::McpServerSpec, name: &str) -> bool {
 mod tests {
     use super::*;
     use crate::types::McpServerSpec;
-    use rmcp::model::CallToolResult;
-    use std::collections::HashMap;
+    use axum::{
+        Router,
+        extract::{Request, State},
+        middleware::Next,
+        response::{IntoResponse, Response},
+    };
+    use rmcp::{
+        ErrorData as McpError, ServerHandler,
+        model::{
+            CallToolResponse, Implementation, InitializeResult, ListToolsResult,
+            PaginatedRequestParams, ServerCapabilities, ServerInfo,
+        },
+        service::{RequestContext, RoleServer},
+        transport::streamable_http_server::{
+            StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
+        },
+    };
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    struct ExpectedHeaders {
+        authorization: &'static str,
+        static_value: &'static str,
+        env_value: &'static str,
+    }
+
+    async fn require_expected_headers(
+        State(expected): State<ExpectedHeaders>,
+        request: Request,
+        next: Next,
+    ) -> Response {
+        let headers = request.headers();
+        let matches = |name: &str, value: &str| {
+            headers.get(name).and_then(|actual| actual.to_str().ok()) == Some(value)
+        };
+        if !matches("authorization", expected.authorization)
+            || !matches("x-static", expected.static_value)
+            || !matches("x-env", expected.env_value)
+        {
+            return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        }
+        next.run(request).await
+    }
+
+    #[derive(Clone)]
+    struct TestHttpMcp;
+
+    impl ServerHandler for TestHttpMcp {
+        fn get_info(&self) -> ServerInfo {
+            InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+                .with_server_info(Implementation::new("test-http-upstream", "1.0.0"))
+                .with_instructions("Use echo for immediate replies and slow to test timeouts.")
+        }
+
+        async fn list_tools(
+            &self,
+            _request: Option<PaginatedRequestParams>,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<ListToolsResult, McpError> {
+            let schema = json!({
+                "type": "object",
+                "properties": { "text": { "type": "string" } },
+                "required": ["text"],
+                "additionalProperties": false
+            })
+            .as_object()
+            .cloned()
+            .unwrap();
+            Ok(ListToolsResult::with_all_items(vec![
+                rmcp::model::Tool::new("echo", "Echo the supplied text", schema.clone()),
+                rmcp::model::Tool::new("slow", "Return after a delay", schema),
+            ]))
+        }
+
+        async fn call_tool(
+            &self,
+            request: CallToolRequestParams,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<CallToolResponse, McpError> {
+            let text = request
+                .arguments
+                .as_ref()
+                .and_then(|arguments| arguments.get("text"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            if request.name.as_ref() == "slow" {
+                tokio::time::sleep(Duration::from_millis(200)).await;
+            }
+            Ok(CallToolResult::success(vec![ContentBlock::text(text)]).into())
+        }
+    }
+
+    async fn spawn_http_upstream() -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let address = listener.local_addr().unwrap();
+        let mut config = StreamableHttpServerConfig::default();
+        config.json_response = true;
+        let service = StreamableHttpService::new(
+            || Ok(TestHttpMcp),
+            Arc::new(LocalSessionManager::default()),
+            config,
+        );
+        let expected = ExpectedHeaders {
+            authorization: "Bearer remote-token",
+            static_value: "static-value",
+            env_value: "env-value",
+        };
+        let app = Router::new().nest_service("/mcp", service).layer(
+            axum::middleware::from_fn_with_state(expected, require_expected_headers),
+        );
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}/mcp"), task)
+    }
 
     #[test]
     fn unique_name_dedups_with_suffix() {
@@ -604,6 +1001,185 @@ mod tests {
         assert!(e.is_error);
     }
 
+    #[test]
+    fn infers_codex_transports_and_rejects_legacy_protocols() {
+        let stdio = McpServerSpec {
+            command: Some("server".to_string()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            select_transport(&stdio).unwrap(),
+            UpstreamTransport::Stdio("server")
+        ));
+
+        let http = McpServerSpec {
+            url: Some("https://example.invalid/mcp".to_string()),
+            ..Default::default()
+        };
+        assert!(matches!(
+            select_transport(&http).unwrap(),
+            UpstreamTransport::StreamableHttp("https://example.invalid/mcp")
+        ));
+
+        let legacy = McpServerSpec {
+            transport: Some("sse".to_string()),
+            url: Some("https://example.invalid/sse".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            select_transport(&legacy)
+                .unwrap_err()
+                .contains("legacy SSE")
+        );
+    }
+
+    #[test]
+    fn rejects_transport_specific_fields_on_the_wrong_transport() {
+        let stdio = McpServerSpec {
+            command: Some("server".to_string()),
+            bearer_token_env_var: Some("TOKEN".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            select_transport(&stdio)
+                .unwrap_err()
+                .contains("stdio transport cannot configure bearerTokenEnvVar")
+        );
+
+        let http = McpServerSpec {
+            url: Some("https://example.invalid/mcp".to_string()),
+            args: vec!["--stdio".to_string()],
+            ..Default::default()
+        };
+        assert!(
+            select_transport(&http)
+                .unwrap_err()
+                .contains("Streamable HTTP transport cannot configure args")
+        );
+    }
+
+    #[test]
+    fn resolves_remote_credentials_without_exposing_values_in_errors() {
+        let resolved = resolve_bearer_token("remote", Some("REMOTE_TOKEN"), &|name| {
+            (name == "REMOTE_TOKEN").then(|| "secret-value".to_string())
+        })
+        .unwrap();
+        assert_eq!(resolved.as_deref(), Some("secret-value"));
+
+        let missing = resolve_bearer_token("remote", Some("MISSING_TOKEN"), &|_| None).unwrap_err();
+        assert!(missing.contains("MISSING_TOKEN"));
+        assert!(!missing.contains("secret-value"));
+
+        let empty = resolve_bearer_token("remote", Some("EMPTY_TOKEN"), &|_| Some(String::new()))
+            .unwrap_err();
+        assert!(empty.contains("is empty"));
+    }
+
+    #[test]
+    fn environment_headers_override_static_headers() {
+        let spec = McpServerSpec {
+            http_headers: HashMap::from([
+                ("X-Static".to_string(), "static".to_string()),
+                ("X-Override".to_string(), "old".to_string()),
+            ]),
+            env_http_headers: HashMap::from([
+                ("X-Env".to_string(), "ENV_HEADER".to_string()),
+                ("X-Override".to_string(), "OVERRIDE_HEADER".to_string()),
+            ]),
+            ..Default::default()
+        };
+        let headers = build_http_headers(&spec, &|name| match name {
+            "ENV_HEADER" => Some("env".to_string()),
+            "OVERRIDE_HEADER" => Some("new".to_string()),
+            _ => None,
+        });
+        let value = |name| {
+            headers
+                .get(&HeaderName::from_static(name))
+                .and_then(|value| value.to_str().ok())
+        };
+        assert_eq!(value("x-static"), Some("static"));
+        assert_eq!(value("x-env"), Some("env"));
+        assert_eq!(value("x-override"), Some("new"));
+    }
+
+    #[tokio::test]
+    async fn rejects_duplicate_authorization_configuration_before_connecting() {
+        let spec = McpServerSpec {
+            url: Some("https://example.invalid/mcp".to_string()),
+            bearer_token_env_var: Some("REMOTE_TOKEN".to_string()),
+            env_http_headers: HashMap::from([(
+                "Authorization".to_string(),
+                "MISSING_AUTH_HEADER".to_string(),
+            )]),
+            ..Default::default()
+        };
+        let config = crate::config::default_config(std::env::temp_dir());
+        let result = connect_one_with_env("remote", &spec, &config, &|name| {
+            (name == "REMOTE_TOKEN").then(|| "secret-value".to_string())
+        })
+        .await;
+        let error = match result {
+            Ok(_) => panic!("ambiguous authorization should fail before connecting"),
+            Err(error) => error,
+        };
+        assert!(error.contains("either bearerTokenEnvVar or an Authorization HTTP header"));
+        assert!(!error.contains("secret-value"));
+    }
+
+    #[tokio::test]
+    async fn bridges_authenticated_streamable_http_and_applies_tool_timeout() {
+        let (url, server_task) = spawn_http_upstream().await;
+        let spec = McpServerSpec {
+            transport: Some("streamable_http".to_string()),
+            url: Some(url),
+            bearer_token_env_var: Some("REMOTE_TOKEN".to_string()),
+            http_headers: HashMap::from([("X-Static".to_string(), "static-value".to_string())]),
+            env_http_headers: HashMap::from([("X-Env".to_string(), "REMOTE_HEADER".to_string())]),
+            startup_timeout_sec: Some(5.0),
+            tool_timeout_sec: Some(0.05),
+            ..Default::default()
+        };
+        let config = crate::config::default_config(std::env::temp_dir());
+        let (service, tools, tool_timeout) =
+            connect_one_with_env("remote", &spec, &config, &|name| match name {
+                "REMOTE_TOKEN" => Some("remote-token".to_string()),
+                "REMOTE_HEADER" => Some("env-value".to_string()),
+                _ => None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(tools.len(), 2);
+
+        let echo = forward_tool_call(
+            service.peer(),
+            CallToolRequestParams::new("echo")
+                .with_arguments(json!({ "text": "hello" }).as_object().cloned().unwrap()),
+            "remote",
+            "echo",
+            tool_timeout,
+        )
+        .await;
+        assert!(!echo.is_error);
+        assert_eq!(echo.joined_text(), "hello");
+
+        let slow = forward_tool_call(
+            service.peer(),
+            CallToolRequestParams::new("slow")
+                .with_arguments(json!({ "text": "late" }).as_object().cloned().unwrap()),
+            "remote",
+            "slow",
+            tool_timeout,
+        )
+        .await;
+        assert!(slow.is_error);
+        assert!(slow.joined_text().contains("timed out after"));
+
+        drop(service);
+        server_task.abort();
+        let _ = server_task.await;
+    }
+
     #[tokio::test]
     async fn skips_upstream_that_fails_to_launch() {
         let mut config = crate::config::default_config(std::env::temp_dir());
@@ -611,15 +1187,7 @@ mod tests {
             "bad".into(),
             McpServerSpec {
                 command: Some("codex-free-nonexistent-binary-xyz".into()),
-                args: vec![],
-                env: HashMap::new(),
-                cwd: None,
-                disabled: false,
-                transport: None,
-                url: None,
-                tools: None,
-                disabled_tools: None,
-                mode: None,
+                ..Default::default()
             },
         );
         let bridge = connect_upstreams(&config).await;
@@ -638,16 +1206,9 @@ mod tests {
         config.mcp_servers.insert(
             "remote".into(),
             McpServerSpec {
-                command: None,
-                args: vec![],
-                env: HashMap::new(),
-                cwd: None,
-                disabled: false,
                 transport: Some("sse".into()),
                 url: Some("http://localhost:9/sse".into()),
-                tools: None,
-                disabled_tools: None,
-                mode: None,
+                ..Default::default()
             },
         );
         let bridge = connect_upstreams(&config).await;
@@ -666,15 +1227,8 @@ mod tests {
             "off".into(),
             McpServerSpec {
                 command: Some("codex-free-should-never-run".into()),
-                args: vec![],
-                env: HashMap::new(),
-                cwd: None,
                 disabled: true,
-                transport: None,
-                url: None,
-                tools: None,
-                disabled_tools: None,
-                mode: None,
+                ..Default::default()
             },
         );
         let bridge = connect_upstreams(&config).await;

--- a/src/codex_mcp.rs
+++ b/src/codex_mcp.rs
@@ -136,16 +136,6 @@ fn parse_server(
             "both `command` and `url` are configured".to_string(),
         ));
     }
-    if url.is_some() {
-        return Ok(ServerImport::Skipped(
-            "streamable HTTP transport is not supported yet".to_string(),
-        ));
-    }
-    let Some(command) = command.filter(|value| !value.trim().is_empty()) else {
-        return Ok(ServerImport::Skipped(
-            "no non-empty stdio `command` is configured".to_string(),
-        ));
-    };
 
     let environment_id = optional_string(table, "environment_id")?;
     let experimental_environment = optional_string(table, "experimental_environment")?;
@@ -159,38 +149,25 @@ fn parse_server(
         ));
     }
 
-    let mut env = optional_string_map(table, "env")?.unwrap_or_default();
-    for env_var in optional_env_vars(table)?.unwrap_or_default() {
-        match env_var.source.as_deref() {
-            None | Some("local") => {
-                if !env.contains_key(&env_var.name)
-                    && let Some(value) = env_lookup(&env_var.name)
-                {
-                    env.insert(env_var.name, value);
-                }
-            }
-            Some("remote") => {
-                return Ok(ServerImport::Skipped(
-                    "remote-sourced `env_vars` are not supported".to_string(),
-                ));
-            }
-            Some(_) => {
-                return Err("`env_vars.source` must be `local` or `remote`".to_string());
-            }
-        }
-    }
-
     let supported_fields = [
         "args",
+        "bearer_token",
+        "bearer_token_env_var",
         "command",
         "cwd",
         "disabled_tools",
         "enabled",
         "enabled_tools",
         "env",
+        "env_http_headers",
         "env_vars",
         "environment_id",
         "experimental_environment",
+        "http_headers",
+        "http_headers_helper",
+        "startup_timeout_ms",
+        "startup_timeout_sec",
+        "tool_timeout_sec",
         "url",
     ];
     let supported: BTreeSet<&str> = supported_fields.into_iter().collect();
@@ -201,17 +178,113 @@ fn parse_server(
         .collect::<Vec<_>>();
     ignored_fields.sort();
 
+    let startup_timeout_seconds = optional_timeout_seconds(table, "startup_timeout_sec")?;
+    let startup_timeout_milliseconds = optional_timeout_milliseconds(table, "startup_timeout_ms")?;
+    let startup_timeout_sec = startup_timeout_seconds.or(startup_timeout_milliseconds);
+    let tool_timeout_sec = optional_timeout_seconds(table, "tool_timeout_sec")?;
+    let disabled = !optional_bool(table, "enabled")?.unwrap_or(true);
+    let tools = optional_string_list(table, "enabled_tools")?;
+    let disabled_tools = optional_string_list(table, "disabled_tools")?;
+
+    if let Some(command) = command.filter(|value| !value.trim().is_empty()) {
+        for field in [
+            "bearer_token",
+            "bearer_token_env_var",
+            "env_http_headers",
+            "http_headers",
+            "http_headers_helper",
+        ] {
+            if table.contains_key(field) {
+                return Ok(ServerImport::Skipped(format!(
+                    "stdio transport cannot configure `{field}`"
+                )));
+            }
+        }
+
+        let mut env = optional_string_map(table, "env")?.unwrap_or_default();
+        for env_var in optional_env_vars(table)?.unwrap_or_default() {
+            match env_var.source.as_deref() {
+                None | Some("local") => {
+                    if !env.contains_key(&env_var.name)
+                        && let Some(value) = env_lookup(&env_var.name)
+                    {
+                        env.insert(env_var.name, value);
+                    }
+                }
+                Some("remote") => {
+                    return Ok(ServerImport::Skipped(
+                        "remote-sourced `env_vars` are not supported".to_string(),
+                    ));
+                }
+                Some(_) => {
+                    return Err("`env_vars.source` must be `local` or `remote`".to_string());
+                }
+            }
+        }
+
+        return Ok(ServerImport::Imported {
+            spec: Box::new(McpServerSpec {
+                command: Some(command),
+                args: optional_string_list(table, "args")?.unwrap_or_default(),
+                env,
+                cwd: optional_string(table, "cwd")?,
+                disabled,
+                transport: None,
+                url: None,
+                bearer_token_env_var: None,
+                http_headers: HashMap::new(),
+                env_http_headers: HashMap::new(),
+                startup_timeout_sec,
+                tool_timeout_sec,
+                tools,
+                disabled_tools,
+                mode: None,
+            }),
+            ignored_fields,
+        });
+    }
+
+    let Some(url) = url.filter(|value| !value.trim().is_empty()) else {
+        return Ok(ServerImport::Skipped(
+            "neither a non-empty stdio `command` nor Streamable HTTP `url` is configured"
+                .to_string(),
+        ));
+    };
+
+    for field in ["args", "cwd", "env", "env_vars"] {
+        if table.contains_key(field) {
+            return Ok(ServerImport::Skipped(format!(
+                "streamable HTTP transport cannot configure `{field}`"
+            )));
+        }
+    }
+    if table.contains_key("bearer_token") {
+        return Ok(ServerImport::Skipped(
+            "literal `bearer_token` values are rejected; use `bearer_token_env_var`".to_string(),
+        ));
+    }
+    if table.contains_key("http_headers_helper") {
+        return Ok(ServerImport::Skipped(
+            "`http_headers_helper` is not supported".to_string(),
+        ));
+    }
+
     Ok(ServerImport::Imported {
         spec: Box::new(McpServerSpec {
-            command: Some(command),
-            args: optional_string_list(table, "args")?.unwrap_or_default(),
-            env,
-            cwd: optional_string(table, "cwd")?,
-            disabled: !optional_bool(table, "enabled")?.unwrap_or(true),
-            transport: None,
-            url: None,
-            tools: optional_string_list(table, "enabled_tools")?,
-            disabled_tools: optional_string_list(table, "disabled_tools")?,
+            command: None,
+            args: Vec::new(),
+            env: HashMap::new(),
+            cwd: None,
+            disabled,
+            transport: Some("streamable-http".to_string()),
+            url: Some(url),
+            bearer_token_env_var: optional_string(table, "bearer_token_env_var")?,
+            http_headers: optional_string_map(table, "http_headers")?.unwrap_or_default(),
+            env_http_headers: optional_string_map(table, "env_http_headers")?.unwrap_or_default(),
+            startup_timeout_sec,
+            tool_timeout_sec,
+            tools,
+            disabled_tools,
             mode: None,
         }),
         ignored_fields,
@@ -270,6 +343,33 @@ fn optional_bool(table: &toml::Table, key: &str) -> Result<Option<bool>, String>
             .map(Some)
             .ok_or_else(|| format!("`{key}` must be a boolean")),
     }
+}
+
+fn optional_timeout_seconds(table: &toml::Table, key: &str) -> Result<Option<f64>, String> {
+    let Some(value) = table.get(key) else {
+        return Ok(None);
+    };
+    let seconds = value
+        .as_float()
+        .or_else(|| value.as_integer().map(|value| value as f64))
+        .ok_or_else(|| format!("`{key}` must be a non-negative number"))?;
+    if !seconds.is_finite() || seconds < 0.0 {
+        return Err(format!("`{key}` must be a non-negative finite number"));
+    }
+    Ok(Some(seconds))
+}
+
+fn optional_timeout_milliseconds(table: &toml::Table, key: &str) -> Result<Option<f64>, String> {
+    let Some(value) = table.get(key) else {
+        return Ok(None);
+    };
+    let milliseconds = value
+        .as_integer()
+        .ok_or_else(|| format!("`{key}` must be a non-negative integer"))?;
+    if milliseconds < 0 {
+        return Err(format!("`{key}` must be a non-negative integer"));
+    }
+    Ok(Some(milliseconds as f64 / 1000.0))
 }
 
 fn optional_string_list(table: &toml::Table, key: &str) -> Result<Option<Vec<String>>, String> {
@@ -386,7 +486,7 @@ STATIC_SECRET = "do-not-log-this"
     }
 
     #[test]
-    fn imports_disabled_server_but_skips_http_and_remote_servers() {
+    fn imports_disabled_and_streamable_http_but_skips_remote_execution() {
         let contents = r#"
 [mcp_servers.off]
 command = "off-server"
@@ -394,6 +494,11 @@ enabled = false
 
 [mcp_servers.web]
 url = "https://example.invalid/mcp"
+bearer_token_env_var = "WEB_TOKEN"
+startup_timeout_sec = 12
+tool_timeout_sec = 34.5
+http_headers = { X-Static = "public" }
+env_http_headers = { X-Secret = "WEB_HEADER" }
 
 [mcp_servers.remote]
 command = "remote-server"
@@ -401,11 +506,70 @@ environment_id = "executor"
 "#;
         let outcome = parse_codex_mcp_servers(contents, &|_| None).unwrap();
         assert!(outcome.servers.get("off").unwrap().disabled);
-        assert!(!outcome.servers.contains_key("web"));
+        let web = outcome.servers.get("web").unwrap();
+        assert_eq!(web.transport.as_deref(), Some("streamable-http"));
+        assert_eq!(web.url.as_deref(), Some("https://example.invalid/mcp"));
+        assert_eq!(web.bearer_token_env_var.as_deref(), Some("WEB_TOKEN"));
+        assert_eq!(
+            web.http_headers.get("X-Static").map(String::as_str),
+            Some("public")
+        );
+        assert_eq!(
+            web.env_http_headers.get("X-Secret").map(String::as_str),
+            Some("WEB_HEADER")
+        );
+        assert_eq!(web.startup_timeout_sec, Some(12.0));
+        assert_eq!(web.tool_timeout_sec, Some(34.5));
         assert!(!outcome.servers.contains_key("remote"));
         let report = outcome.report.join("\n");
-        assert!(report.contains("web -> skipped: streamable HTTP"));
+        assert!(report.contains("web -> imported from Codex"));
         assert!(report.contains("remote -> skipped: non-local"));
+        assert!(!report.contains("public"));
+    }
+
+    #[test]
+    fn imports_legacy_startup_timeout_milliseconds() {
+        let contents = r#"
+[mcp_servers.web]
+url = "https://example.invalid/mcp"
+startup_timeout_ms = 1250
+"#;
+        let outcome = parse_codex_mcp_servers(contents, &|_| None).unwrap();
+        assert_eq!(
+            outcome.servers.get("web").unwrap().startup_timeout_sec,
+            Some(1.25)
+        );
+    }
+
+    #[test]
+    fn rejects_non_integer_legacy_startup_timeout_even_when_seconds_are_present() {
+        let contents = r#"
+[mcp_servers.web]
+url = "https://example.invalid/mcp"
+startup_timeout_sec = 2
+startup_timeout_ms = 12.5
+"#;
+        let outcome = parse_codex_mcp_servers(contents, &|_| None).unwrap();
+        assert!(!outcome.servers.contains_key("web"));
+        assert!(
+            outcome
+                .report
+                .join("\n")
+                .contains("`startup_timeout_ms` must be a non-negative integer")
+        );
+    }
+
+    #[test]
+    fn rejects_literal_remote_bearer_without_echoing_it() {
+        let secret = "literal-secret-that-must-not-appear";
+        let contents = format!(
+            "[mcp_servers.web]\nurl = \"https://example.invalid/mcp\"\nbearer_token = \"{secret}\"\n"
+        );
+        let outcome = parse_codex_mcp_servers(&contents, &|_| None).unwrap();
+        assert!(!outcome.servers.contains_key("web"));
+        let report = outcome.report.join("\n");
+        assert!(report.contains("literal `bearer_token` values are rejected"));
+        assert!(!report.contains(secret));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,6 +165,11 @@ struct PartialMcpServerSpec {
     #[serde(rename = "type")]
     transport: Option<String>,
     url: Option<String>,
+    bearer_token_env_var: Option<String>,
+    http_headers: Option<HashMap<String, String>>,
+    env_http_headers: Option<HashMap<String, String>>,
+    startup_timeout_sec: Option<f64>,
+    tool_timeout_sec: Option<f64>,
     tools: Option<Vec<String>>,
     disabled_tools: Option<Vec<String>>,
     mode: Option<String>,
@@ -180,13 +185,24 @@ impl PartialMcpServerSpec {
             disabled,
             transport,
             url,
+            bearer_token_env_var,
+            http_headers,
+            env_http_headers,
+            startup_timeout_sec,
+            tool_timeout_sec,
             tools,
             disabled_tools,
             mode,
         } = self;
         let sets_command = command.is_some();
+        let sets_args = args.is_some();
+        let sets_env = env.is_some();
+        let sets_cwd = cwd.is_some();
         let sets_url = url.is_some();
         let sets_transport = transport.is_some();
+        let sets_bearer_token_env_var = bearer_token_env_var.is_some();
+        let sets_http_headers = http_headers.is_some();
+        let sets_env_http_headers = env_http_headers.is_some();
 
         if let Some(command) = command {
             base.command = Some(command);
@@ -209,6 +225,21 @@ impl PartialMcpServerSpec {
         if let Some(url) = url {
             base.url = Some(url);
         }
+        if let Some(bearer_token_env_var) = bearer_token_env_var {
+            base.bearer_token_env_var = Some(bearer_token_env_var);
+        }
+        if let Some(http_headers) = http_headers {
+            base.http_headers = http_headers;
+        }
+        if let Some(env_http_headers) = env_http_headers {
+            base.env_http_headers = env_http_headers;
+        }
+        if let Some(startup_timeout_sec) = startup_timeout_sec {
+            base.startup_timeout_sec = Some(startup_timeout_sec);
+        }
+        if let Some(tool_timeout_sec) = tool_timeout_sec {
+            base.tool_timeout_sec = Some(tool_timeout_sec);
+        }
         if let Some(tools) = tools {
             base.tools = Some(tools);
         }
@@ -223,11 +254,29 @@ impl PartialMcpServerSpec {
         // than leaving an impossible command+URL hybrid behind.
         if sets_command && !sets_url {
             base.url = None;
+            if !sets_bearer_token_env_var {
+                base.bearer_token_env_var = None;
+            }
+            if !sets_http_headers {
+                base.http_headers.clear();
+            }
+            if !sets_env_http_headers {
+                base.env_http_headers.clear();
+            }
             if !sets_transport {
                 base.transport = None;
             }
         } else if sets_url && !sets_command {
             base.command = None;
+            if !sets_args {
+                base.args.clear();
+            }
+            if !sets_env {
+                base.env.clear();
+            }
+            if !sets_cwd {
+                base.cwd = None;
+            }
             if !sets_transport {
                 base.transport = Some("streamable-http".to_string());
             }
@@ -590,6 +639,11 @@ mod tests {
             disabled: true,
             transport: None,
             url: None,
+            bearer_token_env_var: None,
+            http_headers: HashMap::new(),
+            env_http_headers: HashMap::new(),
+            startup_timeout_sec: None,
+            tool_timeout_sec: None,
             tools: Some(vec!["read".to_string()]),
             disabled_tools: Some(vec!["write".to_string()]),
             mode: None,
@@ -639,6 +693,12 @@ mod tests {
             McpServerSpec {
                 transport: Some("streamable-http".to_string()),
                 url: Some("https://example.invalid/mcp".to_string()),
+                bearer_token_env_var: Some("TOKEN".to_string()),
+                http_headers: HashMap::from([("X-Static".to_string(), "value".to_string())]),
+                env_http_headers: HashMap::from([(
+                    "X-Secret".to_string(),
+                    "HEADER_TOKEN".to_string(),
+                )]),
                 ..Default::default()
             },
         )]);
@@ -655,6 +715,60 @@ mod tests {
         assert_eq!(server.command.as_deref(), Some("local-server"));
         assert!(server.url.is_none());
         assert!(server.transport.is_none());
+        assert!(server.bearer_token_env_var.is_none());
+        assert!(server.http_headers.is_empty());
+        assert!(server.env_http_headers.is_empty());
+    }
+
+    #[test]
+    fn explicit_url_replaces_imported_stdio_transport() {
+        let imported = HashMap::from([("demo".to_string(), imported_server())]);
+        let explicit = HashMap::from([(
+            "demo".to_string(),
+            PartialMcpServerSpec {
+                url: Some("https://example.invalid/mcp".to_string()),
+                bearer_token_env_var: Some("TOKEN".to_string()),
+                ..Default::default()
+            },
+        )]);
+
+        let (merged, _) = merge_mcp_servers(imported, explicit);
+        let server = merged.get("demo").unwrap();
+        assert!(server.command.is_none());
+        assert!(server.args.is_empty());
+        assert!(server.env.is_empty());
+        assert!(server.cwd.is_none());
+        assert_eq!(server.transport.as_deref(), Some("streamable-http"));
+        assert_eq!(server.bearer_token_env_var.as_deref(), Some("TOKEN"));
+    }
+
+    #[test]
+    fn explicit_incompatible_transport_fields_are_not_silently_discarded() {
+        let stdio = HashMap::from([(
+            "stdio".to_string(),
+            PartialMcpServerSpec {
+                command: Some("local-server".to_string()),
+                bearer_token_env_var: Some("TOKEN".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let (merged, _) = merge_mcp_servers(HashMap::new(), stdio);
+        let server = merged.get("stdio").unwrap();
+        assert_eq!(server.command.as_deref(), Some("local-server"));
+        assert_eq!(server.bearer_token_env_var.as_deref(), Some("TOKEN"));
+
+        let http = HashMap::from([(
+            "http".to_string(),
+            PartialMcpServerSpec {
+                url: Some("https://example.invalid/mcp".to_string()),
+                args: Some(vec!["--stdio".to_string()]),
+                ..Default::default()
+            },
+        )]);
+        let (merged, _) = merge_mcp_servers(HashMap::new(), http);
+        let server = merged.get("http").unwrap();
+        assert_eq!(server.url.as_deref(), Some("https://example.invalid/mcp"));
+        assert_eq!(server.args, ["--stdio"]);
     }
 
     #[test]
@@ -664,6 +778,12 @@ mod tests {
                 "codexMcp": { "enabled": false },
                 "mcpServers": {
                     "demo": {
+                        "url": "https://example.invalid/mcp",
+                        "bearerTokenEnvVar": "TOKEN",
+                        "httpHeaders": { "X-Static": "public" },
+                        "envHttpHeaders": { "X-Secret": "SECRET_HEADER" },
+                        "startupTimeoutSec": 12.5,
+                        "toolTimeoutSec": 30,
                         "mode": "gateway",
                         "disabledTools": ["write"]
                     }
@@ -674,6 +794,18 @@ mod tests {
 
         assert!(!file.codex_mcp.as_ref().unwrap().enabled());
         let demo = file.mcp_servers.as_ref().unwrap().get("demo").unwrap();
+        assert_eq!(demo.url.as_deref(), Some("https://example.invalid/mcp"));
+        assert_eq!(demo.bearer_token_env_var.as_deref(), Some("TOKEN"));
+        assert_eq!(
+            demo.http_headers
+                .as_ref()
+                .unwrap()
+                .get("X-Static")
+                .map(String::as_str),
+            Some("public")
+        );
+        assert_eq!(demo.startup_timeout_sec, Some(12.5));
+        assert_eq!(demo.tool_timeout_sec, Some(30.0));
         assert_eq!(demo.mode.as_deref(), Some("gateway"));
         assert_eq!(
             demo.disabled_tools.as_deref(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -231,14 +231,13 @@ pub struct CommandConfig {
 
 /// One upstream MCP server to bridge, in the standard `mcpServers` shape. Its
 /// tools are discovered at startup and re-exposed under a `<server>__<tool>`
-/// name. Only stdio servers (a `command`) are bridged today; `type: "sse"|"http"`
-/// / `url` entries are recognised and reported as not-yet-supported rather than
-/// failing the whole config.
+/// name. A `command` selects stdio; a `url` selects Codex-compatible Streamable
+/// HTTP. Legacy SSE and WebSocket transports are rejected explicitly.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpServerSpec {
     /// The executable to launch (e.g. `idasql`, `npx`, `python`). Absent for
-    /// url-based (sse/http) servers.
+    /// Streamable HTTP servers.
     #[serde(default)]
     pub command: Option<String>,
     #[serde(default)]
@@ -252,13 +251,29 @@ pub struct McpServerSpec {
     /// Skip this server without removing it from the config.
     #[serde(default)]
     pub disabled: bool,
-    /// Transport type, as in the standard config: `"stdio"` (default),
-    /// `"sse"`, `"http"`. Only `stdio` is bridged so far.
+    /// Transport type. `"stdio"` is inferred from `command`; `"http"`,
+    /// `"streamable-http"`, and `"streamable_http"` are equivalent when `url`
+    /// is present.
     #[serde(rename = "type", default)]
     pub transport: Option<String>,
-    /// URL for an sse/http server. Recognised but not yet bridged.
+    /// URL for a Streamable HTTP server.
     #[serde(default)]
     pub url: Option<String>,
+    /// Environment variable containing a bearer token for Streamable HTTP.
+    #[serde(default)]
+    pub bearer_token_env_var: Option<String>,
+    /// Static headers sent with every Streamable HTTP request.
+    #[serde(default)]
+    pub http_headers: std::collections::HashMap<String, String>,
+    /// Header-name to environment-variable mappings resolved at connection time.
+    #[serde(default)]
+    pub env_http_headers: std::collections::HashMap<String, String>,
+    /// Timeout for initialization and the first tools listing, in seconds.
+    #[serde(default)]
+    pub startup_timeout_sec: Option<f64>,
+    /// Timeout for each forwarded tool call, in seconds.
+    #[serde(default)]
+    pub tool_timeout_sec: Option<f64>,
     /// If set, only these upstream tool names are bridged (an allow-list on the
     /// upstream's own names, e.g. `["exec", "machine_list"]`). Use it to keep the
     /// exposed tool count small — LLM clients work better with fewer tools and


### PR DESCRIPTION
## Overview

Add Codex-compatible Streamable HTTP as an upstream MCP transport alongside the existing stdio bridge.

Codex Free already serves ChatGPT over Streamable HTTP. This change addresses the opposite direction: when Codex Free acts as an MCP client and aggregates another server, a `url` entry can now be connected directly instead of being rejected as unsupported.

## Transport behavior

- Infer stdio from `command` and Streamable HTTP from `url`.
- Accept explicit `http`, `streamable-http`, and `streamable_http` aliases.
- Use rmcp's reqwest-backed Streamable HTTP client, including MCP session handling and JSON/SSE responses.
- Apply `startupTimeoutSec` to initialization plus the initial `tools/list` request; the default remains 20 seconds.
- Apply optional `toolTimeoutSec` to direct and gateway calls through rmcp's cancellable request path, so a timeout sends MCP cancellation instead of merely dropping the local future.
- Preserve the existing allow-list, deny-list, direct-tool, gateway, result-forwarding, and per-upstream non-fatal startup behavior.
- Reject legacy SSE and WebSocket transport names explicitly rather than treating them as Streamable HTTP.

## Authentication and headers

Streamable HTTP entries support:

```json
{
  "mcpServers": {
    "remote-docs": {
      "url": "https://mcp.example.com/mcp",
      "bearerTokenEnvVar": "REMOTE_MCP_TOKEN",
      "httpHeaders": {
        "X-Client": "codex-free"
      },
      "envHttpHeaders": {
        "X-Tenant": "REMOTE_MCP_TENANT"
      },
      "startupTimeoutSec": 20,
      "toolTimeoutSec": 60,
      "tools": ["search", "read"]
    }
  }
}
```

- `bearerTokenEnvVar` resolves a bearer token when the upstream connection is created.
- `envHttpHeaders` maps header names to environment-variable names and overrides same-named static headers.
- Missing or empty environment-backed non-bearer headers are omitted, matching Codex's header behavior.
- A configured bearer-token variable must exist and be non-empty.
- Bearer-token authentication and an explicit `Authorization` header cannot be configured together.
- Credential and header values are not included in discovery reports or connection errors.

## Native Codex configuration

The read-only `$CODEX_HOME/config.toml` importer now preserves compatible remote entries and fields:

- `url`
- `bearer_token_env_var`
- `http_headers`
- `env_http_headers`
- `startup_timeout_sec` and legacy integer `startup_timeout_ms`
- `tool_timeout_sec`
- enablement and tool filters

Explicit `codex.config.json` entries remain field overlays. Replacing an imported URL with `command`, or an imported command with `url`, clears only inherited fields from the old transport. Explicitly mixed stdio/HTTP settings are retained long enough to fail with a clear validation error instead of being silently discarded.

Literal imported `bearer_token` values are rejected in favor of environment references. Non-local Codex execution environments, remote-sourced stdio variables, and `http_headers_helper` remain unsupported and are reported without exposing values.

## Scope boundary

This PR implements the missing upstream transport, authentication/header inputs needed for non-interactive use, and Codex timeout semantics. It does not add Codex-managed OAuth login persistence, MCP resources/templates/prompts, upstream initialization-instruction forwarding, dynamic `tools/list_changed` handling, or generic capability forwarding. Those are separate client-capability layers rather than transports.

## Relationship to PR #9

This PR is intentionally based on `master` and does not depend on PR #9. Explicit remote entries and the existing direct Codex `config.toml` importer work independently. When PR #9 is rebased after this change, its effective-catalogue converter should map Codex CLI `streamable_http` fields into the same `McpServerSpec` instead of retaining its current stdio-only rejection; the runtime transport in this PR requires no further changes.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --quiet` — 403 passed
- `git diff --check`

The tests include a real loopback Streamable HTTP MCP server that requires bearer, static, and environment-backed headers, then verifies tool discovery, a successful forwarded call, and cancellation-aware tool timeout behavior.


