### PR TITLE
feat: add verbose diagnostics and secure audit logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ Each release ships a compiled binary per platform — `windows-x64`, `linux-x64`
 | `--port` | No | `3000` | Server port |
 | `--api-key` | No | - | Bearer token for auth |
 | `--config` | No | `./codex.config.json` | Config file path (tolerated if missing) |
+| `-v`, `--verbose` | No | Info logs | Enable Codex Free debug diagnostics; repeat (`-vv`) for trace diagnostics (`--log-tool-calls` is an alias) |
+| `--audit <FILE>` | No | Disabled | Append privacy-preserving tool activity events to a JSONL file (`--audit-log` is an alias) |
+| `--audit-command-preview` | No | Disabled | Add bounded, redacted previews for `exec_command` and `run_command` to the audit log |
+| `--audit-redact-env <NAME>` | No | - | Redact the current value of an environment variable from command previews; repeat for multiple names |
 | `--openai-tunnel-id` | No | - | Existing OpenAI Secure MCP Tunnel ID; enables native tunnel mode |
 | `--openai-tunnel-api-key-ref` | No | `env:CONTROL_PLANE_API_KEY` | Runtime key reference in `env:NAME` or `file:/path` form |
 | `--openai-tunnel-client` | No | managed pinned runtime | Explicit `tunnel-client` or `tunnel-client-runtime` binary |
@@ -249,6 +253,12 @@ All project-scoped paths are resolved relative to the active project root: `--wo
     "maxEntries": 500,
     "maxTreeNodes": 1000
   },
+  "audit": {
+    "logFile": null,
+    "includeCommandPreview": false,
+    "commandPreviewMaxBytes": 512,
+    "redactEnv": []
+  },
   "memory": {
     "enabled": true,
     "maxBytes": 16384
@@ -270,6 +280,52 @@ All project-scoped paths are resolved relative to the active project root: `--wo
 ```
 
 CLI flags override values from the config file.
+
+## Diagnostics and audit logging
+
+The default tracing level remains `info`. `-v` changes the default filter to `codex_free=debug,rmcp=warn`, which adds tool-start events, hashed conversation/project context, argument field names, duration, and output accounting without dumping protocol traffic. `-vv` changes Codex Free to `trace` while keeping `rmcp` at `warn`, and adds the fully redacted argument-shape summary. An explicit `RUST_LOG` value takes precedence over `-v`/`-vv` when protocol-level diagnostics are required:
+
+```bash
+codex-free -v --work-dir /path/to/project
+RUST_LOG=codex_free=trace,rmcp=warn codex-free --work-dir /path/to/project
+```
+
+Audit logging is separate from diagnostic tracing and is disabled unless a file is configured:
+
+```bash
+codex-free \
+  --work-dir /path/to/project \
+  --audit ~/.codex-free/audit/tools.jsonl
+```
+
+The append-only JSONL stream begins with `audit_started`, which identifies the server version, OS process, random run ID, and command-preview policy, then emits `tool_start` and `tool_finish` records. Tool records carry an RFC 3339 timestamp, monotonic call ID, transport-session ID, hashed ChatGPT conversation and project identifiers, tool name, duration, status, argument shape, returned byte/token counts, truncation status when the tool can report it, and resident `exec_command` session/PID metadata. Argument summaries include only fields declared by the tool's input schema; unknown keys and dynamic maps are counted but their key names are omitted. Raw conversation identifiers, project paths, scalar argument values, image data, structured output, and returned text are not written.
+
+Command previews are a separate opt-in because shell commands can contain credentials, source code, paths, and environment values:
+
+```bash
+codex-free \
+  --work-dir /path/to/project \
+  --audit ~/.codex-free/audit/tools.jsonl \
+  --audit-command-preview \
+  --audit-redact-env GITHUB_TOKEN
+```
+
+Before a preview is written, Codex Free replaces the local MCP bearer, configured MCP-server environment values, the referenced OpenAI tunnel key when readable, values named by `audit.redactEnv` / `--audit-redact-env`, common secret-bearing process environment variables, and common `--token`, `API_KEY=…`, and `Bearer …` forms. The preview is then capped at `commandPreviewMaxBytes`. This is defense in depth, not a proof that an arbitrary command contains no sensitive literal; leave previews disabled when command text itself is sensitive.
+
+The `audit` config block has the same controls:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `logFile` | `null` | JSONL destination; a relative path resolves from the launch directory. Setting it enables auditing |
+| `includeCommandPreview` | `false` | Include bounded, redacted `exec_command` / `run_command` previews |
+| `commandPreviewMaxBytes` | `512` | Maximum UTF-8 byte length of a command preview; accepted range is `1`-`16384` |
+| `redactEnv` | `[]` | Environment-variable names whose current values must be removed from previews |
+
+`--audit` replaces `audit.logFile`; `--audit-command-preview` only enables previews; and repeated `--audit-redact-env` values are merged with `audit.redactEnv` so a CLI invocation cannot accidentally remove configured redactions.
+
+Startup fails if an enabled audit file cannot be opened safely. On Unix, newly created files use mode `0600`, symbolic-link targets are rejected, and an existing file with group/other permission bits is rejected. A later append or flush error is emitted as an error-level diagnostic without changing the result of a tool that may already have had side effects.
+
+This is an operational activity log, not a tamper-evident security boundary. Model-launched commands run as the same OS user and can modify any audit file they can locate and access. Keep the file outside the project access root, restrict its directory permissions, and forward it to a separately protected collector when independent evidence is required.
 
 The `openaiTunnel` block enables OpenAI's native outbound tunnel:
 
@@ -656,6 +712,7 @@ Native tunnel mode ignores `allowedHosts` and forces the accepted authorities to
 - **Tunnel secrets are references, not config values**: `openaiTunnel.apiKeyRef` accepts only `env:NAME` or `file:/path`; literal API keys are rejected. Codex Free resolves the value and exposes it only to the tunnel child under a synthetic environment name, while the child receives a clean, allowlisted environment. Use a restricted runtime key with Tunnels **Read** + **Use**, not an admin key. Private key-file permissions are enforced on Unix. Same-user process inspection and same-user file access remain outside this boundary.
 - **Optional bearer token auth in non-native mode**: set `--api-key` to require an `Authorization: Bearer <key>` header on all requests except `/health`. Native mode instead owns its private per-process bearer token. ChatGPT Plugins do not support simple bearer token auth for URL-based connectors.
 - **Host allowlist**: set `allowedHosts` to pin the accepted `Host` header for DNS-rebinding protection. See [Host allowlist](#host-allowlist).
+- **Audit records exclude payloads by default**: `--audit` writes hashes, timings, result sizes, and redacted argument shape rather than source, file paths, credentials, or returned output. Command previews require a separate opt-in and remain potentially sensitive even after configured and heuristic redaction, so protect the audit file as operational data.
 
 The allowlist is a **guardrail against accidents, not a sandbox**. It catches a model reaching for `curl` or `rm -rf`; it does not contain a determined one. The defaults already include `node`, `python` and `cargo`, each of which runs arbitrary code — `node -e "..."` can do anything the server process can. Shell redirection and explicit absolute or parent paths can also reach outside the active project root even though each command starts with that root as its cwd. Multi-project selection isolates Codex Free's structured tools and logical per-conversation project state; it is not an operating-system sandbox. Treat everything below as reachable by whoever is authorized to use the configured connector or external endpoint:
 

--- a/codex.config.json
+++ b/codex.config.json
@@ -22,5 +22,11 @@
     ],
     "maxSessions": 8,
     "idleTimeoutMs": 300000
+  },
+  "audit": {
+    "logFile": null,
+    "includeCommandPreview": false,
+    "commandPreviewMaxBytes": 512,
+    "redactEnv": []
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,6 +43,10 @@ ChatGPT / MCP client
 │    • openai/session hash → project root       │
 │    • persistent atomic binding records        │
 │                                               │
+│  optional shared AuditLogger                  │
+│    • redacted JSONL tool lifecycle records    │
+│    • no raw arguments or returned output      │
+│                                               │
 │  per-transport SessionState                   │
 │    • fallback root for generic MCP clients    │
 │    • exec sessions + current plan             │
@@ -87,7 +91,11 @@ Three surfaces reach the model:
    the transport-session fallback when no conversation identity exists, then
    receive an effective clone of `AppConfig` whose `work_dir` is that root. The
    server fills in default `structuredContent` when appropriate.
-7. When the transport session ends, rmcp drops the `CodexHandler`; its
+7. Dispatch emits diagnostic tracing and, when enabled, paired JSONL `tool_start`
+   / `tool_finish` audit records. Identity and project values are hashed; scalar
+   argument values and returned payloads are replaced by schema-bounded shape and
+   size accounting. Unknown argument keys and dynamic-map keys are not recorded.
+8. When the transport session ends, rmcp drops the `CodexHandler`; its
    `SessionState::Drop` kills resident `exec_command` shells. The conversation
    binding remains on disk and is restored by a later transport or server process.
 
@@ -118,11 +126,14 @@ trait Tool: Send + Sync {
 ```
 
 ### `ToolResult` (`types.rs`)
-`{ content: Vec<ToolContent>, is_error: bool, structured_content: Option<Value> }`.
+`{ content: Vec<ToolContent>, is_error: bool, structured_content: Option<Value>, audit: ToolAuditMetadata }`.
 The server converts it to rmcp's `CallToolResult`. Tools with an `outputSchema`
 whose text *is* the structured form rely on the server's default-fill
 (`{ "content": <joined text> }`); tools that build their own structured content —
 or bridge it from upstream — return `fills_structured_content() == false`.
+`ToolAuditMetadata` is not sent over MCP; bounded-output and resident-process tools
+use it to report truncation, original token count, exec-session ID and PID without
+putting operational fields into their public output schema.
 
 ### `ProjectBindingStore` (`project_bindings.rs`)
 Shared, durable conversation-to-project bindings. `ConversationIdentity` hashes
@@ -144,7 +155,7 @@ The fully-resolved config handed to every tool. `config.rs` parses
 `codex.config.json` with camelCase field names for backward compatibility, imports
 user-level Codex MCP definitions through `codex_mcp.rs`, then applies explicit
 `mcpServers` entries as field overlays. Optional sub-configs (`projectDoc`,
-`output`, `memory`, `skills`, `ignore`) fall back to per-module defaults. In
+`output`, `memory`, `skills`, `ignore`, `audit`) fall back to per-module defaults. In
 multi-project mode, dispatch clones this config per call and substitutes the
 conversation's selected root—or the transport fallback—for `work_dir`; the static
 server policy and bridge configuration remain shared.
@@ -236,6 +247,8 @@ the original order and rejects duplicate names.
 |--------|----------------|
 | `safe_path.rs` | Lexical path-traversal guard (no `canonicalize`; component-wise containment). The security boundary for every filesystem tool. |
 | `output_budget.rs` | Line/byte windowing and list caps, each cut announced with the continuation argument. |
+| `audit.rs` | Private append-only JSONL tool lifecycle records, stable hashed identities, redacted argument summaries, output accounting, and opt-in bounded command previews. |
+| `logging.rs` | Default tracing filters for normal, `-v`, and `-vv` operation; an explicit `RUST_LOG` remains authoritative. |
 | `ignore_rules.rs` | One `.gitignore`-accurate matcher (the `ignore` crate) shared by glob/grep/tree/list_directory. |
 | `exec_policy.rs` | Shell-string allowlist guard for `exec_command` (a guardrail, not a sandbox). |
 | `project_bindings.rs` | Canonical project-root validation plus durable ChatGPT conversation bindings keyed by a hash of `openai/session`, namespaced by access root, locked per record, and atomically written. |
@@ -361,6 +374,8 @@ startup banner prints the exact file with `Config:`). All fields optional.
               "defaultShell": "…" },
   "ignore": { "useGitignore": true, "useDefaultPatterns": true, "customPatterns": [] },
   "output": { "maxFileLines": 1000, "maxFileBytes": 131072, "maxEntries": 500, "maxTreeNodes": 1000 },
+  "audit": { "logFile": null, "includeCommandPreview": false,
+             "commandPreviewMaxBytes": 512, "redactEnv": [] },
   "projectDoc": { "maxBytes": 32768, "fallbackFilenames": [], "rootMarkers": [".git"] },
   "memory": { "enabled": true, "dir": "…", "maxBytes": 16384 },
   "skills": { "enabled": true, "dirs": ["…"], "includePlugins": true },
@@ -390,6 +405,8 @@ Tools loaded (26): 25 native + 1 bridged from upstream MCP servers
 Upstream MCP servers:
   remote-exec -> gateway (84 functions via `remote_exec`)
 Auth: disabled (no --api-key)
+Audit log: /private/path/tools.jsonl
+Audit command previews: disabled
 ```
 
 - `Config:` reveals the common mistake of editing a different file than the one
@@ -402,6 +419,9 @@ Auth: disabled (no --api-key)
 - Multi-project startup also prints `Project access root:`, `Project mode:
   persistent ChatGPT conversation binding`, and the conversation-binding state
   directory; its native count is 26 because the selector is present.
+- `-v` and `-vv` increase Codex Free diagnostics without dumping raw tool payloads;
+  `RUST_LOG` overrides those defaults. When audit logging is configured, the banner
+  prints its destination and whether command previews are enabled.
 
 ---
 
@@ -425,7 +445,7 @@ units to match the TS `text.length` / `text.slice`.
 
 ## 12. Testing
 
-- **381 tests** — unit tests inside modules plus integration tests under `tests/`
+- **405 tests** — unit tests inside modules plus integration tests under `tests/`
   (`tempfile`-isolated), ported from the TS Bun suite.
 - Memory / skills tests pin `memory.dir` / `skills.dirs` to temp dirs so they never
   touch the real home; plugin discovery is suppressed when `skills.dirs` is set.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -1,0 +1,846 @@
+//! Structured tool activity records that deliberately exclude raw arguments and output.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, bail};
+use chrono::{SecondsFormat, Utc};
+use regex::Regex;
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use crate::exec_sessions::approx_token_count;
+use crate::project_bindings::ConversationIdentity;
+use crate::types::{AppConfig, ToolContent, ToolResult};
+
+const SCHEMA_VERSION: u64 = 1;
+const HASH_HEX_CHARS: usize = 24;
+const MAX_ARGUMENT_FIELDS: usize = 64;
+const MAX_ARGUMENT_DEPTH: usize = 3;
+const MAX_REFERENCED_SECRET_BYTES: u64 = 64 * 1024;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AuditScope {
+    pub(crate) transport_session_id: u64,
+    pub(crate) conversation_id: Option<String>,
+    pub(crate) access_root_id: String,
+    pub(crate) project_id: Option<String>,
+}
+
+impl AuditScope {
+    pub(crate) fn new(
+        transport_session_id: u64,
+        conversation: Option<&ConversationIdentity>,
+        access_root: &Path,
+        project_root: Option<&Path>,
+    ) -> Self {
+        Self {
+            transport_session_id,
+            conversation_id: conversation.map(|identity| identity.audit_hash().to_string()),
+            access_root_id: hash_path(access_root),
+            project_id: project_root.map(hash_path),
+        }
+    }
+}
+
+pub(crate) struct AuditCall {
+    id: u64,
+}
+
+pub(crate) struct AuditLogger {
+    path: PathBuf,
+    run_id: String,
+    next_call_id: AtomicU64,
+    file: Mutex<File>,
+    include_command_preview: bool,
+    command_preview_max_bytes: usize,
+    secrets: Zeroizing<Vec<String>>,
+    secret_patterns: Vec<(Regex, &'static str)>,
+}
+
+impl AuditLogger {
+    pub(crate) fn open(config: &AppConfig) -> anyhow::Result<Option<Self>> {
+        let Some(path) = config.audit.log_file.clone() else {
+            return Ok(None);
+        };
+        let file = open_private_append(&path)?;
+        let include_command_preview = config.audit.include_command_preview;
+        let (secrets, secret_patterns) = if include_command_preview {
+            (collect_secret_values(config), secret_patterns())
+        } else {
+            (Zeroizing::new(Vec::new()), Vec::new())
+        };
+        let logger = Self {
+            path,
+            run_id: random_id()?,
+            next_call_id: AtomicU64::new(1),
+            file: Mutex::new(file),
+            include_command_preview,
+            command_preview_max_bytes: config.audit.command_preview_max_bytes,
+            secrets,
+            secret_patterns,
+        };
+        logger.write_event(&json!({
+            "schema_version": SCHEMA_VERSION,
+            "timestamp": timestamp(),
+            "event": "audit_started",
+            "run_id": logger.run_id,
+            "server_version": env!("CARGO_PKG_VERSION"),
+            "server_process_id": std::process::id(),
+            "command_previews": logger.include_command_preview,
+            "command_preview_max_bytes": logger.command_preview_max_bytes,
+        }))?;
+        Ok(Some(logger))
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn command_previews_enabled(&self) -> bool {
+        self.include_command_preview
+    }
+
+    pub(crate) fn begin_tool(
+        &self,
+        tool: &str,
+        arguments: &Value,
+        input_schema: Option<&Value>,
+        scope: &AuditScope,
+    ) -> AuditCall {
+        let call = AuditCall {
+            id: self.next_call_id.fetch_add(1, Ordering::Relaxed),
+        };
+        let mut event = Map::from_iter([
+            ("schema_version".to_string(), json!(SCHEMA_VERSION)),
+            ("timestamp".to_string(), json!(timestamp())),
+            ("event".to_string(), json!("tool_start")),
+            ("run_id".to_string(), json!(self.run_id)),
+            ("call_id".to_string(), json!(call.id)),
+            (
+                "transport_session_id".to_string(),
+                json!(scope.transport_session_id),
+            ),
+            ("conversation_id".to_string(), json!(scope.conversation_id)),
+            ("access_root_id".to_string(), json!(scope.access_root_id)),
+            ("project_id".to_string(), json!(scope.project_id)),
+            ("tool".to_string(), json!(tool)),
+            (
+                "argument_summary".to_string(),
+                summarize_arguments(arguments, input_schema),
+            ),
+        ]);
+        if let Some(preview) = self.command_preview(tool, arguments) {
+            event.insert("command_preview".to_string(), json!(preview));
+        }
+        self.record(Value::Object(event));
+        call
+    }
+
+    pub(crate) fn finish_tool(
+        &self,
+        call: &AuditCall,
+        tool: &str,
+        result: &ToolResult,
+        duration_ms: u64,
+        scope: &AuditScope,
+    ) {
+        self.record(json!({
+            "schema_version": SCHEMA_VERSION,
+            "timestamp": timestamp(),
+            "event": "tool_finish",
+            "run_id": self.run_id,
+            "call_id": call.id,
+            "transport_session_id": scope.transport_session_id,
+            "conversation_id": scope.conversation_id,
+            "access_root_id": scope.access_root_id,
+            "project_id": scope.project_id,
+            "tool": tool,
+            "duration_ms": duration_ms,
+            "status": if result.is_error { "error" } else { "ok" },
+            "output": summarize_output(result),
+        }));
+    }
+
+    fn command_preview(&self, tool: &str, arguments: &Value) -> Option<String> {
+        if !self.include_command_preview {
+            return None;
+        }
+        match tool {
+            "exec_command" => {
+                let raw = arguments.get("cmd")?.as_str()?.replace('\0', "\u{fffd}");
+                Some(bound_utf8(
+                    &self.redact_command(&raw),
+                    self.command_preview_max_bytes,
+                ))
+            }
+            "run_command" => {
+                let command = arguments.get("command")?.as_str()?;
+                let mut argv = vec![command.to_string()];
+                if let Some(values) = arguments.get("args").and_then(Value::as_array) {
+                    argv.extend(values.iter().filter_map(Value::as_str).map(str::to_string));
+                }
+                let redacted = self.redact_argv(&argv);
+                let preview = serde_json::to_string(&redacted).ok()?;
+                Some(bound_utf8(&preview, self.command_preview_max_bytes))
+            }
+            _ => None,
+        }
+    }
+
+    fn redact_command(&self, command: &str) -> String {
+        let mut redacted = command.to_string();
+        for secret in self.secrets.iter() {
+            redacted = redacted.replace(secret, "[REDACTED]");
+        }
+        for (pattern, replacement) in &self.secret_patterns {
+            redacted = pattern.replace_all(&redacted, *replacement).into_owned();
+        }
+        redacted
+    }
+
+    fn redact_argv(&self, argv: &[String]) -> Vec<String> {
+        let mut redact_next = false;
+        argv.iter()
+            .map(|argument| {
+                if redact_next {
+                    redact_next = false;
+                    return "[REDACTED]".to_string();
+                }
+                redact_next = secret_flag_takes_next(argument);
+                self.redact_command(&argument.replace('\0', "\u{fffd}"))
+            })
+            .collect()
+    }
+
+    fn record(&self, event: Value) {
+        if let Err(error) = self.write_event(&event) {
+            tracing::error!(
+                target: "codex_free::audit",
+                path = %self.path.display(),
+                error = %error,
+                "failed to append audit event"
+            );
+        }
+    }
+
+    fn write_event(&self, event: &Value) -> anyhow::Result<()> {
+        let mut line = serde_json::to_vec(event).context("serialize audit event")?;
+        line.push(b'\n');
+        let mut file = self
+            .file
+            .lock()
+            .map_err(|_| anyhow::anyhow!("audit log lock poisoned"))?;
+        file.write_all(&line)
+            .with_context(|| format!("append audit event to {}", self.path.display()))?;
+        file.flush()
+            .with_context(|| format!("flush audit log {}", self.path.display()))?;
+        Ok(())
+    }
+}
+
+pub(crate) fn summarize_arguments(arguments: &Value, input_schema: Option<&Value>) -> Value {
+    summarize_value(arguments, None, 0, input_schema)
+}
+
+pub(crate) fn argument_field_names(arguments: &Value, input_schema: Option<&Value>) -> String {
+    let Some(object) = arguments.as_object() else {
+        return value_type(arguments).to_string();
+    };
+    let Some(properties) = schema_properties(input_schema) else {
+        return format!("{} redacted field(s)", object.len());
+    };
+    let mut names: Vec<&str> = object
+        .keys()
+        .filter(|name| properties.contains_key(*name))
+        .map(String::as_str)
+        .collect();
+    names.sort_unstable();
+    let redacted = object.len().saturating_sub(names.len());
+    if redacted > 0 {
+        names.push("<additional fields redacted>");
+    }
+    names.join(",")
+}
+
+pub(crate) fn summarize_output(result: &ToolResult) -> Value {
+    let mut text_bytes = 0u64;
+    let mut text_tokens = 0u64;
+    let mut image_base64_bytes = 0u64;
+    let mut image_count = 0u64;
+    for content in &result.content {
+        match content {
+            ToolContent::Text(text) => {
+                text_bytes = text_bytes.saturating_add(text.len() as u64);
+                text_tokens = text_tokens.saturating_add(approx_token_count(text));
+            }
+            ToolContent::Image { data, .. } => {
+                image_count = image_count.saturating_add(1);
+                image_base64_bytes = image_base64_bytes.saturating_add(data.len() as u64);
+            }
+        }
+    }
+    let structured_bytes = result
+        .structured_content
+        .as_ref()
+        .map_or(0, serialized_json_bytes);
+    json!({
+        "content_bytes": text_bytes.saturating_add(image_base64_bytes),
+        "text_bytes": text_bytes,
+        "approx_text_tokens": text_tokens,
+        "image_count": image_count,
+        "image_base64_bytes": image_base64_bytes,
+        "structured_bytes": structured_bytes,
+        "truncated": result.audit.truncated,
+        "original_output_tokens": result.audit.original_output_tokens,
+        "exec_session_id": result.audit.exec_session_id,
+        "process_id": result.audit.process_id,
+        "resident": result.audit.resident,
+    })
+}
+
+#[derive(Default)]
+struct CountingWriter(u64);
+
+impl Write for CountingWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        self.0 = self.0.saturating_add(buffer.len() as u64);
+        Ok(buffer.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn serialized_json_bytes(value: &Value) -> u64 {
+    let mut writer = CountingWriter::default();
+    if serde_json::to_writer(&mut writer, value).is_ok() {
+        writer.0
+    } else {
+        0
+    }
+}
+
+fn summarize_value(
+    value: &Value,
+    key: Option<&str>,
+    depth: usize,
+    schema: Option<&Value>,
+) -> Value {
+    let sensitive = key.is_some_and(sensitive_key);
+    if sensitive {
+        return redacted_value_summary(value);
+    }
+    match value {
+        Value::Null => json!({ "type": "null" }),
+        Value::Bool(_) => json!({ "type": "boolean", "redacted": true }),
+        Value::Number(_) => json!({ "type": "number", "redacted": true }),
+        Value::String(value) => json!({
+            "type": "string",
+            "bytes": value.len(),
+            "redacted": true,
+        }),
+        Value::Array(values) => json!({
+            "type": "array",
+            "items": values.len(),
+            "redacted": true,
+        }),
+        Value::Object(values)
+            if depth >= MAX_ARGUMENT_DEPTH || schema_properties(schema).is_none() =>
+        {
+            json!({
+                "type": "object",
+                "fields": values.len(),
+                "redacted": true,
+            })
+        }
+        Value::Object(values) => {
+            let properties = schema_properties(schema).expect("checked above");
+            let mut names: Vec<&String> = values
+                .keys()
+                .filter(|name| properties.contains_key(*name))
+                .collect();
+            names.sort_unstable();
+            names.truncate(MAX_ARGUMENT_FIELDS);
+            let mut fields = Map::new();
+            for name in names {
+                let value = values.get(name).expect("name came from the object");
+                fields.insert(
+                    name.clone(),
+                    summarize_value(
+                        value,
+                        Some(name),
+                        depth.saturating_add(1),
+                        properties.get(name),
+                    ),
+                );
+            }
+            let fields_omitted = values.len().saturating_sub(fields.len());
+            json!({
+                "type": "object",
+                "field_count": values.len(),
+                "fields": fields,
+                "fields_omitted": fields_omitted,
+            })
+        }
+    }
+}
+
+fn redacted_value_summary(value: &Value) -> Value {
+    match value {
+        Value::Null => json!({ "type": "null", "redacted": true }),
+        Value::Bool(_) => json!({ "type": "boolean", "redacted": true }),
+        Value::Number(_) => json!({ "type": "number", "redacted": true }),
+        Value::String(value) => json!({
+            "type": "string",
+            "bytes": value.len(),
+            "redacted": true,
+        }),
+        Value::Array(values) => json!({
+            "type": "array",
+            "items": values.len(),
+            "redacted": true,
+        }),
+        Value::Object(values) => json!({
+            "type": "object",
+            "fields": values.len(),
+            "redacted": true,
+        }),
+    }
+}
+
+fn schema_properties(schema: Option<&Value>) -> Option<&Map<String, Value>> {
+    schema?.get("properties").and_then(Value::as_object)
+}
+
+fn value_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn sensitive_key(key: &str) -> bool {
+    let normalized: String = key
+        .chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect();
+    [
+        "secret",
+        "token",
+        "password",
+        "passphrase",
+        "credential",
+        "authorization",
+        "cookie",
+        "apikey",
+        "privatekey",
+        "content",
+        "input",
+        "patch",
+        "chars",
+        "data",
+        "env",
+        "header",
+        "file",
+        "path",
+        "workdir",
+        "command",
+        "cmd",
+        "args",
+        "message",
+        "value",
+    ]
+    .iter()
+    .any(|fragment| normalized.contains(fragment))
+}
+
+fn hash_path(path: &Path) -> String {
+    let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(b"codex-free/audit-project/v1\0");
+    hasher.update(path.to_string_lossy().as_bytes());
+    encode_hex(&hasher.finalize(), HASH_HEX_CHARS)
+}
+
+fn encode_hex(bytes: &[u8], chars: usize) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded.truncate(chars);
+    encoded
+}
+
+fn random_id() -> anyhow::Result<String> {
+    let mut bytes = [0u8; 16];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|error| anyhow::anyhow!("generate audit run id: {error}"))?;
+    Ok(encode_hex(&bytes, bytes.len() * 2))
+}
+
+fn timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+fn collect_secret_values(config: &AppConfig) -> Zeroizing<Vec<String>> {
+    let mut values = Vec::new();
+    if let Some(api_key) = config.api_key.as_deref() {
+        push_secret(&mut values, api_key, false);
+    }
+    for server in config.mcp_servers.values() {
+        for value in server.env.values() {
+            push_secret(&mut values, value, false);
+        }
+    }
+    for name in &config.audit.redact_env {
+        if let Ok(value) = std::env::var(name) {
+            push_secret(&mut values, &value, false);
+        }
+    }
+    for (name, value) in std::env::vars_os() {
+        if let (Some(name), Some(value)) = (name.to_str(), value.to_str())
+            && secret_env_name(name)
+        {
+            push_secret(&mut values, value, true);
+        }
+    }
+    if let Some(tunnel) = config.openai_tunnel.as_ref() {
+        if let Some(name) = tunnel.api_key_ref.strip_prefix("env:") {
+            if let Ok(value) = std::env::var(name) {
+                push_secret(&mut values, &value, false);
+            }
+        } else if let Some(path) = tunnel.api_key_ref.strip_prefix("file:") {
+            let path = Path::new(path);
+            if std::fs::metadata(path).is_ok_and(|metadata| {
+                metadata.is_file() && metadata.len() <= MAX_REFERENCED_SECRET_BYTES
+            }) && let Ok(value) = std::fs::read_to_string(path)
+            {
+                push_secret(&mut values, value.trim(), false);
+            }
+        }
+    }
+    values.sort_by(|left, right| right.len().cmp(&left.len()).then_with(|| left.cmp(right)));
+    values.dedup();
+    Zeroizing::new(values)
+}
+
+fn push_secret(values: &mut Vec<String>, value: &str, automatic: bool) {
+    if !value.is_empty() && (!automatic || value.len() >= 8) {
+        values.push(value.to_string());
+    }
+}
+
+fn secret_env_name(name: &str) -> bool {
+    let normalized = name.to_ascii_lowercase();
+    [
+        "secret",
+        "token",
+        "password",
+        "passphrase",
+        "credential",
+        "authorization",
+        "cookie",
+        "api_key",
+        "apikey",
+        "private_key",
+    ]
+    .iter()
+    .any(|fragment| normalized.contains(fragment))
+}
+
+fn secret_flag_takes_next(argument: &str) -> bool {
+    if !argument.starts_with('-') || argument.contains('=') {
+        return false;
+    }
+    let name = argument.trim_start_matches('-').to_ascii_lowercase();
+    matches!(name.as_str(), "u" | "user" | "proxy-user") || secret_env_name(&name)
+}
+
+fn secret_patterns() -> Vec<(Regex, &'static str)> {
+    [
+        (
+            r#"(?i)([\"']?(?:authorization|proxy-authorization)[\"']?\s*:\s*[\"']?(?:bearer|basic)\s+)[^\s'\";]+"#,
+            "$1[REDACTED]",
+        ),
+        (
+            r#"(?i)(\bbearer\s+)[A-Za-z0-9._~+/-]+=*"#,
+            "$1[REDACTED]",
+        ),
+        (
+            r#"(?i)((?:^|\s)--?[A-Za-z0-9_-]*(?:api[-_]?key|token|secret|password|passphrase|authorization|credential)[A-Za-z0-9_-]*(?:=|\s+))(?:\"[^\"]*\"|'[^']*'|[^\s;]+)"#,
+            "$1[REDACTED]",
+        ),
+        (
+            r#"(?i)(\b[A-Za-z0-9_]*(?:api[_-]?key|token|secret|password|passphrase|authorization|credential)[A-Za-z0-9_]*\s*=\s*)(?:\"[^\"]*\"|'[^']*'|[^\s;]+)"#,
+            "$1[REDACTED]",
+        ),
+        (
+            r#"(?i)([\"']?[A-Za-z0-9_-]*(?:api[-_]?key|token|secret|password|passphrase|credential)[A-Za-z0-9_-]*[\"']?\s*:\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;}]+)"#,
+            "$1[REDACTED]",
+        ),
+    ]
+    .into_iter()
+    .map(|(pattern, replacement)| {
+        (
+            Regex::new(pattern).expect("static audit redaction regex"),
+            replacement,
+        )
+    })
+    .collect()
+}
+
+fn bound_utf8(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_string();
+    }
+    let marker = "...[truncated]";
+    if max_bytes <= marker.len() {
+        return marker[..max_bytes].to_string();
+    }
+    let mut end = max_bytes - marker.len();
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}{}", &value[..end], marker)
+}
+
+fn open_private_append(path: &Path) -> anyhow::Result<File> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create audit log directory {}", parent.display()))?;
+    }
+    #[cfg(not(unix))]
+    if std::fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        bail!(
+            "audit log path must not be a symbolic link: {}",
+            path.display()
+        );
+    }
+
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    let file = options
+        .open(path)
+        .with_context(|| format!("open audit log {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("inspect audit log {}", path.display()))?;
+    if !metadata.is_file() {
+        bail!("audit log is not a regular file: {}", path.display());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o077 != 0 {
+            bail!(
+                "audit log is readable by other users; run chmod 600 {}",
+                path.display()
+            );
+        }
+    }
+    Ok(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::default_config;
+
+    #[test]
+    fn argument_summary_exposes_shape_but_not_values() {
+        let arguments = json!({
+            "path": "/private/source.rs",
+            "timeout": 1200,
+            "flag": true,
+            "nested": { "token": "top-secret", "count": 3 },
+            "items": ["a", "b"]
+        });
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "timeout": { "type": "number" },
+                "flag": { "type": "boolean" },
+                "nested": {
+                    "type": "object",
+                    "properties": {
+                        "token": { "type": "string" },
+                        "count": { "type": "number" }
+                    }
+                },
+                "items": { "type": "array" }
+            }
+        });
+        let summary = summarize_arguments(&arguments, Some(&schema)).to_string();
+        assert!(!summary.contains("/private/source.rs"));
+        assert!(!summary.contains("top-secret"));
+        assert!(!summary.contains("\"a\""));
+        assert!(!summary.contains("1200"));
+        assert!(summary.contains("field_count"));
+    }
+
+    #[test]
+    fn argument_summary_omits_unknown_and_sensitive_nested_field_names() {
+        let arguments = json!({
+            "known": true,
+            "secret-as-an-unknown-key": "value",
+            "env": { "SECRET_AS_A_DYNAMIC_KEY": "value" }
+        });
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "known": { "type": "boolean" },
+                "env": { "type": "object" }
+            }
+        });
+
+        let summary = summarize_arguments(&arguments, Some(&schema)).to_string();
+        assert!(summary.contains("known"));
+        assert!(summary.contains("env"));
+        assert!(!summary.contains("secret-as-an-unknown-key"));
+        assert!(!summary.contains("SECRET_AS_A_DYNAMIC_KEY"));
+    }
+
+    #[test]
+    fn command_redaction_covers_known_values_and_secret_syntax() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = default_config(root.path().to_path_buf());
+        config.audit.log_file = Some(root.path().join("audit.jsonl"));
+        config.audit.include_command_preview = true;
+        config.api_key = Some("literal-known-secret".to_string());
+        let logger = AuditLogger::open(&config).unwrap().unwrap();
+        let redacted = logger.redact_command(
+            "tool --github-token prefixed-token OPENAI_API_KEY=assigned-key literal-known-secret \"api_key\": \"json-secret\" Authorization: Basic basic-token Bearer abc.def",
+        );
+        assert!(!redacted.contains("prefixed-token"));
+        assert!(!redacted.contains("assigned-key"));
+        assert!(!redacted.contains("literal-known-secret"));
+        assert!(!redacted.contains("json-secret"), "{redacted}");
+        assert!(!redacted.contains("basic-token"));
+        assert!(!redacted.contains("abc.def"));
+        assert!(redacted.matches("[REDACTED]").count() >= 6);
+    }
+
+    #[test]
+    fn run_command_preview_redacts_separate_secret_arguments() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = default_config(root.path().to_path_buf());
+        config.audit.log_file = Some(root.path().join("audit.jsonl"));
+        config.audit.include_command_preview = true;
+        let logger = AuditLogger::open(&config).unwrap().unwrap();
+        let arguments = json!({
+            "command": "tool",
+            "args": [
+                "--github-token",
+                "separate-token-value",
+                "--header",
+                "Authorization: Bearer header-token-value",
+                "--user",
+                "name:password"
+            ]
+        });
+
+        let preview = logger.command_preview("run_command", &arguments).unwrap();
+        assert!(!preview.contains("separate-token-value"), "{preview}");
+        assert!(!preview.contains("header-token-value"), "{preview}");
+        assert!(!preview.contains("name:password"), "{preview}");
+        assert!(preview.matches("[REDACTED]").count() >= 3, "{preview}");
+    }
+
+    #[test]
+    fn jsonl_records_metadata_without_arguments_or_output() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("audit.jsonl");
+        let mut config = default_config(root.path().to_path_buf());
+        config.audit.log_file = Some(path.clone());
+        config.audit.include_command_preview = true;
+        config.api_key = Some("known-secret-value".to_string());
+        let logger = AuditLogger::open(&config).unwrap().unwrap();
+        let conversation =
+            ConversationIdentity::from_openai_session("raw-conversation-id").unwrap();
+        let scope = AuditScope::new(7, Some(&conversation), root.path(), Some(root.path()));
+        let arguments = json!({ "cmd": "echo known-secret-value", "workdir": "/private" });
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "cmd": { "type": "string" },
+                "workdir": { "type": "string" }
+            }
+        });
+        let call = logger.begin_tool("exec_command", &arguments, Some(&schema), &scope);
+        let result = ToolResult::text("returned sensitive output").with_truncation(true);
+        logger.finish_tool(&call, "exec_command", &result, 17, &scope);
+        drop(logger);
+
+        let contents = std::fs::read_to_string(path).unwrap();
+        assert!(!contents.contains("known-secret-value"));
+        assert!(!contents.contains("returned sensitive output"));
+        assert!(!contents.contains("raw-conversation-id"));
+        assert!(!contents.contains("/private"));
+        let events: Vec<Value> = contents
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect();
+        assert_eq!(events.len(), 3);
+        assert_eq!(events[0]["event"], "audit_started");
+        assert_eq!(events[0]["server_version"], env!("CARGO_PKG_VERSION"));
+        assert!(events[0]["server_process_id"].as_u64().is_some());
+        assert_eq!(events[1]["event"], "tool_start");
+        assert_eq!(events[2]["event"], "tool_finish");
+        assert_eq!(events[2]["duration_ms"], 17);
+        assert_eq!(events[2]["output"]["truncated"], true);
+        assert_eq!(events[2]["output"]["text_bytes"], 25);
+    }
+
+    #[test]
+    fn project_hashes_are_stable_and_do_not_contain_paths() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        assert_eq!(hash_path(first.path()), hash_path(first.path()));
+        assert_ne!(hash_path(first.path()), hash_path(second.path()));
+        assert_eq!(hash_path(first.path()).len(), HASH_HEX_CHARS);
+    }
+
+    #[test]
+    fn utf8_preview_bound_is_byte_strict() {
+        let bounded = bound_utf8(&"é".repeat(100), 31);
+        assert!(bounded.len() <= 31);
+        assert!(bounded.ends_with("...[truncated]"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn audit_log_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("audit.jsonl");
+        let mut config = default_config(root.path().to_path_buf());
+        config.audit.log_file = Some(path.clone());
+        drop(AuditLogger::open(&config).unwrap());
+        assert_eq!(
+            std::fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -129,6 +129,7 @@ fn map_call_result(result: CallToolResult) -> ToolResult {
         content,
         is_error: result.is_error.unwrap_or(false),
         structured_content: result.structured_content,
+        audit: Default::default(),
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,15 +6,15 @@
 
 use std::path::{Path, PathBuf};
 
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use serde::Deserialize;
 
 use std::collections::HashMap;
 
 use crate::codex_mcp::{codex_config_path, discover_codex_mcp_servers};
 use crate::types::{
-    AppConfig, CommandConfig, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig,
-    OpenAiTunnelConfig, OutputConfig, ProjectDocConfig, SkillsConfig, TreeConfig,
+    AppConfig, AuditConfig, CommandConfig, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec,
+    MemoryConfig, OpenAiTunnelConfig, OutputConfig, ProjectDocConfig, SkillsConfig, TreeConfig,
 };
 
 #[derive(Parser, Debug)]
@@ -23,6 +23,15 @@ use crate::types::{
     about = "Codex Free MCP bridge (Rust): expose Codex-style agent tools over Streamable HTTP."
 )]
 pub struct Cli {
+    /// Increase codex-free diagnostics. Repeat for trace-level diagnostics.
+    #[arg(
+        short = 'v',
+        long = "verbose",
+        visible_alias = "log-tool-calls",
+        action = ArgAction::Count
+    )]
+    pub verbose: u8,
+
     /// Project directory, or the access root when --multi-project is enabled.
     #[arg(long = "work-dir")]
     pub work_dir: String,
@@ -43,6 +52,18 @@ pub struct Cli {
     /// Config file path. Default: ./codex.config.json (tolerated if missing).
     #[arg(long)]
     pub config: Option<String>,
+
+    /// Append privacy-preserving tool activity events to a JSONL file.
+    #[arg(long = "audit", visible_alias = "audit-log", value_name = "FILE")]
+    pub audit_log: Option<String>,
+
+    /// Include bounded, redacted previews of exec_command and run_command.
+    #[arg(long = "audit-command-preview")]
+    pub audit_command_preview: bool,
+
+    /// Redact the value of this environment variable from command previews.
+    #[arg(long = "audit-redact-env", value_name = "NAME", action = ArgAction::Append)]
+    pub audit_redact_env: Vec<String>,
 
     /// Existing OpenAI Secure MCP Tunnel id. Enables the outbound native tunnel.
     #[arg(long = "openai-tunnel-id")]
@@ -140,6 +161,15 @@ struct PartialOpenAiTunnel {
     api_key_ref: Option<String>,
     client_path: Option<String>,
     organization_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PartialAudit {
+    log_file: Option<String>,
+    include_command_preview: Option<bool>,
+    command_preview_max_bytes: Option<usize>,
+    redact_env: Option<Vec<String>>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -252,6 +282,7 @@ struct FileConfig {
     memory: Option<MemoryConfig>,
     skills: Option<SkillsConfig>,
     ignore: Option<IgnoreConfig>,
+    audit: Option<PartialAudit>,
     codex_mcp: Option<CodexMcpConfig>,
     allowed_hosts: Option<Vec<String>>,
     openai_tunnel: Option<PartialOpenAiTunnel>,
@@ -338,6 +369,7 @@ pub fn default_config(work_dir: std::path::PathBuf) -> AppConfig {
         memory: MemoryConfig::default(),
         skills: SkillsConfig::default(),
         ignore: IgnoreConfig::default(),
+        audit: AuditConfig::default(),
         allowed_hosts: Vec::new(),
         openai_tunnel: None,
         mcp_servers: HashMap::new(),
@@ -458,6 +490,49 @@ fn resolve_openai_tunnel(
     }))
 }
 
+fn resolve_audit(file: Option<PartialAudit>, cli: &Cli) -> Result<AuditConfig, String> {
+    const MAX_COMMAND_PREVIEW_BYTES: usize = 16 * 1024;
+
+    let file = file.unwrap_or_default();
+    let log_file = cli
+        .audit_log
+        .as_deref()
+        .or(file.log_file.as_deref())
+        .map(resolve_path);
+    let include_command_preview =
+        cli.audit_command_preview || file.include_command_preview.unwrap_or(false);
+    let command_preview_max_bytes = file
+        .command_preview_max_bytes
+        .unwrap_or_else(|| AuditConfig::default().command_preview_max_bytes);
+    if !(1..=MAX_COMMAND_PREVIEW_BYTES).contains(&command_preview_max_bytes) {
+        return Err(format!(
+            "audit.commandPreviewMaxBytes must be between 1 and {MAX_COMMAND_PREVIEW_BYTES}"
+        ));
+    }
+    if include_command_preview && log_file.is_none() {
+        return Err("audit command previews require audit.logFile or --audit <FILE>".to_string());
+    }
+
+    let mut redact_env = file.redact_env.unwrap_or_default();
+    redact_env.extend(cli.audit_redact_env.iter().cloned());
+    for name in &redact_env {
+        if !valid_env_name(name) {
+            return Err(format!(
+                "audit.redactEnv contains an invalid environment-variable name: {name}"
+            ));
+        }
+    }
+    redact_env.sort();
+    redact_env.dedup();
+
+    Ok(AuditConfig {
+        log_file,
+        include_command_preview,
+        command_preview_max_bytes,
+        redact_env,
+    })
+}
+
 /// Load and merge config. Errors are returned as strings for the caller to
 /// print and exit on, mirroring the TS which validates and `process.exit`s.
 pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
@@ -546,6 +621,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
 
     let mcp_servers = resolve_mcp_servers(&mut file);
     let openai_tunnel = resolve_openai_tunnel(file.openai_tunnel, &cli)?;
+    let audit = resolve_audit(file.audit, &cli)?;
     let api_key = cli.api_key.or(file.api_key);
     if api_key.is_some() && openai_tunnel.is_some() {
         return Err(
@@ -570,6 +646,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
         memory: file.memory.unwrap_or_default(),
         skills: file.skills.unwrap_or_default(),
         ignore: file.ignore.unwrap_or_default(),
+        audit,
         allowed_hosts: file.allowed_hosts.unwrap_or_default(),
         openai_tunnel,
         mcp_servers,
@@ -580,6 +657,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn imported_server() -> McpServerSpec {
         McpServerSpec {
@@ -598,16 +676,90 @@ mod tests {
 
     fn cli(work_dir: &Path, config: &Path) -> Cli {
         Cli {
+            verbose: 0,
             work_dir: work_dir.to_string_lossy().into_owned(),
             multi_project: false,
             port: None,
             api_key: None,
             config: Some(config.to_string_lossy().into_owned()),
+            audit_log: None,
+            audit_command_preview: false,
+            audit_redact_env: Vec::new(),
             openai_tunnel_id: None,
             openai_tunnel_api_key_ref: None,
             openai_tunnel_client: None,
             openai_tunnel_organization_id: None,
         }
+    }
+
+    #[test]
+    fn cli_parses_verbose_and_audit_controls() {
+        let parsed = Cli::try_parse_from([
+            "codex-free",
+            "-v",
+            "--log-tool-calls",
+            "--work-dir",
+            "/tmp/project",
+            "--audit-log",
+            "/tmp/audit.jsonl",
+            "--audit-command-preview",
+            "--audit-redact-env",
+            "GITHUB_TOKEN",
+            "--audit-redact-env",
+            "CUSTOM_SECRET",
+        ])
+        .unwrap();
+
+        assert_eq!(parsed.verbose, 2);
+        assert_eq!(parsed.audit_log.as_deref(), Some("/tmp/audit.jsonl"));
+        assert!(parsed.audit_command_preview);
+        assert_eq!(parsed.audit_redact_env, ["GITHUB_TOKEN", "CUSTOM_SECRET"]);
+    }
+
+    #[test]
+    fn cli_audit_settings_override_and_extend_file_settings() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.json");
+        let file_log = root.path().join("from-file.jsonl");
+        let cli_log = root.path().join("from-cli.jsonl");
+        std::fs::write(
+            &config_path,
+            serde_json::to_vec(&json!({
+                "codexMcp": { "enabled": false },
+                "audit": {
+                    "logFile": file_log,
+                    "includeCommandPreview": false,
+                    "commandPreviewMaxBytes": 1024,
+                    "redactEnv": ["FILE_SECRET"]
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let mut args = cli(root.path(), &config_path);
+        args.audit_log = Some(cli_log.to_string_lossy().into_owned());
+        args.audit_command_preview = true;
+        args.audit_redact_env = vec!["CLI_SECRET".to_string(), "FILE_SECRET".to_string()];
+
+        let config = load_config(args).unwrap();
+        assert_eq!(config.audit.log_file.as_deref(), Some(cli_log.as_path()));
+        assert!(config.audit.include_command_preview);
+        assert_eq!(config.audit.command_preview_max_bytes, 1024);
+        assert_eq!(config.audit.redact_env, ["CLI_SECRET", "FILE_SECRET"]);
+    }
+
+    #[test]
+    fn command_previews_require_an_audit_log() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{"codexMcp":{"enabled":false},"audit":{"includeCommandPreview":true}}"#,
+        )
+        .unwrap();
+
+        let error = load_config(cli(root.path(), &config_path)).unwrap_err();
+        assert!(error.contains("require audit.logFile"));
     }
 
     #[test]

--- a/src/exec_policy.rs
+++ b/src/exec_policy.rs
@@ -237,8 +237,8 @@ pub fn assert_exec_allowed(cmd: &str, config: &AppConfig) -> Result<(), ExecPoli
 mod tests {
     use super::*;
     use crate::types::{
-        CommandConfig, ExecConfig, IgnoreConfig, MemoryConfig, OutputConfig, ProjectDocConfig,
-        SkillsConfig, TreeConfig,
+        AuditConfig, CommandConfig, ExecConfig, IgnoreConfig, MemoryConfig, OutputConfig,
+        ProjectDocConfig, SkillsConfig, TreeConfig,
     };
 
     fn cfg(mode: ExecMode) -> AppConfig {
@@ -268,6 +268,7 @@ mod tests {
             memory: MemoryConfig::default(),
             skills: SkillsConfig::default(),
             ignore: IgnoreConfig::default(),
+            audit: AuditConfig::default(),
             allowed_hosts: vec![],
             openai_tunnel: None,
             mcp_servers: std::collections::HashMap::new(),

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -30,6 +30,8 @@ pub const STDIN_POLL_DEFAULT_YIELD_MS: u64 = 5_000;
 pub const STDIN_POLL_MAX_YIELD_MS: u64 = 300_000;
 pub const DEFAULT_MAX_OUTPUT_TOKENS: u64 = 10_000;
 
+static TRANSPORT_SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
+
 /// Codex's `approx_token_count` equivalent: roughly four characters per token.
 /// Counted in UTF-16 code units to match the TS `text.length`.
 pub fn approx_token_count(text: &str) -> u64 {
@@ -205,6 +207,11 @@ struct PendingBuffer {
     omitted: u64,
 }
 
+struct PendingOutput {
+    text: String,
+    truncated: bool,
+}
+
 impl PendingBuffer {
     fn new() -> Self {
         Self::default()
@@ -233,18 +240,24 @@ impl PendingBuffer {
 
     /// Reconstructs the retained output and resets the buffer, mirroring the
     /// old `std::mem::take` semantics of "hand back everything so far, clear".
-    fn take(&mut self) -> String {
+    fn take(&mut self) -> PendingOutput {
         let head = std::mem::take(&mut self.head);
         let tail = std::mem::take(&mut self.tail);
         let omitted = std::mem::replace(&mut self.omitted, 0);
         if omitted == 0 {
             let mut out = head;
             out.push_str(&tail);
-            out
+            PendingOutput {
+                text: out,
+                truncated: false,
+            }
         } else {
-            format!(
-                "{head}\n\n[... {omitted} bytes elided (session output buffer limit) ...]\n\n{tail}"
-            )
+            PendingOutput {
+                text: format!(
+                    "{head}\n\n[... {omitted} bytes elided (session output buffer limit) ...]\n\n{tail}"
+                ),
+                truncated: true,
+            }
         }
     }
 
@@ -289,7 +302,7 @@ impl ExecSession {
     }
 
     /// Take everything buffered so far, clearing the buffer.
-    fn take_pending(&self) -> String {
+    fn take_pending(&self) -> PendingOutput {
         self.pending.lock().unwrap().take()
     }
 
@@ -309,6 +322,11 @@ impl ExecSession {
     /// Wait until the process exits or `yield_ms` elapses, then hand back
     /// everything buffered so far and clear the buffer.
     pub async fn yield_output(&self, yield_ms: u64) -> (String, bool) {
+        let (output, exited, _) = self.yield_output_with_metadata(yield_ms).await;
+        (output, exited)
+    }
+
+    pub async fn yield_output_with_metadata(&self, yield_ms: u64) -> (String, bool, bool) {
         self.touch();
         let deadline = Instant::now() + Duration::from_millis(yield_ms);
         while Instant::now() < deadline && self.exit_code().is_none() {
@@ -324,7 +342,7 @@ impl ExecSession {
         }
 
         let output = self.take_pending();
-        (output, self.exit_code().is_some())
+        (output.text, self.exit_code().is_some(), output.truncated)
     }
 }
 
@@ -334,6 +352,7 @@ impl ExecSession {
 /// Project-root state here is the fallback for clients without a durable
 /// conversation identifier.
 pub struct SessionState {
+    audit_id: u64,
     pub exec_sessions: Arc<StdMutex<HashMap<u64, Arc<ExecSession>>>>,
     next_exec_id: AtomicU64,
     pub plan: StdMutex<Option<PlanState>>,
@@ -343,6 +362,7 @@ pub struct SessionState {
 impl Default for SessionState {
     fn default() -> Self {
         Self {
+            audit_id: TRANSPORT_SESSION_COUNTER.fetch_add(1, Ordering::Relaxed),
             exec_sessions: Arc::new(StdMutex::new(HashMap::new())),
             next_exec_id: AtomicU64::new(1),
             plan: StdMutex::new(None),
@@ -354,6 +374,10 @@ impl Default for SessionState {
 impl SessionState {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn audit_id(&self) -> u64 {
+        self.audit_id
     }
 
     /// Starts a background task that kills and reaps exec sessions idle beyond
@@ -719,7 +743,9 @@ mod tests {
         let mut buf = PendingBuffer::new();
         buf.push_str("hello ");
         buf.push_str("world");
-        assert_eq!(buf.take(), "hello world");
+        let output = buf.take();
+        assert_eq!(output.text, "hello world");
+        assert!(!output.truncated);
         assert!(buf.is_empty());
     }
 
@@ -730,9 +756,10 @@ mod tests {
         // and head+tail must equal the original stream in order.
         let text = "x".repeat(PENDING_HEAD_BYTES + 1024);
         buf.push_str(&text);
-        let out = buf.take();
-        assert_eq!(out, text);
-        assert!(!out.contains("elided"));
+        let output = buf.take();
+        assert_eq!(output.text, text);
+        assert!(!output.text.contains("elided"));
+        assert!(!output.truncated);
     }
 
     #[test]
@@ -746,10 +773,11 @@ mod tests {
         assert!(buf.head.len() <= PENDING_HEAD_BYTES);
         assert!(buf.tail.len() <= PENDING_TAIL_BYTES);
         assert!(buf.omitted > 0);
-        let out = buf.take();
-        assert!(out.contains("elided"));
-        assert!(out.starts_with("aaaa"));
-        assert!(out.ends_with("aaaa"));
+        let output = buf.take();
+        assert!(output.text.contains("elided"));
+        assert!(output.text.starts_with("aaaa"));
+        assert!(output.text.ends_with("aaaa"));
+        assert!(output.truncated);
         assert!(buf.is_empty());
     }
 
@@ -859,8 +887,9 @@ mod tests {
         assert!(buf.head.len() <= PENDING_HEAD_BYTES);
         assert!(buf.tail.len() <= PENDING_TAIL_BYTES);
         assert!(buf.omitted > 0);
-        let out = buf.take(); // must not panic on a char boundary
-        assert!(out.starts_with("xé"));
-        assert!(out.ends_with('é'));
+        let output = buf.take(); // must not panic on a char boundary
+        assert!(output.text.starts_with("xé"));
+        assert!(output.text.ends_with('é'));
+        assert!(output.truncated);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! original TypeScript.
 
 pub mod apply_patch;
+mod audit;
 pub mod auth;
 pub mod bridge;
 pub mod codex_mcp;
@@ -14,6 +15,7 @@ pub mod exec_policy;
 pub mod exec_sessions;
 pub mod ignore_rules;
 pub mod instructions;
+pub mod logging;
 pub mod memory;
 pub mod openai_tunnel;
 pub mod output_budget;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,28 @@
+use tracing_subscriber::EnvFilter;
+
+pub fn default_filter(verbosity: u8) -> &'static str {
+    match verbosity {
+        0 => "info",
+        1 => "codex_free=debug,rmcp=warn",
+        _ => "codex_free=trace,rmcp=warn",
+    }
+}
+
+pub fn init(verbosity: u8) {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(default_filter(verbosity)));
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verbosity_targets_codex_free_before_protocol_internals() {
+        assert_eq!(default_filter(0), "info");
+        assert_eq!(default_filter(1), "codex_free=debug,rmcp=warn");
+        assert_eq!(default_filter(2), "codex_free=trace,rmcp=warn");
+        assert_eq!(default_filter(u8::MAX), "codex_free=trace,rmcp=warn");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,13 @@
 use clap::Parser;
 
 use codex_free::config::{Cli, load_config};
+use codex_free::logging;
 use codex_free::server::start_http_server;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| "info".into()),
-        )
-        .init();
-
     let cli = Cli::parse();
+    logging::init(cli.verbose);
     let config = match load_config(cli) {
         Ok(c) => c,
         Err(e) => {

--- a/src/project_bindings.rs
+++ b/src/project_bindings.rs
@@ -59,6 +59,10 @@ impl ConversationIdentity {
     fn key(&self) -> &str {
         &self.key
     }
+
+    pub fn audit_hash(&self) -> &str {
+        &self.key[..24]
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,6 +7,7 @@
 //! that session ends. ChatGPT project selection is stored separately by its
 //! stable conversation metadata and survives transport replacement.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -27,6 +28,9 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{Any, CorsLayer};
 
+use crate::audit::{
+    AuditLogger, AuditScope, argument_field_names, summarize_arguments, summarize_output,
+};
 use crate::auth::{generate_internal_bearer_token, require_auth};
 use crate::exec_sessions::SessionState;
 use crate::instructions::build_initial_instructions;
@@ -62,7 +66,37 @@ pub struct CodexHandler {
     config: Arc<AppConfig>,
     tools: Arc<Vec<Box<dyn Tool>>>,
     project_bindings: Arc<ProjectBindingStore>,
+    audit: Option<Arc<AuditLogger>>,
     session: SessionState,
+}
+
+impl CodexHandler {
+    fn selected_project_root(
+        &self,
+        conversation: Option<&ConversationIdentity>,
+    ) -> Option<PathBuf> {
+        if !self.config.multi_project {
+            return Some(self.config.work_dir.clone());
+        }
+        match conversation {
+            Some(identity) => self
+                .project_bindings
+                .selected_project_root(&self.config, identity)
+                .ok()
+                .flatten(),
+            None => self.session.selected_project_root(),
+        }
+    }
+
+    fn audit_scope(&self, conversation: Option<&ConversationIdentity>) -> AuditScope {
+        let project_root = self.selected_project_root(conversation);
+        AuditScope::new(
+            self.session.audit_id(),
+            conversation,
+            &self.config.work_dir,
+            project_root.as_deref(),
+        )
+    }
 }
 
 /// Convert this repo's [`ToolResult`] into rmcp's `CallToolResult`.
@@ -126,26 +160,54 @@ impl ServerHandler for CodexHandler {
                 .as_ref()
                 .and_then(ConversationIdentity::from_request_meta)
         });
-        let name = request.name.as_ref();
+        let name = request.name.as_ref().to_string();
         let args = request.arguments.map(Value::Object).unwrap_or(Value::Null);
+        let tool = self.tools.iter().find(|tool| tool.name() == name);
+        let needs_scope = self.audit.is_some()
+            || tracing::enabled!(target: "codex_free::tool", tracing::Level::DEBUG);
+        let input_schema = needs_scope
+            .then(|| tool.map(|tool| tool.input_schema()))
+            .flatten();
+        let start_scope = needs_scope.then(|| self.audit_scope(conversation.as_ref()));
+        let audit_call = self.audit.as_ref().and_then(|audit| {
+            start_scope
+                .as_ref()
+                .map(|scope| audit.begin_tool(&name, &args, input_schema.as_ref(), scope))
+        });
+        if let Some(scope) = start_scope.as_ref() {
+            tracing::debug!(
+                target: "codex_free::tool",
+                tool = %name,
+                transport_session_id = scope.transport_session_id,
+                conversation_id = scope.conversation_id.as_deref().unwrap_or("-"),
+                project_id = scope.project_id.as_deref().unwrap_or("-"),
+                argument_fields = %argument_field_names(&args, input_schema.as_ref()),
+                "tool started"
+            );
+        }
+        if tracing::enabled!(target: "codex_free::tool", tracing::Level::TRACE) {
+            tracing::trace!(
+                target: "codex_free::tool",
+                tool = %name,
+                argument_summary = %summarize_arguments(&args, input_schema.as_ref()),
+                "tool arguments summarized"
+            );
+        }
 
-        let Some(tool) = self.tools.iter().find(|t| t.name() == name) else {
-            let result =
-                CallToolResult::error(vec![ContentBlock::text(format!("Unknown tool: {name}"))]);
-            return Ok(result.into());
-        };
-
-        let mut result = if name == SetProjectRoot::NAME {
-            if let Some(identity) = conversation.as_ref() {
-                select_and_render(&args, |path| {
-                    self.project_bindings
-                        .select_project_root(&self.config, identity, path)
-                })
-            } else {
-                tool.call(args, &self.config, &self.session).await
+        let started = Instant::now();
+        let mut result = match tool {
+            None => ToolResult::error(format!("Unknown tool: {name}")),
+            Some(tool) if name == SetProjectRoot::NAME => {
+                if let Some(identity) = conversation.as_ref() {
+                    select_and_render(&args, |path| {
+                        self.project_bindings
+                            .select_project_root(&self.config, identity, path)
+                    })
+                } else {
+                    tool.call(args, &self.config, &self.session).await
+                }
             }
-        } else {
-            let effective_config = if tool.requires_project_root() {
+            Some(tool) if tool.requires_project_root() => {
                 let resolved = match conversation.as_ref() {
                     Some(identity) => self
                         .project_bindings
@@ -153,20 +215,11 @@ impl ServerHandler for CodexHandler {
                     None => self.session.effective_config(&self.config),
                 };
                 match resolved {
-                    Ok(config) => Some(config),
-                    Err(error) => {
-                        let result = ToolResult::error(error);
-                        tracing::info!("  tool: {name} -> error");
-                        return Ok(to_call_tool_result(result).into());
-                    }
+                    Ok(effective_config) => tool.call(args, &effective_config, &self.session).await,
+                    Err(error) => ToolResult::error(error),
                 }
-            } else {
-                None
-            };
-            let call_config = effective_config
-                .as_ref()
-                .unwrap_or_else(|| self.config.as_ref());
-            tool.call(args, call_config, &self.session).await
+            }
+            Some(tool) => tool.call(args, &self.config, &self.session).await,
         };
 
         // Fill in the `structuredContent` the MCP spec expects from any tool that
@@ -174,7 +227,8 @@ impl ServerHandler for CodexHandler {
         // schema, for which the text they return *is* the structured form; tools
         // with a different schema build their own and pass through. Errors are
         // left alone — the spec exempts `isError` results.
-        if tool.output_schema().is_some()
+        if let Some(tool) = tool
+            && tool.output_schema().is_some()
             && tool.fills_structured_content()
             && !result.is_error
             && result.structured_content.is_none()
@@ -182,10 +236,32 @@ impl ServerHandler for CodexHandler {
             result.structured_content = Some(json!({ "content": result.joined_text() }));
         }
 
+        let duration_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
         tracing::info!(
-            "  tool: {name} -> {}",
-            if result.is_error { "error" } else { "ok" }
+            target: "codex_free::tool",
+            tool = %name,
+            status = if result.is_error { "error" } else { "ok" },
+            duration_ms,
+            "tool completed"
         );
+        if tracing::enabled!(target: "codex_free::tool", tracing::Level::DEBUG) {
+            tracing::debug!(
+                target: "codex_free::tool",
+                tool = %name,
+                output_summary = %summarize_output(&result),
+                "tool output summarized"
+            );
+        }
+        if let (Some(audit), Some(call), Some(start_scope)) =
+            (&self.audit, audit_call.as_ref(), start_scope.as_ref())
+        {
+            if name == SetProjectRoot::NAME {
+                let finish_scope = self.audit_scope(conversation.as_ref());
+                audit.finish_tool(call, &name, &result, duration_ms, &finish_scope);
+            } else {
+                audit.finish_tool(call, &name, &result, duration_ms, start_scope);
+            }
+        }
         Ok(to_call_tool_result(result).into())
     }
 }
@@ -203,6 +279,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
         }
         config.api_key = Some(generate_internal_bearer_token()?);
     }
+    let audit = AuditLogger::open(&config)?.map(Arc::new);
     // Gateway-mode upstreams write their generated skills here; keyed by port so
     // concurrent instances don't clobber each other, and rebuilt fresh per start.
     let gen_dir = std::env::temp_dir()
@@ -259,6 +336,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     let factory_config = config.clone();
     let factory_tools = tools.clone();
     let factory_project_bindings = project_bindings.clone();
+    let factory_audit = audit.clone();
     let service = StreamableHttpService::new(
         move || {
             let session = SessionState::new();
@@ -267,6 +345,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
                 config: factory_config.clone(),
                 tools: factory_tools.clone(),
                 project_bindings: factory_project_bindings.clone(),
+                audit: factory_audit.clone(),
                 session,
             })
         },
@@ -336,6 +415,17 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
         println!("Auth: enabled (bearer token)");
     } else {
         println!("Auth: disabled (no --api-key)");
+    }
+    if let Some(audit) = audit.as_ref() {
+        println!("Audit log: {}", audit.path().display());
+        println!(
+            "Audit command previews: {}",
+            if audit.command_previews_enabled() {
+                "enabled (bounded and redacted)"
+            } else {
+                "disabled"
+            }
+        );
     }
     if !native_tunnel {
         println!("\nAdd to ChatGPT > Plugins > New Plugin:");

--- a/src/tools/exec_command.rs
+++ b/src/tools/exec_command.rs
@@ -9,7 +9,7 @@ use crate::exec_sessions::{
 };
 use crate::safe_path::resolve_safe_path;
 use crate::tool::{Tool, arg_str, arg_u64};
-use crate::types::{AppConfig, ExecMode, ToolResult};
+use crate::types::{AppConfig, ExecMode, ToolAuditMetadata, ToolResult};
 
 /// The output schema shared by `exec_command` and `write_stdin`.
 pub fn unified_exec_output_schema() -> Value {
@@ -158,7 +158,8 @@ impl Tool for ExecCommand {
                 }
             };
 
-        let (output, exited) = exec_session.yield_output(yield_ms).await;
+        let (output, exited, buffer_truncated) =
+            exec_session.yield_output_with_metadata(yield_ms).await;
         let (text, original_token_count) = truncate_output(&output, max_output_tokens);
 
         let mut result = UnifiedExecOutput {
@@ -190,6 +191,41 @@ impl Tool for ExecCommand {
             ))],
             is_error,
             structured_content: Some(structured),
+            audit: ToolAuditMetadata {
+                truncated: Some(buffer_truncated || original_token_count.is_some()),
+                original_output_tokens: original_token_count,
+                exec_session_id: Some(exec_session.id),
+                process_id: exec_session.pid,
+                resident: Some(!exited),
+            },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::default_config;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn completed_command_reports_process_audit_metadata() {
+        let root = tempfile::tempdir().unwrap();
+        let config = default_config(root.path().to_path_buf());
+        let session = SessionState::new();
+
+        let result = ExecCommand
+            .call(
+                json!({ "cmd": "echo audit", "yield_time_ms": 1000 }),
+                &config,
+                &session,
+            )
+            .await;
+
+        assert!(!result.is_error, "{}", result.joined_text());
+        assert_eq!(result.audit.truncated, Some(false));
+        assert_eq!(result.audit.resident, Some(false));
+        assert!(result.audit.exec_session_id.is_some());
+        assert!(result.audit.process_id.is_some());
     }
 }

--- a/src/tools/get_project_doc.rs
+++ b/src/tools/get_project_doc.rs
@@ -95,7 +95,12 @@ impl Tool for GetProjectDoc {
         };
         let content = doc.as_ref().map(|d| d.text.clone()).unwrap_or_default();
         let text = render_project_doc(doc.as_ref());
+        let truncated = doc
+            .as_ref()
+            .is_some_and(|document| document.entries.iter().any(|entry| entry.truncated));
 
-        ToolResult::text(text).with_structured(json!({ "files": files, "content": content }))
+        ToolResult::text(text)
+            .with_structured(json!({ "files": files, "content": content }))
+            .with_truncation(truncated)
     }
 }

--- a/src/tools/glob.rs
+++ b/src/tools/glob.rs
@@ -149,6 +149,6 @@ impl Tool for Glob {
         } else {
             items.join("\n")
         };
-        ToolResult::text(text)
+        ToolResult::text(text).with_truncation(dropped > 0)
     }
 }

--- a/src/tools/grep.rs
+++ b/src/tools/grep.rs
@@ -216,6 +216,6 @@ impl Tool for Grep {
         if truncated {
             output.push_str(&format!("\n\n(truncated at {max_results} matches)"));
         }
-        ToolResult::text(output)
+        ToolResult::text(output).with_truncation(truncated)
     }
 }

--- a/src/tools/list_directory.rs
+++ b/src/tools/list_directory.rs
@@ -110,7 +110,7 @@ impl Tool for ListDirectory {
         } else {
             lines.join("\n")
         };
-        ToolResult::text(text)
+        ToolResult::text(text).with_truncation(dropped > 0)
     }
 }
 

--- a/src/tools/read_file.rs
+++ b/src/tools/read_file.rs
@@ -72,6 +72,7 @@ impl Tool for ReadFile {
             .unwrap_or(0);
         let limit = arg_f64(&args, "limit").map(|f| if f <= 0.0 { 0 } else { f.trunc() as usize });
         let window = window_file_lines(&lines, offset, limit, file_budget(config));
+        let truncated = window.notice.is_some();
 
         let numbered = window
             .lines
@@ -85,6 +86,6 @@ impl Tool for ReadFile {
             Some(notice) => format!("{numbered}\n\n{notice}"),
             None => numbered,
         };
-        ToolResult::text(body)
+        ToolResult::text(body).with_truncation(truncated)
     }
 }

--- a/src/tools/run_command.rs
+++ b/src/tools/run_command.rs
@@ -120,6 +120,7 @@ impl Tool for RunCommand {
             content: vec![crate::types::ToolContent::Text(out)],
             is_error: exit_code != 0,
             structured_content: None,
+            audit: Default::default(),
         }
     }
 }

--- a/src/tools/skills_read.rs
+++ b/src/tools/skills_read.rs
@@ -100,6 +100,7 @@ impl Tool for SkillsRead {
         let offset = arg_u64(&args, "offset").unwrap_or(0) as usize;
         let limit = arg_u64(&args, "limit").map(|n| n as usize);
         let window = window_file_lines(&lines, offset, limit, file_budget(config));
+        let truncated = window.notice.is_some();
 
         let mut parts: Vec<String> = vec![
             format!("{} — {}", skill.name, path.display()),
@@ -124,6 +125,6 @@ impl Tool for SkillsRead {
             }
         }
 
-        ToolResult::text(parts.join("\n"))
+        ToolResult::text(parts.join("\n")).with_truncation(truncated)
     }
 }

--- a/src/tools/tree.rs
+++ b/src/tools/tree.rs
@@ -70,7 +70,7 @@ impl Tool for Tree {
         } else {
             state.lines.join("\n")
         };
-        ToolResult::text(text)
+        ToolResult::text(text).with_truncation(state.stopped)
     }
 }
 

--- a/src/tools/write_stdin.rs
+++ b/src/tools/write_stdin.rs
@@ -8,7 +8,7 @@ use crate::exec_sessions::{
 };
 use crate::tool::{Tool, arg_str, arg_u64};
 use crate::tools::exec_command::{render_unified_exec_output, unified_exec_output_schema};
-use crate::types::{AppConfig, ToolContent, ToolResult};
+use crate::types::{AppConfig, ToolAuditMetadata, ToolContent, ToolResult};
 
 pub struct WriteStdin;
 
@@ -98,7 +98,8 @@ impl Tool for WriteStdin {
             }
         }
 
-        let (output, exited) = exec_session.yield_output(yield_ms).await;
+        let (output, exited, buffer_truncated) =
+            exec_session.yield_output_with_metadata(yield_ms).await;
         let (text, original_token_count) = truncate_output(&output, max_output_tokens);
 
         let mut result = UnifiedExecOutput {
@@ -124,6 +125,13 @@ impl Tool for WriteStdin {
             content: vec![ToolContent::Text(render_unified_exec_output(&result))],
             is_error,
             structured_content: Some(structured),
+            audit: ToolAuditMetadata {
+                truncated: Some(buffer_truncated || original_token_count.is_some()),
+                original_output_tokens: original_token_count,
+                exec_session_id: Some(session_id),
+                process_id: exec_session.pid,
+                resident: Some(!exited),
+            },
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,6 +17,16 @@ pub enum ToolContent {
     Image { data: String, mime_type: String },
 }
 
+/// Metadata retained for operational accounting without retaining tool output.
+#[derive(Debug, Clone, Default)]
+pub struct ToolAuditMetadata {
+    pub truncated: Option<bool>,
+    pub original_output_tokens: Option<u64>,
+    pub exec_session_id: Option<u64>,
+    pub process_id: Option<u32>,
+    pub resident: Option<bool>,
+}
+
 /// What a tool hands back. Mirrors the repo's `ToolResult`: a list of content
 /// blocks, an error flag, and an optional machine-readable form that matches the
 /// tool's `outputSchema`.
@@ -25,6 +35,7 @@ pub struct ToolResult {
     pub content: Vec<ToolContent>,
     pub is_error: bool,
     pub structured_content: Option<Value>,
+    pub audit: ToolAuditMetadata,
 }
 
 impl ToolResult {
@@ -34,6 +45,7 @@ impl ToolResult {
             content: vec![ToolContent::Text(text.into())],
             is_error: false,
             structured_content: None,
+            audit: ToolAuditMetadata::default(),
         }
     }
 
@@ -43,6 +55,7 @@ impl ToolResult {
             content: vec![ToolContent::Text(text.into())],
             is_error: true,
             structured_content: None,
+            audit: ToolAuditMetadata::default(),
         }
     }
 
@@ -55,12 +68,18 @@ impl ToolResult {
             }],
             is_error: false,
             structured_content: None,
+            audit: ToolAuditMetadata::default(),
         }
     }
 
     /// Attach the machine-readable form matching the tool's output schema.
     pub fn with_structured(mut self, value: Value) -> Self {
         self.structured_content = Some(value);
+        self
+    }
+
+    pub fn with_truncation(mut self, truncated: bool) -> Self {
+        self.audit.truncated = Some(truncated);
         self
     }
 
@@ -291,6 +310,25 @@ pub struct OpenAiTunnelConfig {
     pub client_path: Option<std::path::PathBuf>,
 }
 
+#[derive(Debug, Clone)]
+pub struct AuditConfig {
+    pub log_file: Option<std::path::PathBuf>,
+    pub include_command_preview: bool,
+    pub command_preview_max_bytes: usize,
+    pub redact_env: Vec<String>,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            log_file: None,
+            include_command_preview: false,
+            command_preview_max_bytes: 512,
+            redact_env: Vec::new(),
+        }
+    }
+}
+
 /// The fully-resolved server configuration handed to every tool.
 ///
 /// `work_dir` and `port` are always concrete. `projectDoc`, `output`, `memory`,
@@ -311,6 +349,7 @@ pub struct AppConfig {
     pub memory: MemoryConfig,
     pub skills: SkillsConfig,
     pub ignore: IgnoreConfig,
+    pub audit: AuditConfig,
     /// Host authorities accepted for DNS-rebinding protection. Empty means
     /// "accept any Host", which the original bridge did so it works behind a
     /// tunnel that presents an arbitrary hostname.

--- a/tests/fs_and_walk.rs
+++ b/tests/fs_and_walk.rs
@@ -25,7 +25,7 @@ use codex_free::tools::list_directory::ListDirectory;
 use codex_free::tools::read_file::ReadFile;
 use codex_free::tools::tree::Tree;
 use codex_free::tools::write_file::WriteFile;
-use codex_free::types::AppConfig;
+use codex_free::types::{AppConfig, ToolResult};
 
 // --- helpers -----------------------------------------------------------
 
@@ -46,9 +46,13 @@ fn ignore_config(root: &Path) -> AppConfig {
     config
 }
 
-async fn run_text(tool: &dyn Tool, args: serde_json::Value, config: &AppConfig) -> String {
+async fn run_result(tool: &dyn Tool, args: serde_json::Value, config: &AppConfig) -> ToolResult {
     let session = SessionState::new();
-    tool.call(args, config, &session).await.joined_text()
+    tool.call(args, config, &session).await
+}
+
+async fn run_text(tool: &dyn Tool, args: serde_json::Value, config: &AppConfig) -> String {
+    run_result(tool, args, config).await.joined_text()
 }
 
 // --- toRelPosix --------------------------------------------------------
@@ -513,7 +517,9 @@ async fn caps_read_file_stops_at_line_budget_and_names_offset() {
     let mut config = default_config(dir.path().to_path_buf());
     config.output.max_file_lines = Some(10);
 
-    let out = run_text(&ReadFile, json!({ "path": "big.txt" }), &config).await;
+    let result = run_result(&ReadFile, json!({ "path": "big.txt" }), &config).await;
+    let out = result.joined_text();
+    assert_eq!(result.audit.truncated, Some(true));
     assert!(out.contains("10\tline10"), "{out}");
     assert!(!out.contains("11\tline11"), "{out}");
     assert!(
@@ -549,7 +555,9 @@ async fn caps_read_file_small_file_comes_back_whole_no_notice() {
     write(dir.path(), "small.txt", "a\nb");
     let config = default_config(dir.path().to_path_buf());
 
-    let out = run_text(&ReadFile, json!({ "path": "small.txt" }), &config).await;
+    let result = run_result(&ReadFile, json!({ "path": "small.txt" }), &config).await;
+    let out = result.joined_text();
+    assert_eq!(result.audit.truncated, Some(false));
     assert_eq!(out, "1\ta\n2\tb");
 }
 
@@ -574,7 +582,9 @@ async fn caps_glob_cuts_match_list_and_says_how_to_narrow() {
     let mut config = default_config(dir.path().to_path_buf());
     config.output.max_entries = Some(5);
 
-    let out = run_text(&Glob, json!({ "pattern": "*.ts" }), &config).await;
+    let result = run_result(&Glob, json!({ "pattern": "*.ts" }), &config).await;
+    let out = result.joined_text();
+    assert_eq!(result.audit.truncated, Some(true));
     let ts_lines = out.lines().filter(|l| l.ends_with(".ts")).count();
     assert_eq!(ts_lines, 5, "{out}");
     assert!(out.contains("(showing 5 of 20 matches"), "{out}");
@@ -600,7 +610,9 @@ async fn caps_list_directory_cuts_entry_list_and_points_at_glob() {
     let mut config = default_config(dir.path().to_path_buf());
     config.output.max_entries = Some(5);
 
-    let out = run_text(&ListDirectory, json!({}), &config).await;
+    let result = run_result(&ListDirectory, json!({}), &config).await;
+    let out = result.joined_text();
+    assert_eq!(result.audit.truncated, Some(true));
     assert!(out.contains("(showing 5 of 20 entries"), "{out}");
     assert!(out.contains("use glob"), "{out}");
 }
@@ -625,7 +637,9 @@ async fn caps_tree_stops_at_node_budget_and_says_how_to_get_less() {
     let mut config = default_config(dir.path().to_path_buf());
     config.output.max_tree_nodes = Some(6);
 
-    let out = run_text(&Tree, json!({}), &config).await;
+    let result = run_result(&Tree, json!({}), &config).await;
+    let out = result.joined_text();
+    assert_eq!(result.audit.truncated, Some(true));
     assert!(out.contains("(stopped at 6 nodes"), "{out}");
     assert!(out.contains("lower \"depth\""), "{out}");
 }

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -185,6 +185,7 @@ impl Tool for FakeTool {
             content: vec![],
             is_error: false,
             structured_content: None,
+            audit: Default::default(),
         }
     }
 }
@@ -207,6 +208,7 @@ fn derives_content_from_text_blocks() {
         content: vec![ToolContent::Text("hello".into())],
         is_error: false,
         structured_content: None,
+        audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
     assert_eq!(
@@ -229,6 +231,7 @@ fn joins_multiple_text_blocks_and_skips_non_text() {
         ],
         is_error: false,
         structured_content: None,
+        audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
     assert_eq!(
@@ -244,6 +247,7 @@ fn leaves_tools_own_structured_content_alone() {
         content: vec![ToolContent::Text("{}".into())],
         is_error: false,
         structured_content: Some(json!({ "current_time": "2026-01-01 00:00:00 UTC" })),
+        audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
     assert_eq!(
@@ -259,6 +263,7 @@ fn adds_nothing_when_tool_declares_no_output_schema() {
         content: vec![ToolContent::Text("hello".into())],
         is_error: false,
         structured_content: None,
+        audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
     assert_eq!(filled.structured_content, None);
@@ -271,6 +276,7 @@ fn adds_nothing_to_an_error_result() {
         content: vec![ToolContent::Text("boom".into())],
         is_error: true,
         structured_content: None,
+        audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
     assert_eq!(filled.structured_content, None);
@@ -283,6 +289,7 @@ fn does_not_mutate_the_result_it_was_given() {
         content: vec![ToolContent::Text("hello".into())],
         is_error: false,
         structured_content: None,
+        audit: Default::default(),
     };
     let _ = apply_default_structured(&tool, &result);
     assert_eq!(result.structured_content, None);


### PR DESCRIPTION
## Summary

Add first-class verbose diagnostics and a security-conscious audit log for tool activity.

This introduces:

- `-v` / `--verbose` (`--log-tool-calls` alias) for Codex Free debug diagnostics
- `-vv` for trace-level Codex Free diagnostics while keeping `rmcp` at `warn`
- `--audit <FILE>` (`--audit-log` alias) for structured JSONL activity records
- `--audit-command-preview` for separately opted-in, bounded command previews
- `--audit-redact-env <NAME>` for additional environment-value redaction
- an equivalent `audit` configuration block in `codex.config.json`

`RUST_LOG` remains authoritative when explicitly set.

## Design

Verbose tracing and auditing are deliberately separate:

- normal `info` logging reports tool completion, status, and duration
- `-v` adds tool-start events, process-local transport IDs, hashed conversation/project context, schema-declared argument field names, and output accounting
- `-vv` adds a fully redacted argument-shape summary without raising `rmcp` above warnings
- audit mode writes a machine-readable JSONL stream independently of the console tracing filter

The audit stream starts with `audit_started`, then emits paired `tool_start` and `tool_finish` records. Records include:

- RFC 3339 timestamps and schema version
- server version, OS PID, random run ID, monotonic call ID, and transport-session ID
- hashed conversation, access-root, and selected-project identifiers
- tool name, status, and duration
- schema-bounded argument shape
- returned text/image/structured byte counts and approximate text-token count
- truncation status
- `exec_command` / `write_stdin` process ID, exec-session ID, and resident status

Bounded filesystem tools report their real truncation state. Exec tools also distinguish token-budget truncation from output lost at the resident-session buffer ceiling while preserving the existing `yield_output` API.

## Privacy and file safety

Audit mode does not write raw conversation IDs, project paths, scalar argument values, source/patch contents, image data, structured output, or returned text.

Argument summaries only name fields declared by the tool input schema. Unknown keys and dynamic-map keys are counted but omitted, preventing attacker-controlled object keys from becoming a logging side channel.

Command previews are disabled by default and are available only for `exec_command` and `run_command`. When enabled, they are UTF-8 byte bounded and redact:

- the local MCP bearer token
- configured MCP-server environment values
- the referenced OpenAI tunnel key when readable
- explicitly configured environment variables
- common secret-bearing process environment variables
- common secret flags, assignments, JSON-style keys, Basic authorization, and bearer-token forms

On Unix, new audit files are opened with mode `0600`, final-component symlinks are rejected with `O_NOFOLLOW`, and existing files with group/other permission bits are rejected. Runtime append failures are logged without changing a tool result after side effects may already have occurred.

The documentation explicitly treats this as an operational trace rather than a tamper-evident security boundary and recommends storing it outside the project access root or forwarding it to a separately protected collector.

## Compatibility

- auditing remains disabled unless a log file is configured
- the normal default tracing level remains `info`
- explicit `RUST_LOG` behavior is preserved
- no raw payload logging is introduced
- no MCP tool output schema changes are required; operational metadata remains internal to dispatch
- the existing `ExecSession::yield_output` API remains available

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test` — 405 tests passed
- `codex.config.json` parsed as JSON
- `cargo run --quiet -- --help` verified the new CLI surface and aliases
