### PR TITLE
feat: add scoped review checkpoints and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Project-scoped review checkpoints with immutable project-open and incremental
+  last-review baselines. `show_changes` reports structured file statistics,
+  renames, binaries and a bounded complete patch, and can advance the incremental
+  baseline with compare-and-swap semantics.
+- A self-contained MCP Apps review resource linked from `show_changes`. Compatible
+  ChatGPT developer connectors render file summaries and patches interactively;
+  ordinary MCP clients continue to receive the same text and structured result.
+
+### Security
+
+- Review snapshots use a private temporary Git index and an explicit literal
+  pathspec for the selected project. They preserve the real index byte-for-byte, never
+  include sibling monorepo changes, return project-relative patch paths, and persist
+  only hashed conversation identifiers in the dedicated `refs/codex-free/review/`
+  namespace. Mutating calls and reviews for one conversation/project scope are
+  serialized through tool completion.
+
 ## [1.2.0] - 2026-08-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A local MCP bridge server that lets ChatGPT Web Pro call tools on your machine: 
 
 In native-tunnel mode, Codex Free listens only on `127.0.0.1`, protects the MCP endpoint with a random per-process bearer token, starts OpenAI's official runtime-only tunnel client, and supervises it for the lifetime of the server. The tunnel client makes outbound HTTPS requests to OpenAI and forwards tunnel traffic to the authenticated loopback MCP endpoint. A conventional externally managed tunnel remains available as an alternative.
 
-The tool set covers the ones [Codex](https://github.com/openai/codex) gives its own agent — `apply_patch`, `exec_command`/`write_stdin`, `view_image`, `update_plan`, `clock_curr_time`/`clock_sleep` — so ChatGPT Web can work the way Codex does: patch files in place instead of rewriting them, drive interactive and long-running processes, and keep a plan across a task. It carries the project's `AGENTS.md` and Codex's own agent brief, so the client is told how to behave and not just what it can call. It bounds what a tool call can return and keeps a plan and notes on disk across conversations, addressing the one thing Codex never had to solve — a context window far smaller than the task. And it loads Codex's skills: a `SKILL.md` in the repo or your home directory teaches the client how *you* do a recurring task, and only the ones that apply are ever read. Schemas and prompt are ported from the Codex source, not reimplemented from guesswork.
+The tool set covers the ones [Codex](https://github.com/openai/codex) gives its own agent — `apply_patch`, `exec_command`/`write_stdin`, `view_image`, `update_plan`, `clock_curr_time`/`clock_sleep` — so ChatGPT Web can work the way Codex does: patch files in place instead of rewriting them, drive interactive and long-running processes, and keep a plan across a task. It carries the project's `AGENTS.md` and Codex's own agent brief, so the client is told how to behave and not just what it can call. It bounds what a tool call can return, keeps a plan and notes on disk across conversations, and records project-scoped review checkpoints so ChatGPT can inspect either the full task diff or only changes since the last review. And it loads Codex's skills: a `SKILL.md` in the repo or your home directory teaches the client how *you* do a recurring task, and only the ones that apply are ever read. Schemas and prompt are ported from the Codex source, not reimplemented from guesswork.
 
 Beyond the port, Codex Free can **aggregate other MCP servers** — connecting to your local stdio MCP servers and re-exposing their tools through its own endpoint, so the ChatGPT-side agent can call them too.
 
@@ -23,7 +23,7 @@ flowchart LR
     FS["read_file\nwrite_file\nlist_directory\ntree"]
     Search["glob\ngrep"]
     Shell["run_command"]
-    Git["git_status\ngit_push\ngit_commit\ngit_log"]
+    Git["git_status\nshow_changes\ngit_push\ngit_commit\ngit_log"]
     Edit["apply_patch"]
     Exec["exec_command\nwrite_stdin"]
     Agent["view_image\nupdate_plan\nclock_curr_time\nclock_sleep"]
@@ -35,6 +35,8 @@ flowchart LR
     WorkDir[("Project root\nper-conversation in\nmulti-project mode")]
     State[("~/.codex-free\nmemory (per project)")]
     Bindings[("~/.codex-free\nconversation-projects")]
+    ReviewRefs[("Git refs/codex-free/review\nproject-open + last-review")]
+    ReviewUI["MCP App review card\nui://codex-free/review/mcp-app.html"]
     SkillDirs[(".agents/skills\n.codex/skills\n.claude/skills")]
     CodexCfg[("$CODEX_HOME\nconfig.toml")]
     Upstream[("Upstream MCP\nservers (stdio)")]
@@ -67,6 +69,8 @@ flowchart LR
     Mem --> State
     Skills --> SkillDirs
     SetRoot --> Bindings
+    Git --> ReviewRefs
+    Git -.-> ReviewUI
     SetRoot -.->|"selects"| WorkDir
     CodexCfg -.->|"auto-import"| Bridge
     Bridge --> Upstream
@@ -153,6 +157,7 @@ Structured primitives — cheaper and safer than shelling out for the same job, 
 | `write_file` | Write content to a file, creating parent directories if needed |
 | `run_command` | Execute a command in the work directory (allowlist-restricted) |
 | `git_status` | Show git status, parsed into changed files with status codes |
+| `show_changes` | Compare the scoped working tree with the project-open or last-review checkpoint, optionally advancing the incremental baseline; compatible hosts render an interactive review card |
 | `git_push` | Push commits to a remote |
 | `git_commit` | Create a commit, optionally staging all tracked changes |
 | `git_log` | Show recent commit history |
@@ -195,7 +200,7 @@ Multi-project mode adds one project-control tool:
 
 Codex needs the first three for none of these reasons: it puts its agent brief in the system prompt, the OS and shell in an `<environment_context>` message, and `AGENTS.md` straight into the prompt, all before the first turn. An MCP server has none of those channels — it can only expose tools — so the same facts are tool calls here as well as part of the server's `instructions`. It needs `remember` and `recall` for the opposite reason: its context is large and its session state lives in the CLI process, whereas the client here is a chat window that loses the conversation. See [Context and memory](#context-and-memory), [Acting as a Codex agent](#acting-as-a-codex-agent), [Shells and the host](#shells-and-the-host), [AGENTS.md](#agentsmd) and [Skills](#skills).
 
-That is 25 native tools in the default single-project mode and 26 in multi-project mode. When [MCP bridging](#bridging-other-mcp-servers) is configured, the tools of your other MCP servers are re-exposed here too, on top of these.
+That is 26 native tools in the default single-project mode and 27 in multi-project mode. When [MCP bridging](#bridging-other-mcp-servers) is configured, the tools of your other MCP servers are re-exposed here too, on top of these.
 
 Two deliberate differences from Codex:
 
@@ -204,7 +209,7 @@ Two deliberate differences from Codex:
 
 `clock_sleep` also caps at 5 minutes rather than Codex's 12 hours — a longer wait would outlive the HTTP request through the tunnel.
 
-Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it.
+Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `show_changes` returns its review summary, file records, warnings and bounded patch, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it.
 
 All project-scoped paths are resolved relative to the active project root: `--work-dir` in single-project mode, or the root selected for the current ChatGPT conversation in multi-project mode. Non-ChatGPT clients use the root selected for their current MCP transport session.
 
@@ -248,6 +253,9 @@ All project-scoped paths are resolved relative to the active project root: `--wo
     "maxFileBytes": 131072,
     "maxEntries": 500,
     "maxTreeNodes": 1000
+  },
+  "review": {
+    "maxPatchBytes": 524288
   },
   "memory": {
     "enabled": true,
@@ -324,6 +332,12 @@ The `output` block bounds what a single tool call may return. See [Context and m
 | `maxEntries` | `500` | Results per `glob` or `list_directory` call |
 | `maxTreeNodes` | `1000` | Nodes in one `tree` walk, counted across the whole tree rather than per directory |
 
+The `review` block bounds presentation without changing checkpoint semantics:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `maxPatchBytes` | `524288` | Largest complete binary-capable patch returned by `show_changes`; a larger patch is omitted rather than cut mid-hunk, while file metadata and aggregate statistics remain available. `0` disables patch bodies |
+
 The `memory` block governs `remember`, `recall` and the plan `update_plan` saves:
 
 | Key | Default | Description |
@@ -364,6 +378,28 @@ Each conversation binds a project exactly once, through the [`set_project_root`]
 Per-conversation separation extends to saved state: with an explicit `memory.dir`, each selected project gets its own hashed child directory (see the [`memory` block](#config-file)), and conversation bindings stay enabled even when `memory.enabled` is `false`. The end-to-end onboarding flow — select, then request the brief — is in [Starting a chat](#starting-a-chat).
 
 To clear a stray binding, delete its file under `~/.codex-free/conversation-projects/`; there is no tool to re-point an already-bound conversation.
+
+## Review checkpoints and ChatGPT UI
+
+Review state is initialized immediately before the first project-scoped tool call for a conversation or generic MCP transport. That timing captures the checkout as the agent first sees it, before a write, formatter, generator, or shell command can change it. Mutating tool calls and `show_changes` are serialized for the same owner and project through tool completion, so a review cannot advance over a partially completed write. A resident `exec_command` process may continue changing files after its initiating call returns, so every review remains a point-in-time snapshot. Non-Git projects remain usable; inside a Git worktree, a snapshot failure blocks mutating tools rather than silently losing the baseline. Two baselines are maintained:
+
+- **project open** is immutable and shows the complete task diff;
+- **last review** advances only when `show_changes` is called with `advance=true` (the default), so the next review is incremental.
+
+`show_changes` accepts `since: "last_review" | "project_open"`, `advance`, and `include_patch`. Use `advance=false` for a read-only inspection. The result contains a concise text summary plus structured aggregate counts, bounded file records, rename sources, binary markers, warnings, and a complete unified binary patch when it fits `review.maxPatchBytes`. Oversized patches are omitted explicitly rather than returned as invalid partial hunks.
+
+Snapshots use Git objects, but they do **not** touch the real index or working tree. Codex Free builds a private temporary index containing only the logical project root, then carries the same literal pathspec through every comparison. If the selected project is `packages/app` inside a monorepo, sibling changes under `packages/other` cannot enter its checkpoint or diff. Paths returned to the model and UI are relative to the selected project, not the repository root.
+
+With ChatGPT's stable `_meta["openai/session"]`, each conversation/project scope stores exactly two namespaced refs under:
+
+```text
+refs/codex-free/review/<project-hash>/<conversation-hash>/project-open
+refs/codex-free/review/<project-hash>/<conversation-hash>/last-review
+```
+
+The raw conversation identifier is never written. The refs survive MCP reconnects and Codex Free restarts. Generic MCP clients receive transport-local in-memory checkpoints instead. Each conversation/project pair retains only its current two referenced snapshots; superseded synthetic commits are ordinary Git-GC candidates. To inspect or remove old conversation refs manually, use `git for-each-ref refs/codex-free/review/` and `git update-ref -d <ref>`. Removing both refs resets that owner to the current scoped state on its next project call.
+
+Codex Free also advertises the standard MCP Apps extension and serves a self-contained resource at `ui://codex-free/review/mcp-app.html`. Compatible ChatGPT developer connectors render `show_changes` as a file, statistic and patch card. No separate web service or public app publication is needed; clients that ignore MCP Apps metadata still receive the same ordinary MCP result. The card updates at the `show_changes` tool-call boundary—it is not a continuous filesystem watcher.
 
 ## Context and memory
 
@@ -577,7 +613,7 @@ Codex MCP discovery: /home/user/.codex/config.toml
   idasql -> imported from Codex
   remote-exec -> imported fields overlaid by codex.config.json
 bridged MCP server 'idasql': 12 tool(s)
-Tools loaded (37): 25 native + 12 bridged from upstream MCP servers
+Tools loaded (38): 26 native + 12 bridged from upstream MCP servers
 ```
 
 Each upstream tool is offered as `<server>__<tool>` (for example `remote_exec__docker_ps`), and calls are forwarded to the upstream verbatim — text, images, structured content and error flags all pass through. An upstream that fails to launch or answer is skipped; it never blocks startup or the native tools.
@@ -646,6 +682,7 @@ Native tunnel mode ignores `allowedHosts` and forces the accepted authorities to
 
 - **Path traversal prevention**: every filesystem tool — including `apply_patch` and `view_image` — resolves paths through a guard that rejects anything outside the active project root. In multi-project mode, `set_project_root` canonicalizes both the configured access root and the requested directory, so `..` and symlinks cannot bind a conversation or transport session outside the access root.
 - **One bounded exception in single-project mode**: [AGENTS.md](#agentsmd) discovery may read above `--work-dir`, up to the nearest `.git`. It is read-only, opens only `AGENTS.override.md`, `AGENTS.md` and any `projectDoc.fallbackFilenames`, and `get_project_doc` reports the absolute path of every file it used. Set `projectDoc.maxBytes` to `0` to switch it off, or `projectDoc.rootMarkers` to `[]` to keep the search inside the work directory. Multi-project mode does not perform this upward walk; its selected directory is the exact project root.
+- **Namespaced review state inside Git**: ChatGPT review checkpoints are exactly two refs per conversation/project pair under `refs/codex-free/review/`. Synthetic snapshots contain only the selected project path, are built through a temporary index, and never modify the real index or working tree. Generic MCP-client checkpoints are in memory only. The namespace grows with the number of distinct persistent conversation/project pairs; the review section documents inspection and manual removal.
 - **Bounded state writes outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/projects/`. Multi-project mode also writes one small project-binding record under `~/.codex-free/conversation-projects/` for each ChatGPT conversation and access root. Both use atomic replacement and per-record locks. The binding filename is derived from a hash of `openai/session`; the raw identifier is not stored. Set `memory.enabled` to `false` to disable plans and notes; delete `~/.codex-free/conversation-projects/` separately to forget conversation bindings. See [Context and memory](#context-and-memory).
 - **Bounded reads outside the work directory**: [skills](#skills) may live in `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` or an installed Claude Code plugin. `skills_read` opens files there, but only inside a skill package that already exists — the `resource` path is checked against the skill's own directory, so it cannot walk out into the rest of your home directory. `skills_list` reports the absolute path of every skill it found. Set `skills.enabled` to `false` to switch it off, or `skills.dirs` to point the user scope somewhere you choose.
 - **Command allowlist**: `run_command` only runs binaries listed in `allowedCommands`; everything else is rejected. `exec_command` checks the same list plus `exec.extraAllowedCommands`, at every command position in the string.

--- a/codex.config.json
+++ b/codex.config.json
@@ -22,5 +22,8 @@
     ],
     "maxSessions": 8,
     "idleTimeoutMs": 300000
+  },
+  "review": {
+    "maxPatchBytes": 524288
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,11 +30,11 @@ ChatGPT / MCP client
 │                                               │
 │  /health   /mcp (StreamableHttpService)       │
 │                                               │
-│  ServerHandler ── list_tools / call_tool      │
+│  ServerHandler ── tools + resources           │
 │        │                                      │
 │        ▼                                      │
 │  registry: Vec<Box<dyn Tool>>                 │
-│    • 25 native tools                          │
+│    • 26 native tools                          │
 │    • + set_project_root in multi-project mode │
 │    • bridged tools  ← upstream MCP servers    │
 │    • gateway tools  ← upstream MCP servers    │
@@ -43,22 +43,28 @@ ChatGPT / MCP client
 │    • openai/session hash → project root       │
 │    • persistent atomic binding records        │
 │                                               │
+│  shared ReviewCheckpointManager               │
+│    • project-open + last-review snapshots     │
+│    • scoped Git refs + MCP Apps resource      │
+│                                               │
 │  per-transport SessionState                   │
 │    • fallback root for generic MCP clients    │
-│    • exec sessions + current plan             │
+│    • exec sessions + plan + review fallback   │
 └──────────────────────────────────────────────┘
         │ reads/writes           │ stdio child processes
         ▼                        ▼
    active project root     upstream MCP servers (idasql, remote-exec, …)
 ```
 
-Three surfaces reach the model:
+Four surfaces reach the model:
 
 - **Tools** — `tools/list` + `tools/call` (native, bridged, gateway).
 - **Skills** — a catalogue in the server `instructions` plus the `skills_list` /
   `skills_read` tools, discovered from disk.
 - **Instructions** — the agent brief + environment + memory + project doc,
   rebuilt from the active project config.
+- **MCP App** — the self-contained review resource linked from `show_changes`;
+  unsupported clients ignore the UI metadata and keep the ordinary tool result.
 
 ---
 
@@ -74,7 +80,8 @@ Three surfaces reach the model:
    conversation identity arrives in request `_meta` on tool calls, after
    initialization.
 3. `tools/list` → `CodexHandler::list_tools` maps the shared tool registry into
-   rmcp `Tool` definitions.
+   rmcp `Tool` definitions, including optional titles and MCP Apps resource metadata.
+   `resources/list` / `resources/read` expose the embedded review HTML.
 4. `tools/call` → `CodexHandler::call_tool` reads `openai/session` from rmcp's
    `RequestContext::meta`. rmcp moves wire-level request `_meta` into that context
    before dispatch, so the typed tool parameters are not the authoritative source.
@@ -85,11 +92,18 @@ Three surfaces reach the model:
    root is idempotent and selecting a different root is rejected.
 6. Other project-scoped calls resolve the durable conversation binding first, or
    the transport-session fallback when no conversation identity exists, then
-   receive an effective clone of `AppConfig` whose `work_dir` is that root. The
-   server fills in default `structuredContent` when appropriate.
-7. When the transport session ends, rmcp drops the `CodexHandler`; its
+   receive an effective clone of `AppConfig` whose `work_dir` is that root. Before
+   the first such call, the review manager captures the scoped project-open snapshot.
+   Non-Git projects report review as unavailable; a Git snapshot failure blocks
+   mutating tools before dispatch.
+7. Tool dispatch supplies a request context containing the stable conversation
+   identity and shared review manager; tools that do not need it use the default
+   context-free implementation. The server fills in default `structuredContent`
+   when appropriate.
+8. When the transport session ends, rmcp drops the `CodexHandler`; its
    `SessionState::Drop` kills resident `exec_command` shells. The conversation
-   binding remains on disk and is restored by a later transport or server process.
+   binding and ChatGPT review refs remain on disk and are restored by a later
+   transport or server process.
 
 Cross-cutting HTTP concerns live in the axum layer: a `/health` route, a
 bearer-auth middleware that bypasses `/health`, and—in externally exposed
@@ -109,11 +123,15 @@ trait Tool: Send + Sync {
     fn name(&self) -> &'static str;
     fn description(&self) -> String;
     fn describe(&self, cfg: &AppConfig) -> String;      // config-aware override
+    fn title(&self) -> Option<String>;                  // host-facing card title
+    fn meta(&self) -> Option<MetaObject>;               // MCP Apps and extensions
     fn input_schema(&self) -> Value;
     fn output_schema(&self) -> Option<Value>;
     fn fills_structured_content(&self) -> bool;         // opt out of default-fill
     fn requires_project_root(&self) -> bool;            // true by default
+    fn may_modify_project(&self) -> bool;                // fail closed on review errors
     async fn call(&self, args: Value, cfg: &AppConfig, session: &SessionState) -> ToolResult;
+    async fn call_with_context(&self, args: Value, cfg: &AppConfig, session: &SessionState, context: &ToolRequestContext) -> ToolResult;
 }
 ```
 
@@ -135,16 +153,28 @@ can recover the same binding after a server restart.
 ### `SessionState` (`exec_sessions.rs`)
 Per-MCP-transport mutable state: the optional fallback project root used only when
 the client provides no stable ChatGPT conversation identity, the map of resident
-`exec_command` shells, and the current plan. Created fresh by the service factory;
-the fallback root is immutable and `Drop` disposes shells. Live process handles are
-intentionally not persisted across reconnects.
+`exec_command` shells, the current plan, and generic-client review checkpoints.
+Created fresh by the service factory; the fallback root is immutable and `Drop`
+disposes shells. Live process handles and generic review checkpoints are not
+persisted across reconnects.
+
+### `ReviewCheckpointManager` (`review.rs`)
+Shared project-review state. ChatGPT owners are keyed by the existing hashed
+conversation identity and persist two refs under `refs/codex-free/review/`; generic
+clients use the transport state above. Snapshots seed a private index with only
+tracked entries beneath the logical project path, refresh that scope from the
+working tree, and create root commits without touching the user's index. Comparisons
+repeat the same literal pathspec, return project-relative file records and patch
+headers, bound file and patch results, and advance `last-review` through `git update-ref`
+compare-and-swap. The same per-owner/project lock spans mutating tool calls through
+completion so reviews cannot capture an in-process write halfway through.
 
 ### `AppConfig` (`types.rs`)
 The fully-resolved config handed to every tool. `config.rs` parses
 `codex.config.json` with camelCase field names for backward compatibility, imports
 user-level Codex MCP definitions through `codex_mcp.rs`, then applies explicit
 `mcpServers` entries as field overlays. Optional sub-configs (`projectDoc`,
-`output`, `memory`, `skills`, `ignore`) fall back to per-module defaults. In
+`output`, `review`, `memory`, `skills`, `ignore`) fall back to per-module defaults. In
 multi-project mode, dispatch clones this config per call and substitutes the
 conversation's selected root—or the transport fallback—for `work_dir`; the static
 server policy and bridge configuration remain shared.
@@ -167,7 +197,9 @@ server policy and bridge configuration remain shared.
   persistent `ProjectBindingStore`. Upstream MCP connections, the binding store,
   and the tool registry are shared (`Arc`) across transports.
 - **`get_info`** advertises server name `codex-free` (wire-compatible identity),
-  version, `tools` capability, and the `instructions`.
+  version, tools/resources capabilities, the `io.modelcontextprotocol/ui` extension,
+  and the `instructions`. The review resource is embedded in the binary and has no
+  external network or asset dependency.
 - **Errors**: a tool that fails returns `Ok(CallToolResult::error(...))`
   (`isError: true`) so the caller sees the message; only an unknown tool name is
   an error *result* as well. Protocol errors are avoided.
@@ -208,20 +240,20 @@ a private per-run temporary directory and are removed after shutdown.
 
 ---
 
-## 5. Native tools (25 default, 26 multi-project)
+## 5. Native tools (26 default, 27 multi-project)
 
 | Group | Tools |
 |-------|-------|
 | File / code | `read_file`, `write_file`, `apply_patch`, `glob`, `grep`, `list_directory`, `tree`, `view_image` |
 | Commands | `run_command` (allowlisted argv), `exec_command` / `write_stdin` (resident shell sessions) |
-| Git | `git_status`, `git_push`, `git_commit`, `git_log` |
+| Git / review | `git_status`, `show_changes`, `git_push`, `git_commit`, `git_log` |
 | Environment / project | `get_environment`, `get_project_doc`, `get_agent_brief` |
 | Task state | `update_plan`, `remember`, `recall` |
 | Skills | `skills_list`, `skills_read` |
 | Timing | `clock_curr_time`, `clock_sleep` |
 
 Multi-project mode prepends `set_project_root`. It is omitted entirely in the
-default registry, preserving the original 25-tool surface and behaviour. Clocks
+default registry, preserving the single-project surface and behaviour. Clocks
 and bridged/gateway tools are project-independent; every other native tool is
 blocked until a conversation binding or transport fallback is available.
 
@@ -239,7 +271,9 @@ the original order and rejects duplicate names.
 | `ignore_rules.rs` | One `.gitignore`-accurate matcher (the `ignore` crate) shared by glob/grep/tree/list_directory. |
 | `exec_policy.rs` | Shell-string allowlist guard for `exec_command` (a guardrail, not a sandbox). |
 | `project_bindings.rs` | Canonical project-root validation plus durable ChatGPT conversation bindings keyed by a hash of `openai/session`, namespaced by access root, locked per record, and atomically written. |
-| `exec_sessions.rs` | Generic-client transport fallback plus unified-exec sessions: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, output truncation (UTF-16 units to match the TS). |
+| `exec_sessions.rs` | Generic-client transport fallback plus unified-exec sessions and transport-local review state: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, output truncation (UTF-16 units to match the TS). |
+| `review.rs` | Project-scoped Git snapshots, persistent conversation refs, transport-local fallbacks, incremental compare-and-swap checkpoints, diff parsing and result budgets. |
+| `review_ui.rs` | Embedded MCP Apps resource and compatibility metadata for the interactive `show_changes` review card. |
 | `apply_patch.rs` | The Codex patch format: parse then apply, atomically, with fuzzy context matching and CRLF preservation. |
 | `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized active root, with `O_EXCL` locking and atomic writes. In multi-project mode, a configured `memory.dir` is a base containing one hashed child per project. |
 | `openai_tunnel.rs` | Verified installation and lifecycle supervision for OpenAI's outbound Secure MCP Tunnel runtime. |
@@ -361,6 +395,7 @@ startup banner prints the exact file with `Config:`). All fields optional.
               "defaultShell": "…" },
   "ignore": { "useGitignore": true, "useDefaultPatterns": true, "customPatterns": [] },
   "output": { "maxFileLines": 1000, "maxFileBytes": 131072, "maxEntries": 500, "maxTreeNodes": 1000 },
+  "review": { "maxPatchBytes": 524288 },
   "projectDoc": { "maxBytes": 32768, "fallbackFilenames": [], "rootMarkers": [".git"] },
   "memory": { "enabled": true, "dir": "…", "maxBytes": 16384 },
   "skills": { "enabled": true, "dirs": ["…"], "includePlugins": true },
@@ -386,7 +421,7 @@ The banner is designed so failures are never silent:
 
 ```
 Config: D:\codex-bridge\codex.config.json          ← which file actually loaded
-Tools loaded (26): 25 native + 1 bridged from upstream MCP servers
+Tools loaded (27): 26 native + 1 bridged from upstream MCP servers
 Upstream MCP servers:
   remote-exec -> gateway (84 functions via `remote_exec`)
 Auth: disabled (no --api-key)
@@ -401,7 +436,7 @@ Auth: disabled (no --api-key)
   internal bearer are never printed.
 - Multi-project startup also prints `Project access root:`, `Project mode:
   persistent ChatGPT conversation binding`, and the conversation-binding state
-  directory; its native count is 26 because the selector is present.
+  directory; its native count is 27 because the selector is present.
 
 ---
 
@@ -425,7 +460,7 @@ units to match the TS `text.length` / `text.slice`.
 
 ## 12. Testing
 
-- **381 tests** — unit tests inside modules plus integration tests under `tests/`
+- **416 tests** — unit tests inside modules plus integration tests under `tests/`
   (`tempfile`-isolated), ported from the TS Bun suite.
 - Memory / skills tests pin `memory.dir` / `skills.dirs` to temp dirs so they never
   touch the real home; plugin discovery is suppressed when `skills.dirs` is set.
@@ -433,6 +468,10 @@ units to match the TS `text.length` / `text.slice`.
   bindings, concurrent session isolation, traversal and symlink escapes,
   project-keyed persistent state, deferred project instructions, and CLI/config
   activation.
+- `tests/review_checkpoints.rs` uses real repositories to cover monorepo scoping,
+  byte-for-byte real-index preservation, persistent and transport owners, live ref
+  reset, mutation/review serialization, incremental baselines, unborn repositories,
+  malformed Git state, renames, deletions, binaries, relative patches, and patch-budget omission.
 - `tests/review_fixes.rs` locks the behavioral-fidelity fixes found by the
   adversarial review of the port. The bridge/gateway/skills code was reviewed the
   same way; the confirmed low-severity findings (name-collision dedup, YAML-safe

--- a/docs/superpowers/specs/2026-08-24-review-checkpoints-ui-design.md
+++ b/docs/superpowers/specs/2026-08-24-review-checkpoints-ui-design.md
@@ -1,0 +1,128 @@
+# Review checkpoints and MCP Apps UI design
+
+## Goal
+
+Add an explicit review workflow to Codex Free without coupling correctness to a particular MCP host UI. The server must be able to report changes since project opening or since the last acknowledged review, advance the incremental baseline atomically, and optionally render the same structured result as an MCP App.
+
+## Non-goals
+
+- This does not replace Git commits, branches, or the user's index.
+- This does not continuously watch the filesystem or push unsolicited diffs.
+- This does not make arbitrary shell execution project-confined; existing execution policy remains unchanged.
+- This does not expose repository-wide changes when the selected project is a subdirectory.
+
+## Invariants
+
+1. The logical project root is the review scope. A project nested in a monorepo must never include sibling changes.
+2. Snapshot creation must not modify the real Git index or working tree.
+3. The project-open checkpoint is immutable once created for an owner and canonical project root.
+4. The last-review checkpoint advances with compare-and-swap semantics so concurrent reviews cannot silently overwrite one another.
+5. ChatGPT conversation checkpoints survive MCP transport replacement and server restart. Generic MCP-client checkpoints remain transport-local.
+6. Raw ChatGPT conversation identifiers are never stored; the existing hashed conversation identity is used in ref names.
+7. Plain MCP clients receive the complete ordinary MCP tool result, including structured review data. UI support is optional presentation metadata over that same result.
+
+## Ownership model
+
+A checkpoint owner is one of:
+
+- **ChatGPT conversation**: keyed by the existing SHA-256-derived conversation identity. Its two checkpoints are persisted as Git refs so they survive transport and process replacement.
+- **Generic MCP transport**: stored only in the transport's in-memory session state. Its synthetic commits are deliberately unreferenced after the transport closes and become ordinary Git-GC candidates.
+
+The persistent refs are namespaced by the canonical logical project root, not merely the repository root, so two selected subprojects in the same monorepo have independent histories:
+
+```text
+refs/codex-free/review/<project-hash>/<conversation-hash>/project-open
+refs/codex-free/review/<project-hash>/<conversation-hash>/last-review
+```
+
+Only the two current commits remain referenced per conversation/project pair. Advancing a checkpoint does not create an append-only ref history.
+
+## Scoped snapshot algorithm
+
+For a canonical project root `P` inside canonical Git root `G`:
+
+1. Resolve `G` with `git rev-parse --show-toplevel`.
+2. Derive the Git pathspec `S = P relative to G`; use `.` only when `P == G`.
+3. Read only the scope's tracked index entries with `git ls-files --stage -z -- S`.
+4. Create a private temporary Git index and initialise it with `git read-tree --empty`.
+5. Seed only those scoped tracked entries through `git update-index -z --index-info`.
+6. Refresh the temporary index from the working tree with `git add -A -- S`, invoked from `G`.
+7. Write its tree with `git write-tree`.
+8. Create a synthetic commit with `git commit-tree` and controlled identity metadata.
+
+The scoped seed handles repositories whose selected project path is globally ignored but already tracked, without force-adding new ignored files. Starting the temporary index empty is intentional: the synthetic tree contains only the logical scope. It cannot inherit staged entries from siblings, and the real index is read only for scoped tracked-entry metadata and never written. Untracked non-ignored files, deletions, executable-bit changes, symlinks, renames inferred by diff, and binary files are represented by normal Git object semantics.
+
+Every comparison also carries the same explicit `-- S` pathspec as a defence in depth. Structured file records and unified-patch headers are rebased from repository-relative to logical-project-relative form.
+
+## Checkpoint lifecycle
+
+Before the first project-scoped tool call for an owner, the server attempts to initialise both checkpoints from one scoped snapshot. This occurs before execution, including before shell tools, so a mutation cannot precede the baseline merely because it entered through an unclassified command.
+
+Checkpoint initialisation is best-effort for unrelated tools: a non-Git project must still be readable and editable. `show_changes` reports the underlying Git error explicitly.
+
+`show_changes` accepts:
+
+- `since: "last_review" | "project_open"`, default `last_review`;
+- `advance: boolean`, default `true`;
+- `include_patch: boolean`, default `true`.
+
+It creates one current snapshot, compares it with the requested baseline, and optionally advances `last-review` to that snapshot. Persistent advancement uses `git update-ref <ref> <new> <expected-old>`. A compare-and-swap conflict preserves the returned diff but reports that the baseline was not advanced.
+
+## Result contract
+
+The text result is concise and usable by the model. `structuredContent` is the authoritative UI payload:
+
+- requested and effective baseline;
+- whether the last-review checkpoint advanced;
+- scope relative to the repository root;
+- aggregate file/addition/deletion/binary counts;
+- bounded file records with workspace-relative paths, status, rename source, and line counts;
+- unified binary-capable patch when it fits the configured budget;
+- explicit omission metadata when the patch or file list is bounded;
+- warnings such as compare-and-swap conflicts.
+
+A patch larger than `review.maxPatchBytes` is omitted rather than cut mid-hunk. File metadata and aggregate statistics remain available. `0` disables patch bodies.
+
+## MCP Apps integration
+
+The server advertises the standard `io.modelcontextprotocol/ui` extension and a single resource:
+
+```text
+ui://codex-free/review/mcp-app.html
+text/html;profile=mcp-app
+```
+
+The `show_changes` tool descriptor links that resource through both the current nested `_meta.ui.resourceUri` shape and the compatibility `_meta["ui/resourceUri"]` key. Unsupported clients ignore the metadata and continue to receive the normal result.
+
+The resource is a self-contained HTML/CSS/JavaScript document embedded in the Rust binary. It has no external script, font, style, network, or storage dependency. It performs the MCP Apps handshake, validates `postMessage` source identity, consumes `ui/notifications/tool-result`, renders only with DOM `textContent`, and reports size changes. The view never performs checkpoint mutations itself.
+
+## Concurrency and failure handling
+
+Checkpoint initialization, mutating tool calls, and reviews for one owner/project pair are serialized in-process through completion of the tool call. Git refs provide cross-process atomicity for persistent checkpoint creation and advancement. A resident process returned by `exec_command` can outlive its initiating call, so later filesystem mutations from that process are intentionally observed as point-in-time state rather than held behind an unbounded review lock. Snapshot and diff subprocesses run with Codex Free's existing secret-scrubbing policy and controlled temporary-index/identity variables.
+
+Failure rules:
+
+- not a Git worktree: `show_changes` returns a tool error;
+- both missing baseline refs are initialized from the current scoped state; a missing last-review ref is restored from project-open, while last-review without project-open fails closed;
+- oversized patch: success with explicit omission;
+- concurrent baseline advancement: success with diff, no advancement, warning;
+- non-Git projects: record review as unavailable and continue normal tools;
+- checkpoint capture failure inside a Git project: fail closed before mutating tools, while unrelated read-only tools may continue with a diagnostic;
+- real index contents: preserved byte-for-byte by construction.
+
+## Testing strategy
+
+Tests use real temporary Git repositories and cover:
+
+- a selected subdirectory excluding modified siblings;
+- byte-for-byte preservation of the real index, including staged sibling state;
+- immutable project-open and advancing last-review baselines;
+- persistence across manager replacement for ChatGPT owners;
+- isolation between conversations and transport owners;
+- untracked, deleted, renamed, executable, and binary files;
+- unborn repositories;
+- patch budget omission and logical-project-relative patch headers;
+- live deletion and recreation of persistent checkpoint refs;
+- serialization between mutating tool calls and reviews;
+- malformed Git configuration distinguished from a non-Git project;
+- MCP tool metadata, resource discovery/read, handshake ordering, and HTML protocol hooks.

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use crate::codex_mcp::{codex_config_path, discover_codex_mcp_servers};
 use crate::types::{
     AppConfig, CommandConfig, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig,
-    OpenAiTunnelConfig, OutputConfig, ProjectDocConfig, SkillsConfig, TreeConfig,
+    OpenAiTunnelConfig, OutputConfig, ProjectDocConfig, ReviewConfig, SkillsConfig, TreeConfig,
 };
 
 #[derive(Parser, Debug)]
@@ -249,6 +249,7 @@ struct FileConfig {
     exec: Option<PartialExec>,
     project_doc: Option<ProjectDocConfig>,
     output: Option<OutputConfig>,
+    review: Option<ReviewConfig>,
     memory: Option<MemoryConfig>,
     skills: Option<SkillsConfig>,
     ignore: Option<IgnoreConfig>,
@@ -335,6 +336,7 @@ pub fn default_config(work_dir: std::path::PathBuf) -> AppConfig {
         exec: default_exec(),
         project_doc: ProjectDocConfig::default(),
         output: OutputConfig::default(),
+        review: ReviewConfig::default(),
         memory: MemoryConfig::default(),
         skills: SkillsConfig::default(),
         ignore: IgnoreConfig::default(),
@@ -567,6 +569,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
         exec,
         project_doc: file.project_doc.unwrap_or_default(),
         output: file.output.unwrap_or_default(),
+        review: file.review.unwrap_or_default(),
         memory: file.memory.unwrap_or_default(),
         skills: file.skills.unwrap_or_default(),
         ignore: file.ignore.unwrap_or_default(),
@@ -680,6 +683,19 @@ mod tests {
             Some(&["write".to_string()][..])
         );
         assert!(demo.command.is_none());
+    }
+
+    #[test]
+    fn review_config_accepts_an_empty_block_and_camel_case_override() {
+        let empty: FileConfig = serde_json::from_str(r#"{"review":{}}"#).unwrap();
+        assert_eq!(
+            empty.review.unwrap().max_patch_bytes,
+            crate::types::DEFAULT_REVIEW_MAX_PATCH_BYTES
+        );
+
+        let configured: FileConfig =
+            serde_json::from_str(r#"{"review":{"maxPatchBytes":1234}}"#).unwrap();
+        assert_eq!(configured.review.unwrap().max_patch_bytes, 1234);
     }
 
     #[test]

--- a/src/exec_policy.rs
+++ b/src/exec_policy.rs
@@ -238,7 +238,7 @@ mod tests {
     use super::*;
     use crate::types::{
         CommandConfig, ExecConfig, IgnoreConfig, MemoryConfig, OutputConfig, ProjectDocConfig,
-        SkillsConfig, TreeConfig,
+        ReviewConfig, SkillsConfig, TreeConfig,
     };
 
     fn cfg(mode: ExecMode) -> AppConfig {
@@ -265,6 +265,7 @@ mod tests {
             },
             project_doc: ProjectDocConfig::default(),
             output: OutputConfig::default(),
+            review: ReviewConfig::default(),
             memory: MemoryConfig::default(),
             skills: SkillsConfig::default(),
             ignore: IgnoreConfig::default(),

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -18,6 +18,7 @@ use tokio::sync::{Mutex as TokioMutex, Notify};
 
 use crate::process_env::scrub_untrusted_child_env;
 use crate::project_bindings::{ProjectBindingScope, ProjectRootSelection, resolve_project_root};
+use crate::review::TransportReviewState;
 use crate::types::{AppConfig, PlanState};
 
 // Codex constants (shell_spec.rs). Kept as code, not config, because they are
@@ -338,6 +339,7 @@ pub struct SessionState {
     next_exec_id: AtomicU64,
     pub plan: StdMutex<Option<PlanState>>,
     project_root: StdMutex<Option<PathBuf>>,
+    review: TransportReviewState,
 }
 
 impl Default for SessionState {
@@ -347,6 +349,7 @@ impl Default for SessionState {
             next_exec_id: AtomicU64::new(1),
             plan: StdMutex::new(None),
             project_root: StdMutex::new(None),
+            review: TransportReviewState::new(),
         }
     }
 }
@@ -450,6 +453,10 @@ impl SessionState {
 
     pub fn selected_project_root(&self) -> Option<PathBuf> {
         self.project_root.lock().unwrap().clone()
+    }
+
+    pub fn review_state(&self) -> TransportReviewState {
+        self.review.clone()
     }
 }
 

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -29,6 +29,7 @@ pub const AGENT_BRIEF: &str = concat!(
     "- Do not amend a commit unless explicitly asked.\n",
     "- If changes appear that you did not make, STOP and ask the user how to proceed.\n",
     "- NEVER run destructive commands such as `git reset --hard` or `git checkout --` unless the user specifically asked for or approved them.\n",
+    "- After the final related file change, call show_changes once to review the project-scoped aggregate diff. Do not advance the checkpoint after every file unless the user asks for incremental reviews.\n",
     "\n## Running commands\n\n",
     "- Match the shell named under Environment. The same command string does not mean the same thing under POSIX sh, PowerShell and cmd.\n",
     "- exec_command returns a session_id instead of a result when a command outlives its yield window. Drive it from there with write_stdin rather than starting the command again.\n",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub mod process_env;
 pub mod project_bindings;
 pub mod project_doc;
 pub mod registry;
+pub mod review;
+pub mod review_ui;
 pub mod safe_path;
 pub mod server;
 pub mod skills;

--- a/src/project_bindings.rs
+++ b/src/project_bindings.rs
@@ -56,7 +56,7 @@ impl ConversationIdentity {
         })
     }
 
-    fn key(&self) -> &str {
+    pub(crate) fn stable_key(&self) -> &str {
         &self.key
     }
 }
@@ -201,7 +201,7 @@ impl ProjectBindingStore {
         let access_key = encode_hex(&hasher.finalize(), 24);
         self.base_dir
             .join(access_key)
-            .join(format!("{}.json", identity.key()))
+            .join(format!("{}.json", identity.stable_key()))
     }
 
     fn read_binding(&self, path: &Path, access_root: &Path) -> Result<Option<PathBuf>, String> {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -22,6 +22,7 @@ pub fn load_tools_for_mode(multi_project: bool) -> Vec<Box<dyn Tool>> {
         Box::new(tools::write_file::WriteFile),
         Box::new(tools::run_command::RunCommand),
         Box::new(tools::git_status::GitStatus),
+        Box::new(tools::show_changes::ShowChanges),
         Box::new(tools::git_push::GitPush),
         Box::new(tools::git_commit::GitCommit),
         Box::new(tools::git_log::GitLog),
@@ -50,7 +51,7 @@ pub fn load_tools_for_mode(multi_project: bool) -> Vec<Box<dyn Tool>> {
         // Codex's skills.list / skills.read.
         Box::new(tools::skills_list::SkillsList),
         Box::new(tools::skills_read::SkillsRead),
-    ] as [Box<dyn Tool>; 25]);
+    ] as [Box<dyn Tool>; 26]);
 
     let mut seen = std::collections::HashSet::new();
     for tool in &all {

--- a/src/review.rs
+++ b/src/review.rs
@@ -1,0 +1,1340 @@
+//! Project-scoped Git review checkpoints.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::{Output, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, Weak};
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tokio::sync::{Mutex as AsyncMutex, OwnedMutexGuard};
+
+use crate::process_env::scrub_untrusted_child_env;
+use crate::project_bindings::ConversationIdentity;
+use crate::types::AppConfig;
+
+const REVIEW_REF_ROOT: &str = "refs/codex-free/review";
+const SYNTHETIC_IDENTITY_NAME: &str = "Codex Free Review";
+const SYNTHETIC_IDENTITY_EMAIL: &str = "review@codex-free.local";
+const MAX_GIT_ERROR_BYTES: usize = 64 * 1024;
+
+static TRANSPORT_REVIEW_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewBaseline {
+    LastReview,
+    ProjectOpen,
+}
+
+impl ReviewBaseline {
+    pub fn parse(value: Option<&str>) -> Result<Self, String> {
+        match value.unwrap_or("last_review") {
+            "last_review" => Ok(Self::LastReview),
+            "project_open" => Ok(Self::ProjectOpen),
+            other => Err(format!(
+                "since must be `last_review` or `project_open`, got {other:?}"
+            )),
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::LastReview => "last review",
+            Self::ProjectOpen => "project open",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct ReviewRequest {
+    pub since: ReviewBaseline,
+    pub advance: bool,
+    pub include_patch: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewSummary {
+    pub files: usize,
+    pub additions: u64,
+    pub deletions: u64,
+    pub binary_files: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewFile {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_path: Option<String>,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub additions: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletions: Option<u64>,
+    pub binary: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewResult {
+    pub since: ReviewBaseline,
+    pub advance_requested: bool,
+    pub checkpoint_advanced: bool,
+    pub scope: String,
+    pub summary: ReviewSummary,
+    pub files: Vec<ReviewFile>,
+    pub files_omitted: usize,
+    pub patch: String,
+    pub patch_included: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch_bytes: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub patch_omitted_reason: Option<String>,
+    pub warnings: Vec<String>,
+}
+
+impl ReviewResult {
+    pub fn render_text(&self) -> String {
+        let mut lines = Vec::new();
+        if self.summary.files == 0 {
+            lines.push(format!("No changes since {}.", self.since.label()));
+        } else {
+            lines.push(format!(
+                "Changes since {}: {} file{} (+{} -{}, {} binary).",
+                self.since.label(),
+                self.summary.files,
+                if self.summary.files == 1 { "" } else { "s" },
+                self.summary.additions,
+                self.summary.deletions,
+                self.summary.binary_files
+            ));
+        }
+        lines.push(format!("Repository scope: {}", self.scope));
+
+        for file in &self.files {
+            let path = match &file.previous_path {
+                Some(previous) => format!("{previous} -> {}", file.path),
+                None => file.path.clone(),
+            };
+            let stats = if file.binary {
+                "binary".to_string()
+            } else {
+                format!(
+                    "+{} -{}",
+                    file.additions.unwrap_or(0),
+                    file.deletions.unwrap_or(0)
+                )
+            };
+            lines.push(format!("- {} {path} ({stats})", file.status));
+        }
+        if self.files_omitted > 0 {
+            lines.push(format!(
+                "... {} additional file{} omitted from the result.",
+                self.files_omitted,
+                if self.files_omitted == 1 { "" } else { "s" }
+            ));
+        }
+
+        if self.advance_requested {
+            lines.push(if self.checkpoint_advanced {
+                "Last-review checkpoint advanced.".to_string()
+            } else {
+                "Last-review checkpoint was not advanced.".to_string()
+            });
+        }
+        lines.extend(
+            self.warnings
+                .iter()
+                .map(|warning| format!("Warning: {warning}")),
+        );
+
+        if self.patch_included && !self.patch.is_empty() {
+            lines.push(format!(
+                "Patch included in structuredContent ({} bytes).",
+                self.patch_bytes.unwrap_or(self.patch.len())
+            ));
+        } else if let Some(reason) = &self.patch_omitted_reason {
+            lines.push(format!("Patch omitted: {reason}"));
+        }
+
+        lines.join("\n")
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CheckpointPair {
+    project_open: String,
+    last_review: String,
+}
+
+struct TransportCheckpoint {
+    pair: CheckpointPair,
+    objects: TransportObjectStore,
+}
+
+struct TransportObjectStore {
+    _temp: tempfile::TempDir,
+    objects: PathBuf,
+    alternate: PathBuf,
+}
+
+impl TransportObjectStore {
+    fn environment(&self) -> Vec<(OsString, OsString)> {
+        vec![
+            (
+                OsString::from("GIT_OBJECT_DIRECTORY"),
+                self.objects.as_os_str().to_os_string(),
+            ),
+            (
+                OsString::from("GIT_ALTERNATE_OBJECT_DIRECTORIES"),
+                self.alternate.as_os_str().to_os_string(),
+            ),
+        ]
+    }
+}
+
+#[derive(Clone)]
+pub struct TransportReviewState {
+    id: String,
+    checkpoints: Arc<AsyncMutex<HashMap<String, TransportCheckpoint>>>,
+}
+
+impl TransportReviewState {
+    pub fn new() -> Self {
+        let number = TRANSPORT_REVIEW_COUNTER.fetch_add(1, Ordering::SeqCst);
+        Self {
+            id: format!("transport-{}-{number}", std::process::id()),
+            checkpoints: Arc::new(AsyncMutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl Default for TransportReviewState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Clone)]
+pub enum ReviewOwner {
+    Conversation(String),
+    Transport(TransportReviewState),
+}
+
+impl ReviewOwner {
+    pub fn conversation(identity: &ConversationIdentity) -> Self {
+        Self::Conversation(identity.stable_key().to_string())
+    }
+
+    pub fn transport(state: TransportReviewState) -> Self {
+        Self::Transport(state)
+    }
+
+    fn lock_key(&self, workspace_key: &str) -> String {
+        match self {
+            Self::Conversation(key) => format!("conversation:{key}:{workspace_key}"),
+            Self::Transport(state) => format!("{}:{workspace_key}", state.id),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReviewAvailability {
+    Ready,
+    Unavailable(String),
+}
+
+pub struct ReviewMutationGuard {
+    _guard: OwnedMutexGuard<()>,
+}
+
+#[derive(Default)]
+pub struct ReviewCheckpointManager {
+    locks: StdMutex<HashMap<String, Weak<AsyncMutex<()>>>>,
+}
+
+impl ReviewCheckpointManager {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn ensure_initialized(
+        &self,
+        config: &AppConfig,
+        owner: ReviewOwner,
+    ) -> Result<ReviewAvailability, String> {
+        let project_root = canonical_project_root(&config.work_dir)?;
+        let workspace_key = hash_path(&project_root);
+        let lock = self.scope_lock(&owner.lock_key(&workspace_key));
+        let _guard = lock.lock().await;
+        Self::ensure_initialized_locked(config, &owner, project_root).await
+    }
+
+    pub async fn begin_mutation(
+        &self,
+        config: &AppConfig,
+        owner: ReviewOwner,
+    ) -> Result<(ReviewAvailability, ReviewMutationGuard), String> {
+        let project_root = canonical_project_root(&config.work_dir)?;
+        let workspace_key = hash_path(&project_root);
+        let lock = self.scope_lock(&owner.lock_key(&workspace_key));
+        let guard = lock.lock_owned().await;
+        let availability = Self::ensure_initialized_locked(config, &owner, project_root).await?;
+        Ok((availability, ReviewMutationGuard { _guard: guard }))
+    }
+
+    async fn ensure_initialized_locked(
+        config: &AppConfig,
+        owner: &ReviewOwner,
+        project_root: PathBuf,
+    ) -> Result<ReviewAvailability, String> {
+        let workspace = match resolve_workspace(config, project_root).await {
+            Ok(workspace) => workspace,
+            Err(WorkspaceResolutionError::Unavailable(reason)) => {
+                return Ok(ReviewAvailability::Unavailable(reason));
+            }
+            Err(WorkspaceResolutionError::Failed(error)) => return Err(error),
+        };
+        match owner {
+            ReviewOwner::Conversation(owner_key) => {
+                load_or_initialize_persistent(config, &workspace, owner_key).await?;
+            }
+            ReviewOwner::Transport(state) => {
+                let mut checkpoints = state.checkpoints.lock().await;
+                if !checkpoints.contains_key(&workspace.key) {
+                    let checkpoint = create_transport_checkpoint(config, &workspace).await?;
+                    checkpoints.insert(workspace.key.clone(), checkpoint);
+                }
+            }
+        }
+        Ok(ReviewAvailability::Ready)
+    }
+
+    pub async fn show_changes(
+        &self,
+        config: &AppConfig,
+        owner: ReviewOwner,
+        request: ReviewRequest,
+    ) -> Result<ReviewResult, String> {
+        let project_root = canonical_project_root(&config.work_dir)?;
+        let workspace = resolve_workspace(config, project_root)
+            .await
+            .map_err(|error| error.to_string())?;
+        let lock = self.scope_lock(&owner.lock_key(&workspace.key));
+        let _guard = lock.lock().await;
+
+        match owner {
+            ReviewOwner::Conversation(owner_key) => {
+                let pair = load_or_initialize_persistent(config, &workspace, &owner_key).await?;
+                let current = create_snapshot(config, &workspace, &[]).await?;
+                let mut result = compare(config, &workspace, &pair, &current, request, &[]).await?;
+                if request.advance {
+                    let refs = checkpoint_refs(&workspace.key, &owner_key);
+                    if update_ref_compare_and_swap(
+                        config,
+                        &workspace.git_root,
+                        &refs.last_review,
+                        &current,
+                        &pair.last_review,
+                    )
+                    .await?
+                    {
+                        result.checkpoint_advanced = true;
+                    } else {
+                        result.warnings.push(
+                            "the last-review checkpoint changed concurrently; call show_changes again before advancing"
+                                .to_string(),
+                        );
+                    }
+                }
+                Ok(result)
+            }
+            ReviewOwner::Transport(state) => {
+                let mut checkpoints = state.checkpoints.lock().await;
+                if !checkpoints.contains_key(&workspace.key) {
+                    let checkpoint = create_transport_checkpoint(config, &workspace).await?;
+                    checkpoints.insert(workspace.key.clone(), checkpoint);
+                }
+                let checkpoint = checkpoints
+                    .get(&workspace.key)
+                    .ok_or_else(|| "transport review checkpoint disappeared".to_string())?;
+                let pair = checkpoint.pair.clone();
+                let environment = checkpoint.objects.environment();
+                let current = create_snapshot(config, &workspace, &environment).await?;
+                let mut result =
+                    compare(config, &workspace, &pair, &current, request, &environment).await?;
+                if request.advance
+                    && let Some(stored) = checkpoints.get_mut(&workspace.key)
+                {
+                    stored.pair.last_review = current;
+                    result.checkpoint_advanced = true;
+                }
+                Ok(result)
+            }
+        }
+    }
+
+    fn scope_lock(&self, key: &str) -> Arc<AsyncMutex<()>> {
+        let mut locks = self.locks.lock().unwrap();
+        locks.retain(|_, weak| weak.strong_count() > 0);
+        if let Some(lock) = locks.get(key).and_then(Weak::upgrade) {
+            return lock;
+        }
+        let lock = Arc::new(AsyncMutex::new(()));
+        locks.insert(key.to_string(), Arc::downgrade(&lock));
+        lock
+    }
+}
+
+struct ReviewWorkspace {
+    git_root: PathBuf,
+    pathspec: PathBuf,
+    scope: String,
+    key: String,
+}
+
+struct CheckpointRefs {
+    project_open: String,
+    last_review: String,
+}
+
+#[derive(Debug)]
+enum WorkspaceResolutionError {
+    Unavailable(String),
+    Failed(String),
+}
+
+impl std::fmt::Display for WorkspaceResolutionError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unavailable(reason) | Self::Failed(reason) => formatter.write_str(reason),
+        }
+    }
+}
+
+fn is_not_git_worktree(stderr: &[u8]) -> bool {
+    let detail = String::from_utf8_lossy(stderr).to_ascii_lowercase();
+    [
+        "not a git repository",
+        "must be run in a work tree",
+        "must be run in a worktree",
+        "not a git work tree",
+        "not a git worktree",
+    ]
+    .iter()
+    .any(|message| detail.contains(message))
+}
+
+fn checkpoint_refs(workspace_key: &str, owner_key: &str) -> CheckpointRefs {
+    let prefix = format!("{REVIEW_REF_ROOT}/{workspace_key}/{owner_key}");
+    CheckpointRefs {
+        project_open: format!("{prefix}/project-open"),
+        last_review: format!("{prefix}/last-review"),
+    }
+}
+
+fn canonical_project_root(path: &Path) -> Result<PathBuf, String> {
+    let canonical = std::fs::canonicalize(path)
+        .map_err(|error| format!("could not resolve project root {}: {error}", path.display()))?;
+    if !canonical.is_dir() {
+        return Err(format!(
+            "project root is not a directory: {}",
+            canonical.display()
+        ));
+    }
+    Ok(canonical)
+}
+
+async fn resolve_workspace(
+    config: &AppConfig,
+    project_root: PathBuf,
+) -> Result<ReviewWorkspace, WorkspaceResolutionError> {
+    let args = strings(&["rev-parse", "--show-toplevel"]);
+    let output = git_output(config, &project_root, &args, &[])
+        .await
+        .map_err(WorkspaceResolutionError::Failed)?;
+    if !output.status.success() {
+        let error = git_failure("git rev-parse", &output.stderr, output.status.code());
+        if is_not_git_worktree(&output.stderr) {
+            return Err(WorkspaceResolutionError::Unavailable(format!(
+                "show_changes requires a Git worktree: {error}"
+            )));
+        }
+        return Err(WorkspaceResolutionError::Failed(error));
+    }
+    let top = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let git_root = std::fs::canonicalize(&top).map_err(|error| {
+        WorkspaceResolutionError::Failed(format!("could not resolve Git root {top}: {error}"))
+    })?;
+    let relative = project_root.strip_prefix(&git_root).map_err(|_| {
+        WorkspaceResolutionError::Failed(format!(
+            "project root {} is outside Git root {}",
+            project_root.display(),
+            git_root.display()
+        ))
+    })?;
+    let pathspec = if relative.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        relative.to_path_buf()
+    };
+    let scope = if relative.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        relative.to_string_lossy().replace('\\', "/")
+    };
+    Ok(ReviewWorkspace {
+        key: hash_path(&project_root),
+        git_root,
+        pathspec,
+        scope,
+    })
+}
+
+fn hash_path(path: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"codex-free/review-project/v1\0");
+    hasher.update(path.to_string_lossy().as_bytes());
+    hex(&hasher.finalize())
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+async fn load_or_initialize_persistent(
+    config: &AppConfig,
+    workspace: &ReviewWorkspace,
+    owner_key: &str,
+) -> Result<CheckpointPair, String> {
+    let refs = checkpoint_refs(&workspace.key, owner_key);
+    let project_open = read_ref(config, &workspace.git_root, &refs.project_open).await?;
+    let last_review = read_ref(config, &workspace.git_root, &refs.last_review).await?;
+
+    match (project_open, last_review) {
+        (Some(project_open), Some(last_review)) => Ok(CheckpointPair {
+            project_open,
+            last_review,
+        }),
+        (Some(project_open), None) => {
+            create_ref_if_absent(
+                config,
+                &workspace.git_root,
+                &refs.last_review,
+                &project_open,
+            )
+            .await?;
+            let last_review = read_ref(config, &workspace.git_root, &refs.last_review)
+                .await?
+                .ok_or_else(|| "could not initialise the last-review checkpoint".to_string())?;
+            Ok(CheckpointPair {
+                project_open,
+                last_review,
+            })
+        }
+        (None, Some(_)) => Err(
+            "review checkpoint state is inconsistent: last-review exists without project-open"
+                .to_string(),
+        ),
+        (None, None) => {
+            let snapshot = create_snapshot(config, workspace, &[]).await?;
+            create_ref_if_absent(config, &workspace.git_root, &refs.project_open, &snapshot)
+                .await?;
+            let project_open = read_ref(config, &workspace.git_root, &refs.project_open)
+                .await?
+                .ok_or_else(|| "could not initialise the project-open checkpoint".to_string())?;
+            create_ref_if_absent(
+                config,
+                &workspace.git_root,
+                &refs.last_review,
+                &project_open,
+            )
+            .await?;
+            let last_review = read_ref(config, &workspace.git_root, &refs.last_review)
+                .await?
+                .ok_or_else(|| "could not initialise the last-review checkpoint".to_string())?;
+            Ok(CheckpointPair {
+                project_open,
+                last_review,
+            })
+        }
+    }
+}
+
+async fn create_transport_checkpoint(
+    config: &AppConfig,
+    workspace: &ReviewWorkspace,
+) -> Result<TransportCheckpoint, String> {
+    let alternate = git_checked(
+        config,
+        &workspace.git_root,
+        strings(&["rev-parse", "--git-path", "objects"]),
+        &[],
+    )
+    .await?;
+    let alternate = PathBuf::from(String::from_utf8_lossy(&alternate).trim().to_string());
+    let alternate = if alternate.is_absolute() {
+        alternate
+    } else {
+        workspace.git_root.join(alternate)
+    };
+    let alternate = std::fs::canonicalize(&alternate).map_err(|error| {
+        format!(
+            "could not resolve Git object directory {}: {error}",
+            alternate.display()
+        )
+    })?;
+    let temp = tempfile::tempdir()
+        .map_err(|error| format!("could not create transport review object store: {error}"))?;
+    let objects = temp.path().join("objects");
+    std::fs::create_dir(&objects)
+        .map_err(|error| format!("could not create transport review object directory: {error}"))?;
+    let store = TransportObjectStore {
+        _temp: temp,
+        objects,
+        alternate,
+    };
+    let environment = store.environment();
+    let snapshot = create_snapshot(config, workspace, &environment).await?;
+    Ok(TransportCheckpoint {
+        pair: CheckpointPair {
+            project_open: snapshot.clone(),
+            last_review: snapshot,
+        },
+        objects: store,
+    })
+}
+
+async fn create_snapshot(
+    config: &AppConfig,
+    workspace: &ReviewWorkspace,
+    object_environment: &[(OsString, OsString)],
+) -> Result<String, String> {
+    let temp = tempfile::tempdir()
+        .map_err(|error| format!("could not create temporary review index: {error}"))?;
+    let index = temp.path().join("index");
+    let environment = snapshot_environment(&index, object_environment);
+
+    let scoped_index_entries = git_checked(
+        config,
+        &workspace.git_root,
+        vec![
+            OsString::from("--literal-pathspecs"),
+            OsString::from("ls-files"),
+            OsString::from("--stage"),
+            OsString::from("-z"),
+            OsString::from("--"),
+            workspace.pathspec.as_os_str().to_os_string(),
+        ],
+        object_environment,
+    )
+    .await?;
+    git_checked(
+        config,
+        &workspace.git_root,
+        strings(&["read-tree", "--empty"]),
+        &environment,
+    )
+    .await?;
+    if !scoped_index_entries.is_empty() {
+        git_checked_input(
+            config,
+            &workspace.git_root,
+            strings(&["update-index", "-z", "--index-info"]),
+            &environment,
+            &scoped_index_entries,
+        )
+        .await?;
+    }
+    let add_output = git_output(
+        config,
+        &workspace.git_root,
+        &[
+            OsString::from("--literal-pathspecs"),
+            OsString::from("add"),
+            OsString::from("-A"),
+            OsString::from("--"),
+            workspace.pathspec.as_os_str().to_os_string(),
+        ],
+        &environment,
+    )
+    .await?;
+    if !add_output.status.success()
+        && !(add_output.status.code() == Some(1)
+            && String::from_utf8_lossy(&add_output.stderr).contains("paths are ignored"))
+    {
+        return Err(git_failure(
+            "git add",
+            &add_output.stderr,
+            add_output.status.code(),
+        ));
+    }
+    let tree = git_checked(
+        config,
+        &workspace.git_root,
+        strings(&["write-tree"]),
+        &environment,
+    )
+    .await?;
+    let tree = String::from_utf8_lossy(&tree).trim().to_string();
+    let commit = git_checked(
+        config,
+        &workspace.git_root,
+        vec![
+            OsString::from("commit-tree"),
+            OsString::from(tree),
+            OsString::from("-m"),
+            OsString::from("Codex Free review snapshot"),
+        ],
+        &environment,
+    )
+    .await?;
+    let commit = String::from_utf8_lossy(&commit).trim().to_string();
+    if commit.is_empty() {
+        return Err("Git returned an empty review snapshot id".to_string());
+    }
+    Ok(commit)
+}
+
+fn snapshot_environment(
+    index: &Path,
+    object_environment: &[(OsString, OsString)],
+) -> Vec<(OsString, OsString)> {
+    let mut environment = vec![
+        (
+            OsString::from("GIT_INDEX_FILE"),
+            index.as_os_str().to_os_string(),
+        ),
+        (
+            OsString::from("GIT_AUTHOR_NAME"),
+            OsString::from(SYNTHETIC_IDENTITY_NAME),
+        ),
+        (
+            OsString::from("GIT_AUTHOR_EMAIL"),
+            OsString::from(SYNTHETIC_IDENTITY_EMAIL),
+        ),
+        (
+            OsString::from("GIT_COMMITTER_NAME"),
+            OsString::from(SYNTHETIC_IDENTITY_NAME),
+        ),
+        (
+            OsString::from("GIT_COMMITTER_EMAIL"),
+            OsString::from(SYNTHETIC_IDENTITY_EMAIL),
+        ),
+        (
+            OsString::from("GIT_AUTHOR_DATE"),
+            OsString::from("@0 +0000"),
+        ),
+        (
+            OsString::from("GIT_COMMITTER_DATE"),
+            OsString::from("@0 +0000"),
+        ),
+    ];
+    environment.extend(object_environment.iter().cloned());
+    environment
+}
+
+async fn compare(
+    config: &AppConfig,
+    workspace: &ReviewWorkspace,
+    pair: &CheckpointPair,
+    current: &str,
+    request: ReviewRequest,
+    object_environment: &[(OsString, OsString)],
+) -> Result<ReviewResult, String> {
+    let baseline = match request.since {
+        ReviewBaseline::LastReview => &pair.last_review,
+        ReviewBaseline::ProjectOpen => &pair.project_open,
+    };
+    let name_status = git_checked(
+        config,
+        &workspace.git_root,
+        diff_args("--name-status", baseline, current, &workspace.pathspec),
+        object_environment,
+    )
+    .await?;
+    let numstat = git_checked(
+        config,
+        &workspace.git_root,
+        diff_args("--numstat", baseline, current, &workspace.pathspec),
+        object_environment,
+    )
+    .await?;
+    let names = parse_name_status(&name_status)?;
+    let stats = parse_numstat(&numstat)?;
+    let mut files = merge_records(workspace, names, stats)?;
+    let summary = summarize(&files);
+    let max_files = crate::output_budget::entry_budget(config);
+    let files_omitted = if max_files == 0 || files.len() <= max_files {
+        0
+    } else {
+        files.len() - max_files
+    };
+    if files_omitted > 0 {
+        files.truncate(max_files);
+    }
+
+    let patch_result = if !request.include_patch {
+        PatchResult::omitted("disabled by the show_changes request")
+    } else if config.review.max_patch_bytes == 0 {
+        PatchResult::omitted("disabled by review.maxPatchBytes=0")
+    } else {
+        git_patch_bounded(
+            config,
+            workspace,
+            baseline,
+            current,
+            config.review.max_patch_bytes,
+            object_environment,
+        )
+        .await?
+    };
+
+    Ok(ReviewResult {
+        since: request.since,
+        advance_requested: request.advance,
+        checkpoint_advanced: false,
+        scope: workspace.scope.clone(),
+        summary,
+        files,
+        files_omitted,
+        patch: patch_result.patch,
+        patch_included: patch_result.included,
+        patch_bytes: patch_result.bytes,
+        patch_omitted_reason: patch_result.omitted_reason,
+        warnings: Vec::new(),
+    })
+}
+
+fn diff_args(kind: &str, baseline: &str, current: &str, pathspec: &Path) -> Vec<OsString> {
+    vec![
+        OsString::from("--literal-pathspecs"),
+        OsString::from("diff"),
+        OsString::from("--no-ext-diff"),
+        OsString::from("--no-textconv"),
+        OsString::from("--find-renames"),
+        OsString::from(kind),
+        OsString::from("-z"),
+        OsString::from(baseline),
+        OsString::from(current),
+        OsString::from("--"),
+        pathspec.as_os_str().to_os_string(),
+    ]
+}
+
+#[derive(Debug)]
+struct NameRecord {
+    status: String,
+    previous_path: Option<String>,
+    path: String,
+}
+
+#[derive(Debug)]
+struct StatRecord {
+    additions: Option<u64>,
+    deletions: Option<u64>,
+    previous_path: Option<String>,
+    path: String,
+}
+
+fn parse_name_status(output: &[u8]) -> Result<Vec<NameRecord>, String> {
+    let tokens = nul_tokens(output);
+    let mut records = Vec::new();
+    let mut index = 0;
+    while index < tokens.len() {
+        let status = token_string(tokens[index]);
+        index += 1;
+        if status.is_empty() {
+            continue;
+        }
+        if status.starts_with('R') || status.starts_with('C') {
+            let previous = tokens
+                .get(index)
+                .ok_or_else(|| "truncated Git rename status".to_string())?;
+            let path = tokens
+                .get(index + 1)
+                .ok_or_else(|| "truncated Git rename destination".to_string())?;
+            records.push(NameRecord {
+                status,
+                previous_path: Some(token_string(previous)),
+                path: token_string(path),
+            });
+            index += 2;
+        } else {
+            let path = tokens
+                .get(index)
+                .ok_or_else(|| "truncated Git name-status record".to_string())?;
+            records.push(NameRecord {
+                status,
+                previous_path: None,
+                path: token_string(path),
+            });
+            index += 1;
+        }
+    }
+    Ok(records)
+}
+
+fn parse_numstat(output: &[u8]) -> Result<Vec<StatRecord>, String> {
+    let mut records = Vec::new();
+    let mut cursor = 0;
+    while cursor < output.len() {
+        let end = output[cursor..]
+            .iter()
+            .position(|byte| *byte == 0)
+            .map(|offset| cursor + offset)
+            .unwrap_or(output.len());
+        let header = &output[cursor..end];
+        cursor = end.saturating_add(1);
+        if header.is_empty() {
+            continue;
+        }
+        let mut fields = header.splitn(3, |byte| *byte == b'\t');
+        let additions = parse_stat(fields.next())?;
+        let deletions = parse_stat(fields.next())?;
+        let path_field = fields
+            .next()
+            .ok_or_else(|| "invalid Git numstat record".to_string())?;
+        if !path_field.is_empty() {
+            records.push(StatRecord {
+                additions,
+                deletions,
+                previous_path: None,
+                path: token_string(path_field),
+            });
+            continue;
+        }
+
+        let previous = take_nul_token(output, &mut cursor)
+            .ok_or_else(|| "truncated Git numstat rename source".to_string())?;
+        let path = take_nul_token(output, &mut cursor)
+            .ok_or_else(|| "truncated Git numstat rename destination".to_string())?;
+        records.push(StatRecord {
+            additions,
+            deletions,
+            previous_path: Some(token_string(previous)),
+            path: token_string(path),
+        });
+    }
+    Ok(records)
+}
+
+fn parse_stat(value: Option<&[u8]>) -> Result<Option<u64>, String> {
+    let value = value.ok_or_else(|| "missing Git numstat value".to_string())?;
+    if value == b"-" {
+        return Ok(None);
+    }
+    let value = String::from_utf8_lossy(value);
+    value
+        .parse::<u64>()
+        .map(Some)
+        .map_err(|_| format!("invalid Git numstat value {value:?}"))
+}
+
+fn nul_tokens(output: &[u8]) -> Vec<&[u8]> {
+    output
+        .split(|byte| *byte == 0)
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn take_nul_token<'a>(output: &'a [u8], cursor: &mut usize) -> Option<&'a [u8]> {
+    if *cursor > output.len() {
+        return None;
+    }
+    let end = output[*cursor..]
+        .iter()
+        .position(|byte| *byte == 0)
+        .map(|offset| *cursor + offset)
+        .unwrap_or(output.len());
+    let token = &output[*cursor..end];
+    *cursor = end.saturating_add(1);
+    Some(token)
+}
+
+fn token_string(value: &[u8]) -> String {
+    String::from_utf8_lossy(value).into_owned()
+}
+
+fn merge_records(
+    workspace: &ReviewWorkspace,
+    names: Vec<NameRecord>,
+    stats: Vec<StatRecord>,
+) -> Result<Vec<ReviewFile>, String> {
+    if names.len() != stats.len() {
+        return Err(format!(
+            "Git returned {} name records but {} stat records",
+            names.len(),
+            stats.len()
+        ));
+    }
+    names
+        .into_iter()
+        .zip(stats)
+        .map(|(name, stat)| {
+            if name.path != stat.path || name.previous_path != stat.previous_path {
+                return Err("Git name-status and numstat records do not align".to_string());
+            }
+            let binary = stat.additions.is_none() || stat.deletions.is_none();
+            Ok(ReviewFile {
+                path: project_relative_path(workspace, &name.path)?,
+                previous_path: name
+                    .previous_path
+                    .as_deref()
+                    .map(|path| project_relative_path(workspace, path))
+                    .transpose()?,
+                status: status_name(&name.status).to_string(),
+                additions: stat.additions,
+                deletions: stat.deletions,
+                binary,
+            })
+        })
+        .collect()
+}
+
+fn project_relative_path(
+    workspace: &ReviewWorkspace,
+    repository_path: &str,
+) -> Result<String, String> {
+    if workspace.scope == "." {
+        return Ok(repository_path.to_string());
+    }
+    let prefix = format!("{}/", workspace.scope);
+    repository_path
+        .strip_prefix(&prefix)
+        .map(String::from)
+        .ok_or_else(|| {
+            format!("Git returned a path outside the logical review scope: {repository_path}")
+        })
+}
+
+fn status_name(status: &str) -> &'static str {
+    match status.as_bytes().first().copied() {
+        Some(b'A') => "added",
+        Some(b'M') => "modified",
+        Some(b'D') => "deleted",
+        Some(b'R') => "renamed",
+        Some(b'C') => "copied",
+        Some(b'T') => "type_changed",
+        Some(b'U') => "unmerged",
+        Some(b'X') => "unknown",
+        Some(b'B') => "broken_pairing",
+        _ => "unknown",
+    }
+}
+
+fn summarize(files: &[ReviewFile]) -> ReviewSummary {
+    files
+        .iter()
+        .fold(ReviewSummary::default(), |mut summary, file| {
+            summary.files += 1;
+            summary.additions += file.additions.unwrap_or(0);
+            summary.deletions += file.deletions.unwrap_or(0);
+            summary.binary_files += usize::from(file.binary);
+            summary
+        })
+}
+
+struct PatchResult {
+    patch: String,
+    included: bool,
+    bytes: Option<usize>,
+    omitted_reason: Option<String>,
+}
+
+impl PatchResult {
+    fn omitted(reason: impl Into<String>) -> Self {
+        Self {
+            patch: String::new(),
+            included: false,
+            bytes: None,
+            omitted_reason: Some(reason.into()),
+        }
+    }
+}
+
+async fn git_patch_bounded(
+    config: &AppConfig,
+    workspace: &ReviewWorkspace,
+    baseline: &str,
+    current: &str,
+    max_bytes: usize,
+    object_environment: &[(OsString, OsString)],
+) -> Result<PatchResult, String> {
+    let mut args = vec![
+        OsString::from("--literal-pathspecs"),
+        OsString::from("diff"),
+        OsString::from("--no-ext-diff"),
+        OsString::from("--no-textconv"),
+        OsString::from("--find-renames"),
+        OsString::from("--binary"),
+        OsString::from("--full-index"),
+        OsString::from("--no-color"),
+    ];
+    if workspace.scope != "." {
+        args.push(OsString::from(format!("--relative={}", workspace.scope)));
+    }
+    args.extend([
+        OsString::from(baseline),
+        OsString::from(current),
+        OsString::from("--"),
+        workspace.pathspec.as_os_str().to_os_string(),
+    ]);
+    let mut command = git_command(config, &workspace.git_root, &args, object_environment);
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to start git diff: {error}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "git diff stdout was unavailable".to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "git diff stderr was unavailable".to_string())?;
+    let stderr_task = tokio::spawn(async move {
+        let mut bytes = Vec::new();
+        let _ = stderr
+            .take(MAX_GIT_ERROR_BYTES as u64)
+            .read_to_end(&mut bytes)
+            .await;
+        bytes
+    });
+
+    let mut bytes = Vec::new();
+    stdout
+        .take(max_bytes.saturating_add(1) as u64)
+        .read_to_end(&mut bytes)
+        .await
+        .map_err(|error| format!("failed to read git diff: {error}"))?;
+    let oversized = bytes.len() > max_bytes;
+    if oversized {
+        let _ = child.kill().await;
+    }
+    let status = child
+        .wait()
+        .await
+        .map_err(|error| format!("failed to wait for git diff: {error}"))?;
+    let stderr = stderr_task.await.unwrap_or_default();
+
+    if oversized {
+        return Ok(PatchResult::omitted(format!(
+            "exceeds review.maxPatchBytes ({max_bytes} bytes)"
+        )));
+    }
+    if !status.success() {
+        return Err(git_failure("git diff", &stderr, status.code()));
+    }
+    let patch = String::from_utf8_lossy(&bytes).into_owned();
+    Ok(PatchResult {
+        patch,
+        included: true,
+        bytes: Some(bytes.len()),
+        omitted_reason: None,
+    })
+}
+
+async fn read_ref(
+    config: &AppConfig,
+    git_root: &Path,
+    reference: &str,
+) -> Result<Option<String>, String> {
+    let args = vec![
+        OsString::from("rev-parse"),
+        OsString::from("--verify"),
+        OsString::from("--quiet"),
+        OsString::from(format!("{reference}^{{commit}}")),
+    ];
+    let output = git_output(config, git_root, &args, &[]).await?;
+    if output.status.success() {
+        return Ok(Some(
+            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        ));
+    }
+    if output.status.code() == Some(1) && output.stderr.is_empty() {
+        return Ok(None);
+    }
+    Err(git_failure(
+        "git rev-parse",
+        &output.stderr,
+        output.status.code(),
+    ))
+}
+
+async fn create_ref_if_absent(
+    config: &AppConfig,
+    git_root: &Path,
+    reference: &str,
+    value: &str,
+) -> Result<(), String> {
+    let output = git_output(
+        config,
+        git_root,
+        &[
+            OsString::from("update-ref"),
+            OsString::from(reference),
+            OsString::from(value),
+            OsString::new(),
+        ],
+        &[],
+    )
+    .await?;
+    if output.status.success() || read_ref(config, git_root, reference).await?.is_some() {
+        return Ok(());
+    }
+    Err(git_failure(
+        "git update-ref",
+        &output.stderr,
+        output.status.code(),
+    ))
+}
+
+async fn update_ref_compare_and_swap(
+    config: &AppConfig,
+    git_root: &Path,
+    reference: &str,
+    value: &str,
+    expected: &str,
+) -> Result<bool, String> {
+    let output = git_output(
+        config,
+        git_root,
+        &[
+            OsString::from("update-ref"),
+            OsString::from(reference),
+            OsString::from(value),
+            OsString::from(expected),
+        ],
+        &[],
+    )
+    .await?;
+    if output.status.success() {
+        return Ok(true);
+    }
+    let current = read_ref(config, git_root, reference).await?;
+    if current.as_deref() != Some(expected) {
+        return Ok(false);
+    }
+    Err(git_failure(
+        "git update-ref",
+        &output.stderr,
+        output.status.code(),
+    ))
+}
+
+fn strings(values: &[&str]) -> Vec<OsString> {
+    values.iter().map(OsString::from).collect()
+}
+
+fn git_command(
+    config: &AppConfig,
+    cwd: &Path,
+    args: &[OsString],
+    environment: &[(OsString, OsString)],
+) -> Command {
+    let mut command = Command::new("git");
+    command.args(args).current_dir(cwd);
+    scrub_untrusted_child_env(&mut command, config);
+    // Keep diagnostics parseable and stop read-only Git commands from refreshing
+    // the user's real index as a side effect.
+    command
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
+        .env("GIT_PAGER", "cat")
+        .env("GIT_OPTIONAL_LOCKS", "0");
+    command.envs(environment.iter().cloned());
+    command
+}
+
+async fn git_output(
+    config: &AppConfig,
+    cwd: &Path,
+    args: &[OsString],
+    environment: &[(OsString, OsString)],
+) -> Result<Output, String> {
+    git_command(config, cwd, args, environment)
+        .output()
+        .await
+        .map_err(|error| format!("failed to run git: {error}"))
+}
+
+async fn git_checked_input(
+    config: &AppConfig,
+    cwd: &Path,
+    args: Vec<OsString>,
+    environment: &[(OsString, OsString)],
+    input: &[u8],
+) -> Result<Vec<u8>, String> {
+    let command_name = args
+        .first()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "git".to_string());
+    let mut command = git_command(config, cwd, &args, environment);
+    command.stdin(Stdio::piped());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to run git: {error}"))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(input)
+            .await
+            .map_err(|error| format!("failed to write git input: {error}"))?;
+    }
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|error| format!("failed to wait for git: {error}"))?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(git_failure(
+            &format!("git {command_name}"),
+            &output.stderr,
+            output.status.code(),
+        ))
+    }
+}
+
+async fn git_checked(
+    config: &AppConfig,
+    cwd: &Path,
+    args: Vec<OsString>,
+    environment: &[(OsString, OsString)],
+) -> Result<Vec<u8>, String> {
+    let command_name = args
+        .first()
+        .map(|value| value.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "git".to_string());
+    let output = git_output(config, cwd, &args, environment).await?;
+    if output.status.success() {
+        Ok(output.stdout)
+    } else {
+        Err(git_failure(
+            &format!("git {command_name}"),
+            &output.stderr,
+            output.status.code(),
+        ))
+    }
+}
+
+fn git_failure(command: &str, stderr: &[u8], code: Option<i32>) -> String {
+    let detail = String::from_utf8_lossy(stderr).trim().to_string();
+    if detail.is_empty() {
+        format!("{command} failed with exit code {}", code.unwrap_or(-1))
+    } else {
+        format!("{command} failed: {detail}")
+    }
+}

--- a/src/review_ui.rs
+++ b/src/review_ui.rs
@@ -1,0 +1,352 @@
+use rmcp::model::{MetaObject, Resource, ResourceContents};
+use serde_json::json;
+
+pub const REVIEW_UI_URI: &str = "ui://codex-free/review/mcp-app.html";
+pub const REVIEW_UI_MIME_TYPE: &str = "text/html;profile=mcp-app";
+pub const MCP_APPS_EXTENSION_ID: &str = "io.modelcontextprotocol/ui";
+
+pub fn tool_meta() -> MetaObject {
+    serde_json::from_value(json!({
+        "ui": { "resourceUri": REVIEW_UI_URI },
+        "ui/resourceUri": REVIEW_UI_URI
+    }))
+    .expect("static review tool metadata must be an object")
+}
+
+pub fn resource_meta() -> MetaObject {
+    serde_json::from_value(json!({
+        "ui": { "prefersBorder": true }
+    }))
+    .expect("static review resource metadata must be an object")
+}
+
+pub fn resource() -> Resource {
+    Resource::new(REVIEW_UI_URI, "codex-free-review")
+        .with_title("Code review")
+        .with_description("Interactive rendering of Codex Free review checkpoints")
+        .with_mime_type(REVIEW_UI_MIME_TYPE)
+        .with_size(REVIEW_UI_HTML.len() as u64)
+        .with_meta(resource_meta())
+}
+
+pub fn contents() -> ResourceContents {
+    ResourceContents::text(REVIEW_UI_HTML, REVIEW_UI_URI)
+        .with_mime_type(REVIEW_UI_MIME_TYPE)
+        .with_meta(resource_meta())
+}
+
+pub const REVIEW_UI_HTML: &str = r##"<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Code review</title>
+<style>
+:root {
+  color-scheme: light dark;
+  --bg: var(--color-background-primary, light-dark(#ffffff, #171717));
+  --panel: var(--color-background-secondary, light-dark(#f6f7f8, #222222));
+  --text: var(--color-text-primary, light-dark(#171717, #f4f4f4));
+  --muted: var(--color-text-secondary, light-dark(#62666d, #a7a7a7));
+  --border: var(--color-border-primary, light-dark(#d9dce1, #3a3a3a));
+  --added-bg: light-dark(#e7f7ed, #163321);
+  --added-text: light-dark(#145c2e, #8ee4aa);
+  --deleted-bg: light-dark(#fceaea, #421d1d);
+  --deleted-text: light-dark(#8a1f1f, #f2a0a0);
+  --accent: light-dark(#2457c5, #8db4ff);
+  font-family: var(--font-sans, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+}
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--bg); color: var(--text); }
+main { display: grid; gap: 12px; padding: 14px; }
+header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+h1 { margin: 0; font-size: 16px; line-height: 1.35; }
+.subhead { margin-top: 3px; color: var(--muted); font-size: 12px; }
+.badge { border: 1px solid var(--border); border-radius: 999px; padding: 4px 8px; color: var(--muted); font-size: 11px; white-space: nowrap; }
+.summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 8px; }
+.metric { border: 1px solid var(--border); border-radius: 10px; padding: 9px 10px; background: var(--panel); }
+.metric strong { display: block; font-size: 16px; font-variant-numeric: tabular-nums; }
+.metric span { color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: .055em; }
+section { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+.section-title { display: flex; justify-content: space-between; gap: 12px; padding: 9px 11px; background: var(--panel); border-bottom: 1px solid var(--border); font-size: 12px; font-weight: 650; }
+.files { display: grid; }
+.file { display: grid; grid-template-columns: 94px minmax(0, 1fr) auto; align-items: center; gap: 10px; padding: 8px 11px; border-top: 1px solid var(--border); font-size: 12px; }
+.file:first-child { border-top: 0; }
+.status { color: var(--muted); text-transform: capitalize; }
+.path { min-width: 0; overflow-wrap: anywhere; font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace); }
+.stats { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.add { color: var(--added-text); }
+.del { color: var(--deleted-text); margin-left: 7px; }
+.empty, .notice { padding: 18px 12px; color: var(--muted); font-size: 12px; text-align: center; }
+.warning { border: 1px solid var(--border); border-radius: 10px; padding: 9px 11px; color: var(--muted); font-size: 12px; }
+.diff-files { display: grid; }
+.diff-file { border-top: 1px solid var(--border); }
+.diff-file:first-child { border-top: 0; }
+.diff-heading { padding: 8px 11px; background: var(--panel); color: var(--muted); font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace); font-size: 11px; overflow-wrap: anywhere; }
+pre { margin: 0; overflow: auto; font: 11px/1.55 var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace); tab-size: 4; }
+.line { display: block; min-width: max-content; padding: 0 11px; white-space: pre; }
+.line.added { background: var(--added-bg); color: var(--added-text); }
+.line.deleted { background: var(--deleted-bg); color: var(--deleted-text); }
+.line.hunk { color: var(--accent); background: var(--panel); }
+.line.meta { color: var(--muted); }
+@media (max-width: 520px) {
+  main { padding: 10px; }
+  .summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .file { grid-template-columns: 72px minmax(0, 1fr); }
+  .stats { grid-column: 2; }
+}
+</style>
+</head>
+<body>
+<main id="root" aria-live="polite">
+  <div class="notice">Preparing review…</div>
+</main>
+<script>
+(() => {
+  "use strict";
+  const root = document.getElementById("root");
+  let nextId = 1;
+  const pending = new Map();
+  let resizeObserver;
+
+  function post(message) {
+    window.parent.postMessage(message, "*");
+  }
+
+  function request(method, params) {
+    const id = nextId++;
+    post({ jsonrpc: "2.0", id, method, params });
+    return new Promise((resolve, reject) => pending.set(id, { resolve, reject }));
+  }
+
+  function notify(method, params) {
+    post({ jsonrpc: "2.0", method, params });
+  }
+
+  function el(tag, className, text) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    if (text !== undefined) node.textContent = String(text);
+    return node;
+  }
+
+  function metric(value, label) {
+    const node = el("div", "metric");
+    node.append(el("strong", "", value), el("span", "", label));
+    return node;
+  }
+
+  function splitPatch(patch) {
+    const chunks = [];
+    let current = null;
+    for (const line of patch.split("\n")) {
+      if (line.startsWith("diff --git ")) {
+        current = { heading: line.slice(11), lines: [line] };
+        chunks.push(current);
+      } else {
+        if (!current) {
+          current = { heading: "Patch", lines: [] };
+          chunks.push(current);
+        }
+        current.lines.push(line);
+      }
+    }
+    return chunks;
+  }
+
+  function renderPatch(patch, container) {
+    for (const chunk of splitPatch(patch)) {
+      const article = el("article", "diff-file");
+      article.append(el("div", "diff-heading", chunk.heading));
+      const pre = el("pre");
+      for (const text of chunk.lines) {
+        let className = "line";
+        if (text.startsWith("+") && !text.startsWith("+++")) className += " added";
+        else if (text.startsWith("-") && !text.startsWith("---")) className += " deleted";
+        else if (text.startsWith("@@")) className += " hunk";
+        else if (/^(diff --git|index |--- |\+\+\+ |new file|deleted file|similarity|rename )/.test(text)) className += " meta";
+        pre.append(el("span", className, text + "\n"));
+      }
+      article.append(pre);
+      container.append(article);
+    }
+  }
+
+  function render(data) {
+    if (!data || typeof data !== "object") return;
+    root.replaceChildren();
+    const summary = data.summary || {};
+    const header = el("header");
+    const heading = el("div");
+    heading.append(
+      el("h1", "", summary.files ? `Changed ${summary.files} file${summary.files === 1 ? "" : "s"}` : "No changes"),
+      el("div", "subhead", `Since ${String(data.since || "last_review").replaceAll("_", " ")} · scope ${data.scope || "."}`)
+    );
+    const badgeText = data.advanceRequested
+      ? (data.checkpointAdvanced ? "Checkpoint advanced" : "Checkpoint unchanged")
+      : "Read-only review";
+    header.append(heading, el("div", "badge", badgeText));
+    root.append(header);
+
+    const metrics = el("div", "summary");
+    metrics.append(
+      metric(summary.files || 0, "Files"),
+      metric(`+${summary.additions || 0}`, "Additions"),
+      metric(`-${summary.deletions || 0}`, "Deletions"),
+      metric(summary.binaryFiles || 0, "Binary")
+    );
+    root.append(metrics);
+
+    const filesSection = el("section");
+    const filesTitle = el("div", "section-title");
+    filesTitle.append(el("span", "", "Files"));
+    if (data.filesOmitted) filesTitle.append(el("span", "", `${data.filesOmitted} omitted`));
+    filesSection.append(filesTitle);
+    const files = el("div", "files");
+    for (const file of data.files || []) {
+      const row = el("div", "file");
+      row.append(el("span", "status", file.status || "changed"));
+      const path = file.previousPath ? `${file.previousPath} → ${file.path}` : file.path;
+      row.append(el("span", "path", path));
+      const stats = el("span", "stats");
+      if (file.binary) stats.append(el("span", "", "binary"));
+      else stats.append(
+        el("span", "add", `+${file.additions || 0}`),
+        el("span", "del", `-${file.deletions || 0}`)
+      );
+      row.append(stats);
+      files.append(row);
+    }
+    if (!(data.files || []).length) files.append(el("div", "empty", "The scoped working tree matches the selected checkpoint."));
+    filesSection.append(files);
+    root.append(filesSection);
+
+    for (const warning of data.warnings || []) root.append(el("div", "warning", warning));
+
+    const diffSection = el("section");
+    diffSection.append(el("div", "section-title", "Patch"));
+    const diffFiles = el("div", "diff-files");
+    if (data.patchIncluded && data.patch) renderPatch(data.patch, diffFiles);
+    else diffFiles.append(el("div", "empty", data.patchOmittedReason || "No textual patch."));
+    diffSection.append(diffFiles);
+    root.append(diffSection);
+    reportSize();
+  }
+
+  function toolResultPayload(params) {
+    return params && (params.structuredContent || params.structured_content);
+  }
+
+  window.addEventListener("message", event => {
+    if (event.source !== window.parent) return;
+    const message = event.data;
+    if (!message || message.jsonrpc !== "2.0") return;
+    const hasResult = Object.prototype.hasOwnProperty.call(message, "result");
+    const hasError = Object.prototype.hasOwnProperty.call(message, "error");
+    if (Object.prototype.hasOwnProperty.call(message, "id") && (hasResult || hasError)) {
+      const waiter = pending.get(message.id);
+      if (!waiter) return;
+      pending.delete(message.id);
+      hasError ? waiter.reject(message.error) : waiter.resolve(message.result);
+      return;
+    }
+    if (message.method === "ui/notifications/tool-result") {
+      render(toolResultPayload(message.params));
+    } else if (message.method === "ui/notifications/host-context-changed") {
+      applyHostContext(message.params);
+    } else if (message.method === "ui/resource-teardown" && message.id !== undefined) {
+      post({ jsonrpc: "2.0", id: message.id, result: {} });
+    }
+  });
+
+  function applyHostContext(context) {
+    if (context && context.theme) document.documentElement.dataset.theme = context.theme;
+  }
+
+  function reportSize() {
+    notify("ui/notifications/size-changed", {
+      width: Math.ceil(document.documentElement.scrollWidth),
+      height: Math.ceil(document.documentElement.scrollHeight)
+    });
+  }
+
+  function startSizeReporting() {
+    if ("ResizeObserver" in window) {
+      resizeObserver = new ResizeObserver(reportSize);
+      resizeObserver.observe(document.documentElement);
+    }
+    reportSize();
+  }
+
+  const legacy = window.openai && window.openai.toolOutput;
+  if (legacy) render(legacy);
+  window.addEventListener("openai:set_globals", event => {
+    const output = event.detail && event.detail.globals && event.detail.globals.toolOutput;
+    if (output) render(output);
+  });
+
+  request("ui/initialize", {
+    protocolVersion: "2026-01-26",
+    appInfo: { name: "codex-free-review", version: "1.0.0" },
+    appCapabilities: {}
+  }).then(result => {
+    applyHostContext(result && result.hostContext);
+    notify("ui/notifications/initialized", {});
+    startSizeReporting();
+  }).catch(error => {
+    if (!legacy) root.replaceChildren(el("div", "notice", `Review UI could not initialize: ${error && error.message ? error.message : String(error)}`));
+  });
+})();
+</script>
+</body>
+</html>
+"##;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_metadata_carries_current_and_compatibility_resource_keys() {
+        let meta = tool_meta();
+        assert_eq!(
+            meta.get("ui")
+                .and_then(|value| value.get("resourceUri"))
+                .and_then(serde_json::Value::as_str),
+            Some(REVIEW_UI_URI)
+        );
+        assert_eq!(
+            meta.get("ui/resourceUri")
+                .and_then(serde_json::Value::as_str),
+            Some(REVIEW_UI_URI)
+        );
+    }
+
+    #[test]
+    fn resource_uses_the_mcp_apps_mime_type() {
+        let resource = resource();
+        assert_eq!(resource.uri, REVIEW_UI_URI);
+        assert_eq!(resource.mime_type.as_deref(), Some(REVIEW_UI_MIME_TYPE));
+        let contents = contents();
+        let value = serde_json::to_value(contents).unwrap();
+        assert_eq!(value["uri"], REVIEW_UI_URI);
+        assert_eq!(value["mimeType"], REVIEW_UI_MIME_TYPE);
+    }
+
+    #[test]
+    fn embedded_view_implements_the_standard_handshake_and_safe_rendering() {
+        assert!(REVIEW_UI_HTML.contains("ui/initialize"));
+        assert!(REVIEW_UI_HTML.contains("ui/notifications/initialized"));
+        assert!(REVIEW_UI_HTML.contains("ui/notifications/tool-result"));
+        assert!(REVIEW_UI_HTML.contains("ui/notifications/size-changed"));
+        assert!(REVIEW_UI_HTML.contains("event.source !== window.parent"));
+        assert!(REVIEW_UI_HTML.contains("hasOwnProperty.call(message, \"result\")"));
+        assert!(REVIEW_UI_HTML.contains("textContent"));
+        assert!(!REVIEW_UI_HTML.contains("<script src="));
+        let initialized = REVIEW_UI_HTML
+            .find("notify(\"ui/notifications/initialized\", {});")
+            .unwrap();
+        let size_reporting = REVIEW_UI_HTML.find("startSizeReporting();").unwrap();
+        assert!(initialized < size_reporting);
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,10 +2,10 @@
 //! the axum wiring (`/mcp` Streamable HTTP, `/health`, CORS, bearer auth).
 //!
 //! Ports `src/server.ts`. rmcp's `StreamableHttpService` owns the transport and
-//! MCP session lifecycle: the service factory runs once per transport session,
-//! so a fresh [`SessionState`] owns resident exec processes and drops them when
-//! that session ends. ChatGPT project selection is stored separately by its
-//! stable conversation metadata and survives transport replacement.
+//! MCP session lifecycle: the service factory runs once per transport session.
+//! Transport-owned state is dropped with that session; ChatGPT project selection
+//! and review checkpoints use stable conversation metadata and survive replacement
+//! transports, while the embedded review resource remains presentation-only.
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -14,8 +14,10 @@ use axum::{Router, extract::State, response::Json, routing::get};
 use rmcp::{
     ErrorData as McpError, ServerHandler,
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, Implementation,
-        InitializeResult, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock,
+        ExtensionCapabilities, Implementation, InitializeResult, ListResourcesResult,
+        ListToolsResult, PaginatedRequestParams, ReadResourceRequestParams, ReadResourceResponse,
+        ReadResourceResult, ServerCapabilities, ServerInfo,
     },
     service::{RequestContext, RoleServer},
     transport::streamable_http_server::{
@@ -33,7 +35,9 @@ use crate::instructions::build_initial_instructions;
 use crate::openai_tunnel::TunnelHealth;
 use crate::project_bindings::{ConversationIdentity, ProjectBindingStore};
 use crate::registry::load_tools_for_mode;
-use crate::tool::Tool;
+use crate::review::{ReviewAvailability, ReviewCheckpointManager, ReviewOwner};
+use crate::review_ui;
+use crate::tool::{Tool, ToolRequestContext};
 use crate::tools::set_project_root::{SetProjectRoot, select_and_render};
 use crate::types::{AppConfig, ToolContent, ToolResult};
 
@@ -62,6 +66,7 @@ pub struct CodexHandler {
     config: Arc<AppConfig>,
     tools: Arc<Vec<Box<dyn Tool>>>,
     project_bindings: Arc<ProjectBindingStore>,
+    review_checkpoints: Arc<ReviewCheckpointManager>,
     session: SessionState,
 }
 
@@ -87,7 +92,20 @@ fn to_call_tool_result(result: ToolResult) -> CallToolResult {
 
 impl ServerHandler for CodexHandler {
     fn get_info(&self) -> ServerInfo {
-        InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+        let mut capabilities = ServerCapabilities::builder()
+            .enable_resources()
+            .enable_tools()
+            .build();
+        let mut extensions = ExtensionCapabilities::new();
+        extensions.insert(
+            review_ui::MCP_APPS_EXTENSION_ID.to_string(),
+            json!({ "mimeTypes": [review_ui::REVIEW_UI_MIME_TYPE] })
+                .as_object()
+                .cloned()
+                .expect("static MCP Apps capability must be an object"),
+        );
+        capabilities.extensions = Some(extensions);
+        InitializeResult::new(capabilities)
             .with_server_info(Implementation::new("codex-free", "1.2.0"))
             .with_instructions(build_initial_instructions(&self.config))
     }
@@ -104,6 +122,12 @@ impl ServerHandler for CodexHandler {
                 let schema = tool.input_schema().as_object().cloned().unwrap_or_default();
                 let mut mcp_tool =
                     rmcp::model::Tool::new(tool.name(), tool.describe(&self.config), schema);
+                if let Some(title) = tool.title() {
+                    mcp_tool = mcp_tool.with_title(title);
+                }
+                if let Some(meta) = tool.meta() {
+                    mcp_tool = mcp_tool.with_meta(meta);
+                }
                 if let Some(out) = tool.output_schema()
                     && let Some(obj) = out.as_object()
                 {
@@ -113,6 +137,30 @@ impl ServerHandler for CodexHandler {
             })
             .collect();
         Ok(ListToolsResult::with_all_items(tools))
+    }
+
+    async fn list_resources(
+        &self,
+        _request: Option<PaginatedRequestParams>,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, McpError> {
+        Ok(ListResourcesResult::with_all_items(vec![
+            review_ui::resource(),
+        ]))
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResponse, McpError> {
+        if request.uri != review_ui::REVIEW_UI_URI {
+            return Err(McpError::resource_not_found(
+                format!("Unknown resource: {}", request.uri),
+                None,
+            ));
+        }
+        Ok(ReadResourceResult::new(vec![review_ui::contents()]).into())
     }
 
     async fn call_tool(
@@ -128,6 +176,10 @@ impl ServerHandler for CodexHandler {
         });
         let name = request.name.as_ref();
         let args = request.arguments.map(Value::Object).unwrap_or(Value::Null);
+        let tool_context = ToolRequestContext {
+            conversation: conversation.clone(),
+            review_checkpoints: self.review_checkpoints.clone(),
+        };
 
         let Some(tool) = self.tools.iter().find(|t| t.name() == name) else {
             let result =
@@ -142,7 +194,8 @@ impl ServerHandler for CodexHandler {
                         .select_project_root(&self.config, identity, path)
                 })
             } else {
-                tool.call(args, &self.config, &self.session).await
+                tool.call_with_context(args, &self.config, &self.session, &tool_context)
+                    .await
             }
         } else {
             let effective_config = if tool.requires_project_root() {
@@ -166,7 +219,56 @@ impl ServerHandler for CodexHandler {
             let call_config = effective_config
                 .as_ref()
                 .unwrap_or_else(|| self.config.as_ref());
-            tool.call(args, call_config, &self.session).await
+            let review_guard = if tool.requires_project_root() {
+                let owner = match conversation.as_ref() {
+                    Some(identity) => ReviewOwner::conversation(identity),
+                    None => ReviewOwner::transport(self.session.review_state()),
+                };
+                if tool.may_modify_project() {
+                    match self
+                        .review_checkpoints
+                        .begin_mutation(call_config, owner)
+                        .await
+                    {
+                        Ok((ReviewAvailability::Ready, guard)) => Some(guard),
+                        Ok((ReviewAvailability::Unavailable(reason), guard)) => {
+                            tracing::debug!("review checkpoints unavailable for {name}: {reason}");
+                            Some(guard)
+                        }
+                        Err(error) => {
+                            let result = ToolResult::error(format!(
+                                "Refusing to run mutating tool `{name}` because the project review checkpoint could not be captured: {error}"
+                            ));
+                            tracing::info!("  tool: {name} -> error");
+                            return Ok(to_call_tool_result(result).into());
+                        }
+                    }
+                } else {
+                    match self
+                        .review_checkpoints
+                        .ensure_initialized(call_config, owner)
+                        .await
+                    {
+                        Ok(ReviewAvailability::Ready) => {}
+                        Ok(ReviewAvailability::Unavailable(reason)) => {
+                            tracing::debug!("review checkpoints unavailable for {name}: {reason}");
+                        }
+                        Err(error) => {
+                            tracing::debug!(
+                                "review checkpoint initialization skipped for {name}: {error}"
+                            );
+                        }
+                    }
+                    None
+                }
+            } else {
+                None
+            };
+            let result = tool
+                .call_with_context(args, call_config, &self.session, &tool_context)
+                .await;
+            drop(review_guard);
+            result
         };
 
         // Fill in the `structuredContent` the MCP spec expects from any tool that
@@ -212,6 +314,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     config.generated_skills_dir = Some(gen_dir);
     let config = Arc::new(config);
     let project_bindings = Arc::new(ProjectBindingStore::for_current_user());
+    let review_checkpoints = Arc::new(ReviewCheckpointManager::new());
 
     // Connect to any configured upstream MCP servers and merge their tools in.
     // The returned services must stay alive for the whole server lifetime, so
@@ -259,6 +362,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     let factory_config = config.clone();
     let factory_tools = tools.clone();
     let factory_project_bindings = project_bindings.clone();
+    let factory_review_checkpoints = review_checkpoints.clone();
     let service = StreamableHttpService::new(
         move || {
             let session = SessionState::new();
@@ -267,6 +371,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
                 config: factory_config.clone(),
                 tools: factory_tools.clone(),
                 project_bindings: factory_project_bindings.clone(),
+                review_checkpoints: factory_review_checkpoints.clone(),
                 session,
             })
         },
@@ -646,6 +751,29 @@ async fn shutdown_signal() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn advertises_review_resources_and_mcp_apps_extension() {
+        let root = tempfile::tempdir().unwrap();
+        let handler = CodexHandler {
+            config: Arc::new(crate::config::default_config(root.path().to_path_buf())),
+            tools: Arc::new(crate::registry::load_tools()),
+            project_bindings: Arc::new(ProjectBindingStore::new(root.path().join("bindings"))),
+            review_checkpoints: Arc::new(ReviewCheckpointManager::new()),
+            session: SessionState::new(),
+        };
+
+        let info = handler.get_info();
+        assert!(info.capabilities.resources.is_some());
+        assert!(
+            info.capabilities
+                .extensions
+                .as_ref()
+                .is_some_and(|extensions| {
+                    extensions.contains_key(review_ui::MCP_APPS_EXTENSION_ID)
+                })
+        );
+    }
 
     #[tokio::test]
     async fn http_shutdown_aborts_after_the_grace_period() {

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -4,11 +4,22 @@
 //! `Box<dyn Tool>` in the registry and dispatched by name, so the trait is
 //! object-safe via `async_trait`.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
+use rmcp::model::MetaObject;
 use serde_json::Value;
 
 use crate::exec_sessions::SessionState;
+use crate::project_bindings::ConversationIdentity;
+use crate::review::ReviewCheckpointManager;
 use crate::types::{AppConfig, ToolResult};
+
+#[derive(Clone)]
+pub struct ToolRequestContext {
+    pub conversation: Option<ConversationIdentity>,
+    pub review_checkpoints: Arc<ReviewCheckpointManager>,
+}
 
 #[async_trait]
 pub trait Tool: Send + Sync {
@@ -23,6 +34,16 @@ pub trait Tool: Send + Sync {
     /// the shell it will actually launch, which is not knowable at load time.
     fn describe(&self, _config: &AppConfig) -> String {
         self.description()
+    }
+
+    /// Optional human-readable title for hosts that render tool cards.
+    fn title(&self) -> Option<String> {
+        None
+    }
+
+    /// Optional protocol metadata, including MCP Apps resource links.
+    fn meta(&self) -> Option<MetaObject> {
+        None
     }
 
     /// The JSON Schema object for the tool's arguments.
@@ -49,9 +70,25 @@ pub trait Tool: Send + Sync {
         true
     }
 
+    /// Whether dispatch must fail closed if the initial review checkpoint cannot
+    /// be captured for a Git project.
+    fn may_modify_project(&self) -> bool {
+        false
+    }
+
     /// Run the tool. `args` is the arguments object (or `Value::Null` when the
     /// call named none).
     async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult;
+
+    async fn call_with_context(
+        &self,
+        args: Value,
+        config: &AppConfig,
+        session: &SessionState,
+        _context: &ToolRequestContext,
+    ) -> ToolResult {
+        self.call(args, config, session).await
+    }
 }
 
 /// Read a string argument by key, or `None` when absent or not a string.

--- a/src/tools/apply_patch.rs
+++ b/src/tools/apply_patch.rs
@@ -112,6 +112,10 @@ impl Tool for ApplyPatch {
         }))
     }
 
+    fn may_modify_project(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, config: &AppConfig, _session: &SessionState) -> ToolResult {
         let Some(input) = args.get("input").and_then(|v| v.as_str()) else {
             return ToolResult::error("input must be a string containing the patch text");

--- a/src/tools/exec_command.rs
+++ b/src/tools/exec_command.rs
@@ -107,6 +107,10 @@ impl Tool for ExecCommand {
         Some(unified_exec_output_schema())
     }
 
+    fn may_modify_project(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult {
         let cmd = arg_str(&args, "cmd").unwrap_or("");
         if cmd.trim().is_empty() {

--- a/src/tools/git_commit.rs
+++ b/src/tools/git_commit.rs
@@ -39,6 +39,10 @@ impl Tool for GitCommit {
         }))
     }
 
+    fn may_modify_project(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, config: &AppConfig, _session: &SessionState) -> ToolResult {
         let message = arg_str(&args, "message").unwrap_or("");
         let mut commit_args: Vec<&str> = vec!["commit"];

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -19,6 +19,7 @@ pub mod recall;
 pub mod remember;
 pub mod run_command;
 pub mod set_project_root;
+pub mod show_changes;
 pub mod skills_list;
 pub mod skills_read;
 pub mod tree;

--- a/src/tools/run_command.rs
+++ b/src/tools/run_command.rs
@@ -43,6 +43,10 @@ impl Tool for RunCommand {
         }))
     }
 
+    fn may_modify_project(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, config: &AppConfig, _session: &SessionState) -> ToolResult {
         let Some(command) = arg_str(&args, "command") else {
             return ToolResult::error("command must be a string");

--- a/src/tools/show_changes.rs
+++ b/src/tools/show_changes.rs
@@ -1,0 +1,195 @@
+use async_trait::async_trait;
+use rmcp::model::MetaObject;
+use serde_json::{Value, json};
+
+use crate::exec_sessions::SessionState;
+use crate::review::{ReviewBaseline, ReviewCheckpointManager, ReviewOwner, ReviewRequest};
+use crate::review_ui;
+use crate::tool::{Tool, ToolRequestContext};
+use crate::types::{AppConfig, ToolResult};
+
+pub struct ShowChanges;
+
+fn bool_argument(args: &Value, key: &str, default: bool) -> Result<bool, String> {
+    match args.get(key) {
+        None => Ok(default),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(_) => Err(format!("{key} must be a boolean")),
+    }
+}
+
+impl ShowChanges {
+    pub const NAME: &'static str = "show_changes";
+
+    fn request(args: &Value) -> Result<ReviewRequest, String> {
+        let since = match args.get("since") {
+            None => None,
+            Some(Value::String(value)) => Some(value.as_str()),
+            Some(_) => return Err("since must be a string".to_string()),
+        };
+        Ok(ReviewRequest {
+            since: ReviewBaseline::parse(since)?,
+            advance: bool_argument(args, "advance", true)?,
+            include_patch: bool_argument(args, "include_patch", true)?,
+        })
+    }
+
+    async fn run(
+        args: Value,
+        config: &AppConfig,
+        session: &SessionState,
+        manager: &ReviewCheckpointManager,
+        conversation: Option<&crate::project_bindings::ConversationIdentity>,
+    ) -> ToolResult {
+        let request = match Self::request(&args) {
+            Ok(request) => request,
+            Err(error) => return ToolResult::error(error),
+        };
+        let owner = match conversation {
+            Some(identity) => ReviewOwner::conversation(identity),
+            None => ReviewOwner::transport(session.review_state()),
+        };
+        match manager.show_changes(config, owner, request).await {
+            Ok(result) => {
+                let structured = serde_json::to_value(&result).unwrap_or(Value::Null);
+                ToolResult::text(result.render_text()).with_structured(structured)
+            }
+            Err(error) => ToolResult::error(error),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ShowChanges {
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn title(&self) -> Option<String> {
+        Some("Show changes".to_string())
+    }
+
+    fn meta(&self) -> Option<MetaObject> {
+        Some(review_ui::tool_meta())
+    }
+
+    fn description(&self) -> String {
+        "Review project-scoped working-tree changes against the immutable project-open checkpoint or the incremental last-review checkpoint. The snapshot includes tracked, untracked, deleted, renamed, executable, symlink, and binary changes without modifying the real Git index. By default the returned review advances the last-review checkpoint, so call once after a related batch of edits rather than after every file. Set advance=false for a read-only comparison."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "since": {
+                    "type": "string",
+                    "enum": ["last_review", "project_open"],
+                    "description": "Checkpoint to compare against. Default: last_review."
+                },
+                "advance": {
+                    "type": "boolean",
+                    "description": "Advance the last-review checkpoint to the current scoped snapshot after comparison. Default: true."
+                },
+                "include_patch": {
+                    "type": "boolean",
+                    "description": "Include the unified binary-capable patch when it fits review.maxPatchBytes. Default: true."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "since": { "type": "string", "enum": ["last_review", "project_open"] },
+                "advanceRequested": { "type": "boolean" },
+                "checkpointAdvanced": { "type": "boolean" },
+                "scope": { "type": "string" },
+                "summary": {
+                    "type": "object",
+                    "properties": {
+                        "files": { "type": "integer" },
+                        "additions": { "type": "integer" },
+                        "deletions": { "type": "integer" },
+                        "binaryFiles": { "type": "integer" }
+                    },
+                    "required": ["files", "additions", "deletions", "binaryFiles"]
+                },
+                "files": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string" },
+                            "previousPath": { "type": "string" },
+                            "status": { "type": "string" },
+                            "additions": { "type": "integer" },
+                            "deletions": { "type": "integer" },
+                            "binary": { "type": "boolean" }
+                        },
+                        "required": ["path", "status", "binary"]
+                    }
+                },
+                "filesOmitted": { "type": "integer" },
+                "patch": { "type": "string" },
+                "patchIncluded": { "type": "boolean" },
+                "patchBytes": { "type": "integer" },
+                "patchOmittedReason": { "type": "string" },
+                "warnings": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": [
+                "since", "advanceRequested", "checkpointAdvanced", "scope", "summary",
+                "files", "filesOmitted", "patch", "patchIncluded", "warnings"
+            ]
+        }))
+    }
+
+    fn fills_structured_content(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult {
+        let manager = ReviewCheckpointManager::new();
+        Self::run(args, config, session, &manager, None).await
+    }
+
+    async fn call_with_context(
+        &self,
+        args: Value,
+        config: &AppConfig,
+        session: &SessionState,
+        context: &ToolRequestContext,
+    ) -> ToolResult {
+        Self::run(
+            args,
+            config,
+            session,
+            &context.review_checkpoints,
+            context.conversation.as_ref(),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_defaults_to_incremental_advancing_patch_review() {
+        let request = ShowChanges::request(&json!({})).unwrap();
+        assert_eq!(request.since, ReviewBaseline::LastReview);
+        assert!(request.advance);
+        assert!(request.include_patch);
+    }
+
+    #[test]
+    fn request_rejects_wrong_argument_types() {
+        assert!(ShowChanges::request(&json!({ "since": 1 })).is_err());
+        assert!(ShowChanges::request(&json!({ "advance": "yes" })).is_err());
+        assert!(ShowChanges::request(&json!({ "include_patch": 1 })).is_err());
+    }
+}

--- a/src/tools/write_file.rs
+++ b/src/tools/write_file.rs
@@ -38,6 +38,10 @@ impl Tool for WriteFile {
         }))
     }
 
+    fn may_modify_project(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, config: &AppConfig, _session: &SessionState) -> ToolResult {
         let Some(path) = arg_str(&args, "path") else {
             return ToolResult::error("path must be a string");

--- a/src/tools/write_stdin.rs
+++ b/src/tools/write_stdin.rs
@@ -40,6 +40,10 @@ impl Tool for WriteStdin {
         Some(unified_exec_output_schema())
     }
 
+    fn may_modify_project(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, _config: &AppConfig, session: &SessionState) -> ToolResult {
         let Some(session_id) = arg_u64(&args, "session_id") else {
             return ToolResult::error("session_id must be a number");

--- a/src/types.rs
+++ b/src/types.rs
@@ -171,6 +171,28 @@ pub struct MemoryConfig {
     pub max_bytes: Option<usize>,
 }
 
+pub const DEFAULT_REVIEW_MAX_PATCH_BYTES: usize = 512 * 1024;
+
+/// Bounds review results without changing checkpoint semantics.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewConfig {
+    #[serde(default = "default_review_max_patch_bytes")]
+    pub max_patch_bytes: usize,
+}
+
+fn default_review_max_patch_bytes() -> usize {
+    DEFAULT_REVIEW_MAX_PATCH_BYTES
+}
+
+impl Default for ReviewConfig {
+    fn default() -> Self {
+        Self {
+            max_patch_bytes: DEFAULT_REVIEW_MAX_PATCH_BYTES,
+        }
+    }
+}
+
 /// Governs `SKILL.md` discovery. Every field is optional; `skills.rs` owns the
 /// defaults and search order.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -293,8 +315,8 @@ pub struct OpenAiTunnelConfig {
 
 /// The fully-resolved server configuration handed to every tool.
 ///
-/// `work_dir` and `port` are always concrete. `projectDoc`, `output`, `memory`,
-/// `skills` and `ignore` are passed through as-is and each implementing module
+/// `work_dir` and `port` are always concrete. `projectDoc`, `output`, `review`,
+/// `memory`, `skills` and `ignore` are passed through as-is and each implementing module
 /// owns what an absent field falls back to.
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -308,6 +330,7 @@ pub struct AppConfig {
     pub exec: ExecConfig,
     pub project_doc: ProjectDocConfig,
     pub output: OutputConfig,
+    pub review: ReviewConfig,
     pub memory: MemoryConfig,
     pub skills: SkillsConfig,
     pub ignore: IgnoreConfig,

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -25,15 +25,15 @@ use codex_free::types::{AppConfig, ToolContent, ToolResult};
 // ─── registry.test.ts ──────────────────────────────────────────────────
 
 #[test]
-fn loads_all_25_tools() {
+fn loads_all_26_tools() {
     let tools = load_tools();
-    assert_eq!(tools.len(), 25);
+    assert_eq!(tools.len(), 26);
 }
 
 #[test]
 fn multi_project_mode_adds_only_the_session_selector() {
     let tools = load_tools_for_mode(true);
-    assert_eq!(tools.len(), 26);
+    assert_eq!(tools.len(), 27);
     assert_eq!(tools[0].name(), "set_project_root");
 }
 
@@ -74,6 +74,7 @@ fn includes_expected_tool_names() {
         "write_file",
         "run_command",
         "git_status",
+        "show_changes",
         "git_push",
         "git_commit",
         "git_log",
@@ -141,6 +142,44 @@ fn all_tool_names_are_valid_mcp_names() {
             tool.name()
         );
     }
+}
+
+#[test]
+fn show_changes_links_the_review_mcp_app() {
+    let tools = load_tools();
+    let tool = tools
+        .iter()
+        .find(|tool| tool.name() == "show_changes")
+        .unwrap();
+    assert_eq!(tool.title().as_deref(), Some("Show changes"));
+    let meta = tool.meta().unwrap();
+    assert_eq!(
+        meta.get("ui")
+            .and_then(|value| value.get("resourceUri"))
+            .and_then(Value::as_str),
+        Some(codex_free::review_ui::REVIEW_UI_URI)
+    );
+}
+
+#[test]
+fn mutating_tools_are_classified_for_checkpoint_fail_closed_behavior() {
+    let mut names = load_tools()
+        .into_iter()
+        .filter(|tool| tool.may_modify_project())
+        .map(|tool| tool.name().to_string())
+        .collect::<Vec<_>>();
+    names.sort();
+    assert_eq!(
+        names,
+        [
+            "apply_patch".to_string(),
+            "exec_command".to_string(),
+            "git_commit".to_string(),
+            "run_command".to_string(),
+            "write_file".to_string(),
+            "write_stdin".to_string(),
+        ]
+    );
 }
 
 // ─── structured-content.test.ts ────────────────────────────────────────
@@ -321,6 +360,7 @@ fn tools_that_need_their_own_structured_content() {
             "exec_command".to_string(),
             "get_environment".to_string(),
             "get_project_doc".to_string(),
+            "show_changes".to_string(),
             "skills_list".to_string(),
             "write_stdin".to_string(),
         ]

--- a/tests/review_checkpoints.rs
+++ b/tests/review_checkpoints.rs
@@ -1,0 +1,598 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Duration;
+
+use codex_free::config::default_config;
+use codex_free::project_bindings::ConversationIdentity;
+use codex_free::review::{
+    ReviewBaseline, ReviewCheckpointManager, ReviewOwner, ReviewRequest, TransportReviewState,
+};
+use tempfile::TempDir;
+
+fn git(dir: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .expect("git must be installed");
+    assert!(
+        output.status.success(),
+        "git {} failed: {}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn init_repo() -> TempDir {
+    let repo = TempDir::new().unwrap();
+    git(repo.path(), &["init", "--quiet"]);
+    git(repo.path(), &["config", "user.name", "Test"]);
+    git(repo.path(), &["config", "user.email", "test@example.com"]);
+    git(repo.path(), &["config", "commit.gpgsign", "false"]);
+    repo
+}
+
+fn commit_all(repo: &Path, message: &str) {
+    git(repo, &["add", "-f", "-A"]);
+    git(repo, &["commit", "--quiet", "-m", message]);
+}
+
+fn conversation(value: &str) -> ReviewOwner {
+    ReviewOwner::conversation(&ConversationIdentity::from_openai_session(value).unwrap())
+}
+
+fn request(since: ReviewBaseline, advance: bool) -> ReviewRequest {
+    ReviewRequest {
+        since,
+        advance,
+        include_patch: true,
+    }
+}
+
+#[tokio::test]
+async fn nested_project_excludes_sibling_changes_and_preserves_the_real_index() {
+    let repo = init_repo();
+    let app = repo.path().join("packages/app");
+    let sibling = repo.path().join("packages/other");
+    std::fs::create_dir_all(app.join("src")).unwrap();
+    std::fs::create_dir_all(&sibling).unwrap();
+    std::fs::write(app.join("src/app.txt"), "app\n").unwrap();
+    std::fs::write(sibling.join("other.txt"), "other\n").unwrap();
+    commit_all(repo.path(), "seed");
+
+    std::fs::write(sibling.join("staged.txt"), "staged\n").unwrap();
+    git(repo.path(), &["add", "-f", "packages/other/staged.txt"]);
+    let index_before = git(repo.path(), &["diff", "--cached", "--binary"]);
+    let index_path = PathBuf::from(git(repo.path(), &["rev-parse", "--git-path", "index"]));
+    let index_path = if index_path.is_absolute() {
+        index_path
+    } else {
+        repo.path().join(index_path)
+    };
+    let index_bytes_before = std::fs::read(&index_path).unwrap();
+
+    let config = default_config(app.clone());
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("nested-project");
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+    let index_after = git(repo.path(), &["diff", "--cached", "--binary"]);
+    let index_bytes_after = std::fs::read(&index_path).unwrap();
+    assert_eq!(index_after, index_before);
+    assert_eq!(index_bytes_after, index_bytes_before);
+
+    std::fs::write(app.join("src/app.txt"), "app changed\n").unwrap();
+    std::fs::write(sibling.join("other.txt"), "sibling changed\n").unwrap();
+    let result = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+
+    assert_eq!(result.scope, "packages/app");
+    assert_eq!(result.summary.files, 1);
+    assert_eq!(result.files[0].path, "src/app.txt");
+    assert!(result.patch.contains("a/src/app.txt"));
+    assert!(result.patch.contains("b/src/app.txt"));
+    assert!(!result.patch.contains("packages/app"));
+    assert!(!result.patch.contains("packages/other"));
+    assert!(!result.patch.contains("sibling changed"));
+}
+
+#[tokio::test]
+async fn last_review_advances_while_project_open_remains_immutable() {
+    let repo = init_repo();
+    let file = repo.path().join("file.txt");
+    std::fs::write(&file, "zero\n").unwrap();
+    commit_all(repo.path(), "seed");
+
+    let config = default_config(repo.path().to_path_buf());
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("incremental-review");
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+
+    std::fs::write(&file, "one\n").unwrap();
+    let first = manager
+        .show_changes(
+            &config,
+            owner.clone(),
+            request(ReviewBaseline::LastReview, true),
+        )
+        .await
+        .unwrap();
+    assert!(first.checkpoint_advanced);
+    assert!(first.patch.contains("+one"));
+
+    std::fs::write(&file, "two\n").unwrap();
+    let incremental = manager
+        .show_changes(
+            &config,
+            owner.clone(),
+            request(ReviewBaseline::LastReview, false),
+        )
+        .await
+        .unwrap();
+    assert!(incremental.patch.contains("-one"));
+    assert!(incremental.patch.contains("+two"));
+    assert!(!incremental.patch.contains("-zero"));
+
+    let from_open = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+    assert!(from_open.patch.contains("-zero"));
+    assert!(from_open.patch.contains("+two"));
+}
+
+#[tokio::test]
+async fn conversation_checkpoints_survive_manager_replacement() {
+    let repo = init_repo();
+    let file = repo.path().join("file.txt");
+    std::fs::write(&file, "before\n").unwrap();
+    commit_all(repo.path(), "seed");
+    let config = default_config(repo.path().to_path_buf());
+    let identity = ConversationIdentity::from_openai_session("persistent-review").unwrap();
+
+    ReviewCheckpointManager::new()
+        .ensure_initialized(&config, ReviewOwner::conversation(&identity))
+        .await
+        .unwrap();
+    std::fs::write(&file, "after\n").unwrap();
+
+    let result = ReviewCheckpointManager::new()
+        .show_changes(
+            &config,
+            ReviewOwner::conversation(&identity),
+            request(ReviewBaseline::ProjectOpen, false),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.summary.files, 1);
+    assert!(result.patch.contains("+after"));
+}
+
+#[tokio::test]
+async fn deleting_persistent_refs_reinitializes_a_live_manager() {
+    let repo = init_repo();
+    let file = repo.path().join("file.txt");
+    std::fs::write(&file, "before\n").unwrap();
+    commit_all(repo.path(), "seed");
+    let config = default_config(repo.path().to_path_buf());
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("live-ref-reset");
+
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+    let refs = git(
+        repo.path(),
+        &[
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/codex-free/review/",
+        ],
+    );
+    assert_eq!(refs.lines().count(), 2);
+    for reference in refs.lines() {
+        git(repo.path(), &["update-ref", "-d", reference]);
+    }
+
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+    let recreated = git(
+        repo.path(),
+        &[
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/codex-free/review/",
+        ],
+    );
+    assert_eq!(recreated.lines().count(), 2);
+
+    std::fs::write(&file, "after\n").unwrap();
+    let result = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+    assert_eq!(result.summary.files, 1);
+    assert!(result.patch.contains("+after"));
+}
+
+#[tokio::test]
+async fn mutation_guard_serializes_review_for_the_same_scope() {
+    let repo = init_repo();
+    std::fs::write(repo.path().join("file.txt"), "before\n").unwrap();
+    commit_all(repo.path(), "seed");
+    let config = default_config(repo.path().to_path_buf());
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("serialized-review");
+
+    let (_, guard) = manager
+        .begin_mutation(&config, owner.clone())
+        .await
+        .unwrap();
+    let blocked = tokio::time::timeout(
+        Duration::from_millis(50),
+        manager.show_changes(
+            &config,
+            owner.clone(),
+            request(ReviewBaseline::ProjectOpen, false),
+        ),
+    )
+    .await;
+    assert!(blocked.is_err());
+
+    drop(guard);
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        manager.show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false)),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(result.summary.files, 0);
+}
+
+#[tokio::test]
+async fn transport_checkpoints_survive_aggressive_git_gc() {
+    let repo = init_repo();
+    let file = repo.path().join("file.txt");
+    std::fs::write(&file, "before\n").unwrap();
+    commit_all(repo.path(), "seed");
+    let config = default_config(repo.path().to_path_buf());
+    let manager = ReviewCheckpointManager::new();
+    let state = TransportReviewState::new();
+    let owner = ReviewOwner::transport(state.clone());
+
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+    git(repo.path(), &["reflog", "expire", "--expire=now", "--all"]);
+    git(repo.path(), &["gc", "--prune=now"]);
+
+    std::fs::write(&file, "after\n").unwrap();
+    let result = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+    assert_eq!(result.summary.files, 1);
+    assert!(result.patch.contains("+after"));
+}
+
+#[tokio::test]
+async fn conversations_and_transports_have_independent_open_checkpoints() {
+    let repo = init_repo();
+    let file = repo.path().join("file.txt");
+    std::fs::write(&file, "zero\n").unwrap();
+    commit_all(repo.path(), "seed");
+    let config = default_config(repo.path().to_path_buf());
+    let manager = ReviewCheckpointManager::new();
+
+    let first_conversation = conversation("first");
+    manager
+        .ensure_initialized(&config, first_conversation.clone())
+        .await
+        .unwrap();
+    std::fs::write(&file, "one\n").unwrap();
+
+    let second_conversation = manager
+        .show_changes(
+            &config,
+            conversation("second"),
+            request(ReviewBaseline::ProjectOpen, false),
+        )
+        .await
+        .unwrap();
+    assert_eq!(second_conversation.summary.files, 0);
+
+    let first_result = manager
+        .show_changes(
+            &config,
+            first_conversation,
+            request(ReviewBaseline::ProjectOpen, false),
+        )
+        .await
+        .unwrap();
+    assert_eq!(first_result.summary.files, 1);
+
+    let transport_one = ReviewOwner::transport(TransportReviewState::new());
+    manager
+        .ensure_initialized(&config, transport_one.clone())
+        .await
+        .unwrap();
+    std::fs::write(&file, "two\n").unwrap();
+    let transport_two = manager
+        .show_changes(
+            &config,
+            ReviewOwner::transport(TransportReviewState::new()),
+            request(ReviewBaseline::ProjectOpen, false),
+        )
+        .await
+        .unwrap();
+    assert_eq!(transport_two.summary.files, 0);
+    let transport_one = manager
+        .show_changes(
+            &config,
+            transport_one,
+            request(ReviewBaseline::ProjectOpen, false),
+        )
+        .await
+        .unwrap();
+    assert_eq!(transport_one.summary.files, 1);
+}
+
+#[tokio::test]
+async fn captures_renames_deletions_untracked_and_binary_files() {
+    let repo = init_repo();
+    std::fs::write(repo.path().join("rename-me.txt"), "same\n").unwrap();
+    std::fs::write(repo.path().join("delete-me.txt"), "gone\n").unwrap();
+    commit_all(repo.path(), "seed");
+    let config = default_config(repo.path().to_path_buf());
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("change-kinds");
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+
+    std::fs::rename(
+        repo.path().join("rename-me.txt"),
+        repo.path().join("renamed.txt"),
+    )
+    .unwrap();
+    std::fs::remove_file(repo.path().join("delete-me.txt")).unwrap();
+    std::fs::write(repo.path().join("untracked.txt"), "new\n").unwrap();
+    std::fs::write(repo.path().join("binary.bin"), [0_u8, 1, 2, 0, 4]).unwrap();
+
+    let result = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+    assert_eq!(result.summary.files, 4);
+    assert_eq!(result.summary.binary_files, 1);
+    assert!(result.files.iter().any(|file| file.status == "renamed"));
+    assert!(result.files.iter().any(|file| file.status == "deleted"));
+    assert!(result.files.iter().any(|file| file.path == "untracked.txt"));
+    assert!(result.files.iter().any(|file| file.binary));
+    assert!(result.patch.contains("GIT binary patch"));
+}
+
+#[tokio::test]
+async fn supports_unborn_repositories() {
+    let repo = init_repo();
+    let file = repo.path().join("file.txt");
+    std::fs::write(&file, "before\n").unwrap();
+    let config = default_config(repo.path().to_path_buf());
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("unborn");
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+
+    std::fs::write(&file, "after\n").unwrap();
+    let result = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+    assert_eq!(result.summary.files, 1);
+    assert!(result.patch.contains("+after"));
+}
+
+#[tokio::test]
+async fn omits_instead_of_truncating_an_oversized_patch() {
+    let repo = init_repo();
+    let file = repo.path().join("large.txt");
+    std::fs::write(&file, "before\n").unwrap();
+    commit_all(repo.path(), "seed");
+    let mut config = default_config(repo.path().to_path_buf());
+    config.review.max_patch_bytes = 128;
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("patch-budget");
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+
+    std::fs::write(&file, format!("{}\n", "after".repeat(2_000))).unwrap();
+    let result = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+    assert!(!result.patch_included);
+    assert!(result.patch.is_empty());
+    assert!(
+        result
+            .patch_omitted_reason
+            .as_deref()
+            .unwrap()
+            .contains("maxPatchBytes")
+    );
+}
+
+#[tokio::test]
+async fn non_git_project_reports_a_clear_error() {
+    let root = TempDir::new().unwrap();
+    let config = default_config(PathBuf::from(root.path()));
+    let error = ReviewCheckpointManager::new()
+        .show_changes(
+            &config,
+            conversation("not-git"),
+            request(ReviewBaseline::ProjectOpen, false),
+        )
+        .await
+        .unwrap_err();
+    assert!(error.contains("requires a Git worktree"), "{error}");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn captures_executable_and_symlink_changes() {
+    use std::os::unix::fs::{PermissionsExt, symlink};
+
+    let repo = init_repo();
+    let script = repo.path().join("script.sh");
+    let link = repo.path().join("current");
+    std::fs::write(&script, "#!/bin/sh\necho ok\n").unwrap();
+    std::fs::write(repo.path().join("first.txt"), "first\n").unwrap();
+    std::fs::write(repo.path().join("second.txt"), "second\n").unwrap();
+    symlink("first.txt", &link).unwrap();
+    commit_all(repo.path(), "seed");
+
+    let config = default_config(repo.path().to_path_buf());
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("modes-and-links");
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+
+    let mut permissions = std::fs::metadata(&script).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&script, permissions).unwrap();
+    std::fs::remove_file(&link).unwrap();
+    symlink("second.txt", &link).unwrap();
+
+    let result = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+    assert_eq!(result.summary.files, 2);
+    assert!(result.files.iter().any(|file| file.path == "script.sh"));
+    assert!(result.files.iter().any(|file| file.path == "current"));
+    assert!(result.patch.contains("old mode 100644"));
+    assert!(result.patch.contains("new mode 100755"));
+    assert!(result.patch.contains("-first.txt"));
+    assert!(result.patch.contains("+second.txt"));
+}
+
+#[tokio::test]
+async fn concurrent_advancement_uses_compare_and_swap() {
+    let repo = init_repo();
+    let file = repo.path().join("file.txt");
+    std::fs::write(&file, "before\n").unwrap();
+    commit_all(repo.path(), "seed");
+
+    let config = default_config(repo.path().to_path_buf());
+    let identity = ConversationIdentity::from_openai_session("concurrent-review").unwrap();
+    ReviewCheckpointManager::new()
+        .ensure_initialized(&config, ReviewOwner::conversation(&identity))
+        .await
+        .unwrap();
+    std::fs::write(&file, "after\n").unwrap();
+
+    let first = ReviewCheckpointManager::new();
+    let second = ReviewCheckpointManager::new();
+    let (left, right) = tokio::join!(
+        first.show_changes(
+            &config,
+            ReviewOwner::conversation(&identity),
+            request(ReviewBaseline::LastReview, true),
+        ),
+        second.show_changes(
+            &config,
+            ReviewOwner::conversation(&identity),
+            request(ReviewBaseline::LastReview, true),
+        )
+    );
+    let left = left.unwrap();
+    let right = right.unwrap();
+    assert_eq!(
+        usize::from(left.checkpoint_advanced) + usize::from(right.checkpoint_advanced),
+        1
+    );
+    let conflicted = if left.checkpoint_advanced {
+        right
+    } else {
+        left
+    };
+    assert!(
+        conflicted
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("changed concurrently"))
+    );
+}
+
+#[tokio::test]
+async fn non_git_initialization_is_explicitly_unavailable() {
+    let root = TempDir::new().unwrap();
+    let config = default_config(root.path().to_path_buf());
+    let availability = ReviewCheckpointManager::new()
+        .ensure_initialized(&config, conversation("not-git-initialization"))
+        .await
+        .unwrap();
+    assert!(matches!(
+        availability,
+        codex_free::review::ReviewAvailability::Unavailable(_)
+    ));
+}
+
+#[tokio::test]
+async fn malformed_git_configuration_is_a_checkpoint_error() {
+    let repo = init_repo();
+    std::fs::write(repo.path().join(".git/config"), "[broken\n").unwrap();
+    let config = default_config(repo.path().to_path_buf());
+
+    let error = ReviewCheckpointManager::new()
+        .ensure_initialized(&config, conversation("malformed-git-config"))
+        .await
+        .unwrap_err();
+    assert!(error.contains("bad config"), "{error}");
+}
+
+#[tokio::test]
+async fn git_snapshot_failures_are_not_treated_as_non_git_projects() {
+    let repo = init_repo();
+    std::fs::write(repo.path().join("broken.txt"), "before\n").unwrap();
+    commit_all(repo.path(), "seed");
+    std::fs::write(
+        repo.path().join(".gitattributes"),
+        "broken.txt filter=review-test-failure\n",
+    )
+    .unwrap();
+    git(
+        repo.path(),
+        &["config", "filter.review-test-failure.clean", "false"],
+    );
+    git(
+        repo.path(),
+        &["config", "filter.review-test-failure.required", "true"],
+    );
+
+    let config = default_config(repo.path().to_path_buf());
+    let error = ReviewCheckpointManager::new()
+        .ensure_initialized(&config, conversation("snapshot-failure"))
+        .await
+        .unwrap_err();
+    assert!(error.contains("git add failed"), "{error}");
+}


### PR DESCRIPTION
## Overview

Add a first-class, project-scoped review workflow to Codex Free. The new `show_changes` tool compares the current working tree against either an immutable project-open checkpoint or the last acknowledged review, returns a complete structured review result, and optionally renders that result as an MCP Apps card in compatible ChatGPT clients.

The implementation is deliberately independent of the UI: plain MCP clients receive the same text summary and structured file, statistic, warning, and patch data.

## Checkpoint model

Each review scope is the canonical logical project root plus its owner:

- ChatGPT conversations use the existing hashed `openai/session` identity and retain two Git refs under `refs/codex-free/review/`.
- Generic MCP clients keep checkpoint identifiers in transport-local state and snapshot objects in a transport-owned temporary Git object database. Repository GC cannot invalidate an active transport, and a clean transport close leaves no persistent refs.

The two baselines are:

- `project_open`: immutable state captured before the first project mutation;
- `last_review`: incremental state advanced only by `show_changes` with `advance=true`.

Persistent advancement uses `git update-ref` compare-and-swap semantics. Mutating tool calls and review operations are serialized per owner/project scope so a concurrent write cannot slip between baseline initialization and execution.

## Repository and monorepo safety

Snapshots are created through a private temporary Git index. The real index and working tree are never modified.

Every snapshot and comparison carries an explicit literal pathspec for the selected logical project. A project such as `packages/app` therefore cannot include changes from `packages/other`; returned file paths and patch headers are rebased relative to the selected project.

The snapshot path covers tracked, untracked, deleted, renamed, binary, executable-bit, symlink, and unborn-repository cases. Git failures inside an existing worktree fail closed before mutating tools, while non-Git projects remain usable and report review as unavailable.

## Tool and result contract

`show_changes` accepts:

- `since: "last_review" | "project_open"`;
- `advance: boolean` (default `true`);
- `include_patch: boolean` (default `true`).

Its structured result includes aggregate counts, bounded per-file records, rename sources, binary markers, checkpoint status, warnings, and a complete binary-capable patch. `review.maxPatchBytes` bounds patch output; oversized patches are omitted explicitly rather than truncated mid-hunk.

## MCP Apps UI

The server advertises the standard `io.modelcontextprotocol/ui` extension and serves a self-contained resource at:

```text
ui://codex-free/review/mcp-app.html
```

The `show_changes` descriptor links this resource through current and compatibility metadata. The embedded card renders summary statistics, changed files, and the unified patch without external scripts, styles, fonts, storage, or network requests. It performs the MCP Apps initialization handshake before sending size notifications and renders untrusted result text through DOM `textContent`.

The card updates when `show_changes` is called; it is not a continuous filesystem watcher.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all` — 413 tests passed
- `git diff --check`
- Independent `codex review --uncommitted` — no findings

Regression coverage includes monorepo sibling exclusion, byte-for-byte real-index preservation, persistent and transport ownership, ref reset while the server is live, mutation/review serialization, compare-and-swap conflicts, aggressive repository GC, unborn repositories, renames, deletions, binary files, executable and symlink changes, malformed Git state, patch-budget omission, and MCP Apps metadata/handshake behavior.
