### PR TITLE
feat: add conversation-scoped connector authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Optional per-conversation connector authorization through
+  `conversationAuthToken`. Quickstart can generate and persist a high-entropy
+  token, protect the config on Unix, and print a one-line instruction for an
+  individual chat or ChatGPT Project instructions. The conditional `authenticate`
+  tool verifies the token once, then restores the grant from stable ChatGPT
+  conversation metadata across connector reconnects and server restarts; generic
+  MCP clients use transport-session authorization.
+
+### Security
+
+- Conversation authorization blocks every non-authentication tool and withholds
+  the project-aware initialization brief until verification. Durable markers store
+  only a hashed conversation identity and grant, in a namespace derived from the
+  canonical work directory and current token, so token rotation invalidates older
+  grants without copying the token into the cache. Audit command previews also
+  redact the configured conversation token. The token remains plaintext in
+  `codex.config.json` by design and must be kept private and out of version control.
+
 ## [1.4.0] - 2026-08-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -115,8 +115,11 @@ cargo run --release -- quickstart
 The wizard asks which project directory ChatGPT may access and whether that
 directory is one project or a multi-project access root. It then walks through
 creating an OpenAI Secure MCP Tunnel, entering the tunnel ID and runtime API key,
-and creating the matching ChatGPT developer-mode connector. The relevant OpenAI
-and ChatGPT links are printed together with the exact connection values to use.
+and creating the matching ChatGPT developer-mode connector. It can also generate
+an optional per-conversation authorization token and prints the exact one-line
+instruction to paste into a chat or into a ChatGPT Project's Project instructions.
+The relevant OpenAI and ChatGPT links are printed together with the exact
+connection values to use.
 
 The runtime key is entered without terminal echo and stored in a dedicated
 per-tunnel file under `~/.codex-free/openai-tunnel/credentials/`. On Unix, the
@@ -125,6 +128,12 @@ wizard restricts the credential directory and file to the current user.
 settings are preserved. At the end, the wizard can start Codex Free immediately
 so ChatGPT can scan the live connector. Keep that process running while using the
 connector.
+
+The optional conversation token is deliberately different from the tunnel runtime
+key: it is stored directly as `conversationAuthToken` in the JSON config so the
+server can verify chat-supplied values. When enabled, quickstart restricts the
+config file to the current user on Unix. Keep that config out of version control
+and do not share it.
 
 Use `codex-free quickstart --config /path/to/codex.config.json` to update a
 different config file, or `--work-dir /path/to/project` to change the directory
@@ -171,6 +180,42 @@ cargo run --release -- --work-dir /path/to/projects --multi-project
 ```
 
 Here `--work-dir` is an **access root**, not the active project. In ChatGPT, call `set_project_root` directly when the exact relative path is known; otherwise `list_projects` can search the read-only project catalogue by name, alias, description, or relative selector first. Codex Free keys the resulting binding from ChatGPT's `_meta["openai/session"]` conversation identifier and persists it outside the repository, so later turns in the same chat recover the project after an MCP reconnect or codex-free restart. A new chat gets a new binding and an existing chat cannot switch projects. Clients that do not provide `openai/session` fall back to a one-time MCP transport-session binding and must select again after reconnecting.
+
+### Optional per-conversation authorization
+
+Set a high-entropy token in the config, or let `quickstart` generate one:
+
+```json
+{
+  "conversationAuthToken": "codex_free_chat_REPLACE_WITH_A_RANDOM_TOKEN"
+}
+```
+
+When this key is present, Codex Free exposes an `authenticate` tool and rejects
+every other tool call until the current chat supplies the exact token once. The
+project-aware initialization brief is withheld until then; after authentication,
+the tool response directs the client to load it with `get_agent_brief`.
+
+For ChatGPT, the grant is keyed by the hash of `_meta["openai/session"]` and
+persisted under `~/.codex-free/conversation-authorizations/`, so it survives MCP
+transport replacement and Codex Free restarts. The authorization marker contains
+no token or raw conversation identifier. Its namespace is derived from the
+canonical work directory and current token, so rotating `conversationAuthToken`
+invalidates grants made with the previous token. MCP clients without stable
+conversation metadata fall back to authorization for the current transport only.
+
+Use this one-line instruction, replacing `[TOKEN]` with the configured value:
+
+```text
+To use this connector in a chat, call its `authenticate` tool once with token `[TOKEN]`.
+```
+
+Paste it into an individual chat, or add it to the ChatGPT Project's
+[Project instructions](https://help.openai.com/en/articles/10169521-projects-in-chatgpt)
+so chats created in that project can authenticate automatically. The token is an
+application-level gate for model conversations, not a replacement for tunnel,
+HTTP, workspace, or operating-system access controls. It is plaintext in the
+config by design; anyone who can read that file can authorize another chat.
 
 To build a standalone binary:
 
@@ -246,6 +291,13 @@ Structured primitives — cheaper and safer than shelling out for the same job, 
 | `list_directory` | List files and directories with name, type, and size |
 | `tree` | Print directory tree as ASCII art |
 
+When `conversationAuthToken` is configured, one gate tool is added ahead of the
+protected tools:
+
+| Tool | Description |
+|------|-------------|
+| `authenticate` | Verify the configured token once and cache only the authorization decision for the stable ChatGPT conversation, or for the current transport when conversation metadata is unavailable |
+
 Ported from Codex's own agent tools:
 
 | Tool | Codex name | Description |
@@ -281,7 +333,7 @@ Multi-project mode adds two project-control tools:
 
 Codex needs the first three for none of these reasons: it puts its agent brief in the system prompt, the OS and shell in an `<environment_context>` message, and `AGENTS.md` straight into the prompt, all before the first turn. An MCP server has none of those channels — it can only expose tools — so the same facts are tool calls here as well as part of the server's `instructions`. It needs `remember` and `recall` for the opposite reason: its context is large and its session state lives in the CLI process, whereas the client here is a chat window that loses the conversation. See [Context and memory](#context-and-memory), [Acting as a Codex agent](#acting-as-a-codex-agent), [Shells and the host](#shells-and-the-host), [AGENTS.md](#agentsmd) and [Skills](#skills).
 
-That is 27 native tools in the default single-project mode and 29 in multi-project mode. Setting `artifactIngress.enabled` to `false` removes `import_host_file`, reducing those counts by one. When [MCP bridging](#bridging-other-mcp-servers) is configured, the tools of your other MCP servers are re-exposed here too, on top of these.
+That is 27 native tools in the default single-project mode and 29 in multi-project mode. Enabling conversation authorization adds `authenticate`, producing 28 or 30 respectively. Setting `artifactIngress.enabled` to `false` removes `import_host_file`, reducing the applicable count by one. When [MCP bridging](#bridging-other-mcp-servers) is configured, the tools of your other MCP servers are re-exposed here too, on top of these.
 
 Two deliberate differences from Codex:
 
@@ -309,6 +361,7 @@ All project-scoped paths are resolved relative to the active project root: `--wo
 ```json
 {
   "multiProject": false,
+  "conversationAuthToken": null,
   "worktrees": {
     "mode": "auto",
     "root": "/path/to/worktrees",
@@ -400,6 +453,14 @@ All project-scoped paths are resolved relative to the active project root: `--wo
 
 CLI flags override values from the config file.
 
+`conversationAuthToken` has no CLI override. A non-null value must contain 32 to
+256 ASCII bytes using only letters, digits, `_`, and `-`. `quickstart` generates a
+256-bit URL-safe token with the `codex_free_chat_` prefix and writes the copyable
+ChatGPT instruction shown above. Because the token is intentionally stored in
+this file, use a config path outside the repository or add it to the repository's
+ignore rules. On Unix, quickstart changes the config mode to `0600` when this
+feature is enabled; manually created configs should be protected equivalently.
+
 ## Diagnostics and audit logging
 
 The default tracing level remains `info`. `-v` changes the default filter to `codex_free=debug,rmcp=warn`, which adds tool-start events, hashed conversation/project context, argument field names, duration, and output accounting without dumping protocol traffic. `-vv` changes Codex Free to `trace` while keeping `rmcp` at `warn`, and adds the fully redacted argument-shape summary. An explicit `RUST_LOG` value takes precedence over `-v`/`-vv` when protocol-level diagnostics are required:
@@ -429,7 +490,7 @@ codex-free \
   --audit-redact-env GITHUB_TOKEN
 ```
 
-Before a preview is written, Codex Free replaces the local MCP bearer, configured MCP-server environment values, the referenced OpenAI tunnel key when readable, values named by `audit.redactEnv` / `--audit-redact-env`, common secret-bearing process environment variables, and common `--token`, `API_KEY=…`, and `Bearer …` forms. The preview is then capped at `commandPreviewMaxBytes`. This is defense in depth, not a proof that an arbitrary command contains no sensitive literal; leave previews disabled when command text itself is sensitive.
+Before a preview is written, Codex Free replaces the local MCP bearer, the configured conversation-authentication token, configured MCP-server environment values, the referenced OpenAI tunnel key when readable, values named by `audit.redactEnv` / `--audit-redact-env`, common secret-bearing process environment variables, and common `--token`, `API_KEY=…`, and `Bearer …` forms. The preview is then capped at `commandPreviewMaxBytes`. This is defense in depth, not a proof that an arbitrary command contains no sensitive literal; leave previews disabled when command text itself is sensitive.
 
 The `audit` config block has the same controls:
 
@@ -1001,7 +1062,7 @@ When `remote-exec` was imported from Codex, that overlay is sufficient; include 
 3. In ChatGPT's connector/plugin settings, create a developer-mode connector with **Connection type: Tunnel**.
 4. Select the same tunnel ID that Codex Free reports as ready. Set **Authentication** to **None**.
 5. Set the connector's permissions to **Allow all actions** if you do not want per-call confirmations.
-6. Enable the connector in a new chat, then open with `Call get_agent_brief and follow it for the rest of this chat.` — see [Acting as a Codex agent](#acting-as-a-codex-agent). In multi-project mode (`--multi-project`), call `set_project_root` first when the path is known or `list_projects` first when it is not; later follow-ups in that same chat can call `get_agent_brief` directly, since the project binding is restored from ChatGPT's conversation metadata.
+6. Enable the connector in a new chat. Without conversation authorization, open with `Call get_agent_brief and follow it for the rest of this chat.` With `conversationAuthToken`, first supply the one-line `authenticate` instruction printed by quickstart; after it succeeds, follow its project-selection or `get_agent_brief` direction. See [Acting as a Codex agent](#acting-as-a-codex-agent). In multi-project mode (`--multi-project`), call `set_project_root` first when the path is known or `list_projects` first when it is not; later follow-ups in that same chat recover both authorization and the project binding from ChatGPT's conversation metadata.
 
 There is no server URL to enter in this mode. OpenAI routes the selected tunnel to the supervised client, which supplies Codex Free's generated per-process bearer on the local hop. The startup banner prints the runtime-only `/readyz` and `/metrics` URLs. It does not advertise an admin UI because `tunnel-client-runtime` deliberately omits that full-client surface.
 
@@ -1026,13 +1087,14 @@ Native tunnel mode ignores `allowedHosts` and forces the accepted authorities to
 - **Host-authorized native-file ingress**: `import_host_file` accepts only ChatGPT's declared native-file object, rejects local source paths, constrains the download URL and every redirect hop to the configurable `artifactIngress.allowedHosts` allowlist (default `"*"`, which admits any public HTTPS host but never a loopback, private, link-local, unique-local, CGNAT, `localhost`, or metadata address), ignores ambient proxy credentials, and enforces whole-request, idle, size and concurrency limits. Its signed URL and file ID are never logged or returned: RMCP debug/trace payload logging is unconditionally suppressed even when `RUST_LOG` requests it. Destination publication uses a capability-confined directory handle, canonical-path and file-identity revalidation, a private partial file, SHA-256, and atomic no-overwrite linking so traversal, moved roots, symlink escapes, partial visibility and replacement races fail closed.
 - **One bounded exception in single-project mode**: [AGENTS.md](#agentsmd) discovery may read above `--work-dir`, up to the nearest `.git`. It is read-only, opens only `AGENTS.override.md`, `AGENTS.md` and any `projectDoc.fallbackFilenames`, and `get_project_doc` reports the absolute path of every file it used. Set `projectDoc.maxBytes` to `0` to switch it off, or `projectDoc.rootMarkers` to `[]` to keep the search inside the work directory. Multi-project mode does not perform this upward walk; its selected directory is the exact project root.
 - **Namespaced review state inside Git**: ChatGPT review checkpoints are exactly two refs per conversation/project pair under `refs/codex-free/review/`. Synthetic snapshots contain only the selected project path, are built through a temporary index, and never modify the real index or working tree. Generic MCP-client checkpoints are in memory only. The namespace grows with the number of distinct persistent conversation/project pairs; the review section documents inspection and manual removal.
-- **Bounded state writes outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/projects/`. Multi-project mode also writes one small project-binding record under `~/.codex-free/conversation-projects/` for each ChatGPT conversation and access root. Both use atomic replacement and per-record locks. The binding filename is derived from a hash of `openai/session`; the raw identifier is not stored. Set `memory.enabled` to `false` to disable plans and notes; delete `~/.codex-free/conversation-projects/` separately to forget conversation bindings. See [Context and memory](#context-and-memory).
+- **Bounded state writes outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/projects/`. Multi-project mode also writes one small project-binding record under `~/.codex-free/conversation-projects/` for each ChatGPT conversation and access root. Per-conversation authorization writes a small marker under `~/.codex-free/conversation-authorizations/`. Binding and authorization filenames are derived from a hash of `openai/session`; the raw identifier is not stored. Authorization namespaces include a one-way digest of the canonical work directory and configured token, while marker contents store only the grant. Set `memory.enabled` to `false` to disable plans and notes; delete the corresponding state directory to forget bindings or authorizations. See [Context and memory](#context-and-memory).
 - **Bounded reads outside the work directory**: [skills](#skills) may live in `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` or an installed Claude Code plugin. `skills_read` opens files there, but only inside a skill package that already exists — the `resource` path is checked against the skill's own directory, so it cannot walk out into the rest of your home directory. `skills_list` reports the absolute path of every skill it found. Set `skills.enabled` to `false` to switch it off, or `skills.dirs` to point the user scope somewhere you choose.
 - **Read-only Codex configuration discovery**: MCP import and the project catalogue read the user-level Codex `config.toml` without rewriting it. Project discovery inspects only the top-level `projects` table, does not read candidate project contents, and suppresses rejected absolute paths from MCP output. Set `projectCatalog.codexConfig.enabled` to `false` to disable that provider. Native Codex trust does not override the Codex Free access-root boundary.
 - **Command allowlist**: `run_command` only runs binaries listed in `allowedCommands`; everything else is rejected. `exec_command` checks the same list plus `exec.extraAllowedCommands`, at every command position in the string.
 - **Bridged servers carry delegated authority**: an explicit `mcpServers` entry or an automatically imported Codex MCP—including one contributed by a Codex plugin—forwards the model's calls verbatim. A stdio upstream launches a real process that runs as your OS user; a Streamable HTTP upstream receives model-directed calls plus its configured bearer token and HTTP headers. Only bridge servers you trust, prefer `tools`/`disabledTools` filters or `gateway` mode to keep the exposed surface small, keep secrets in `bearerTokenEnvVar`/`envHttpHeaders` rather than static JSON, set `codexMcp.useCli` to `false` to exclude plugin-only discovery, or set `codexMcp.enabled` to `false` to disable all automatic Codex import. Launch, connection, authentication, and handshake failures are reported rather than silently ignored.
 - **Native OpenAI tunnel is outbound-only**: Codex Free binds its MCP listener to loopback and supervises OpenAI's official runtime-only tunnel client. Startup fails unless the runtime reports `/readyz` and completes a control-plane poll. Failure of either process stops the other, and HTTP shutdown has a bounded grace period before remaining connections are aborted.
 - **The loopback MCP hop is authenticated**: native mode generates a random per-process bearer token and configures the tunnel runtime to send it on MCP requests and discovery probes. The token is never printed, written to the config file, or inherited by model-launched commands and bridged MCP children.
+- **Optional conversation-level authorization**: `conversationAuthToken` blocks all tools except `authenticate` until the stable ChatGPT conversation presents the token. Successful grants persist by hashed conversation identity and are invalidated by token rotation; clients without `openai/session` get transport-only grants. Initialization withholds the project-aware brief until authentication. This gate controls model conversations, not network callers: keep the native tunnel, reverse proxy, ChatGPT workspace, and local account secured independently. The token itself remains plaintext in `codex.config.json` because the server must compare chat-supplied values, so keep that file private and out of version control.
 - **Verified tunnel-client installation**: the managed client is pinned to a specific official release and per-platform archive SHA-256 embedded in Codex Free, extracted by exact filename under size limits, installed atomically with private permissions, and hash-checked against its installation manifest on subsequent starts. Set `clientPath` to opt out of managed installation while retaining compatibility checks.
 - **Tunnel secrets are references, not config values**: `openaiTunnel.apiKeyRef` accepts only `env:NAME` or `file:/path`; literal API keys are rejected. Codex Free resolves the value and exposes it only to the tunnel child under a synthetic environment name, while the child receives a clean, allowlisted environment. Use a restricted runtime key with Tunnels **Read** + **Use**, not an admin key. Private key-file permissions are enforced on Unix. Same-user process inspection and same-user file access remain outside this boundary.
 - **Optional bearer token auth in non-native mode**: set `--api-key` to require an `Authorization: Bearer <key>` header on all requests except `/health`. Native mode instead owns its private per-process bearer token. ChatGPT Plugins do not support simple bearer token auth for URL-based connectors.

--- a/codex.config.json
+++ b/codex.config.json
@@ -1,5 +1,6 @@
 {
   "allowedCommands": ["bun", "npm", "npx", "node", "git", "python", "pip", "cargo", "make"],
+  "conversationAuthToken": null,
   "port": 3000,
   "tree": {
     "defaultDepth": 3,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,7 +35,8 @@ ChatGPT / MCP client
 │        │                                      │
 │        ▼                                      │
 │  registry: Vec<Box<dyn Tool>>                 │
-│    • 26 native tools                          │
+│    • 27 native tools                          │
+│    • + authenticate when token-gated          │
 │    • + list_projects + set_project_root       │
 │      in multi-project mode                    │
 │    • bridged tools  ← upstream MCP servers    │
@@ -44,6 +45,10 @@ ChatGPT / MCP client
 │  shared ProjectBindingStore                   │
 │    • openai/session hash → project root       │
 │    • persistent atomic binding records        │
+│                                               │
+│  shared ConversationAuthorizationStore        │
+│    • openai/session hash → allowed             │
+│    • token-scoped persistent markers          │
 │                                               │
 │  shared ConversationExecSessionStore          │
 │    • openai/session hash → resident commands  │
@@ -59,20 +64,23 @@ ChatGPT / MCP client
 │                                               │
 │  per-transport SessionState                   │
 │    • fallback root for generic MCP clients    │
-│    • exec sessions + plan + review fallback   │
+│    • auth + exec + plan + review fallback     │
 └──────────────────────────────────────────────┘
         │ reads/writes           │ stdio / Streamable HTTP
         ▼                        ▼
    active project root     upstream MCP servers (idasql, remote-docs, …)
 ```
 
-Four surfaces reach the model:
+Five surfaces reach the model:
 
 - **Tools** — `tools/list` + `tools/call` (native, bridged, gateway).
 - **Skills** — a catalogue in the server `instructions` plus the `skills_list` /
   `skills_read` tools, discovered from disk.
 - **Instructions** — the agent brief + environment + memory + project doc,
   rebuilt from the active project config.
+- **Conversation authorization** — an optional token gate whose durable grant is
+  keyed by ChatGPT's stable conversation metadata rather than by the replaceable
+  MCP transport.
 - **MCP App** — the self-contained review resource linked from `show_changes`;
   unsupported clients ignore the UI metadata and keep the ordinary tool result.
 
@@ -84,11 +92,13 @@ Four surfaces reach the model:
    `StreamableHttpService` manages the session and calls the **service factory**
    once per session, producing a fresh `CodexHandler`.
 2. `CodexHandler::get_info` returns the negotiated protocol version, capabilities
-   (`tools`), server identity, and the `instructions` string. Single-project mode
-   builds the full project-aware brief immediately. Multi-project mode emits only
-   the root-selection protocol and a project-neutral environment because ChatGPT's
-   conversation identity arrives in request `_meta` on tool calls, after
-   initialization.
+   (`tools`), server identity, and the `instructions` string. With
+   `conversationAuthToken`, initialization exposes only the authentication
+   protocol; project context is loaded later through `get_agent_brief`. Otherwise,
+   single-project mode builds the full project-aware brief immediately, while
+   multi-project mode emits only the root-selection protocol and a project-neutral
+   environment because ChatGPT's conversation identity arrives in request `_meta`
+   on tool calls, after initialization.
 3. `tools/list` → `CodexHandler::list_tools` maps the shared tool registry into
    rmcp `Tool` definitions, including optional titles, behavioral annotations,
    OpenAI file-parameter metadata, and MCP Apps resource metadata.
@@ -96,41 +106,48 @@ Four surfaces reach the model:
 4. `tools/call` → `CodexHandler::call_tool` reads `openai/session` from rmcp's
    `RequestContext::meta`. rmcp moves wire-level request `_meta` into that context
    before dispatch, so the typed tool parameters are not the authoritative source.
-5. In multi-project mode, `list_projects` may run before selection. It rebuilds a
+5. When conversation authorization is configured, `authenticate` compares the
+   submitted token without echoing it and records only the authorization decision.
+   Every other tool fails before project resolution or dispatch until the hashed
+   ChatGPT conversation is authorized. The marker survives server restarts and is
+   namespaced by the canonical work directory and current token, so rotation
+   invalidates prior grants. Clients without `openai/session` receive a
+   transport-local fallback grant.
+6. In multi-project mode, `list_projects` may run before selection. It rebuilds a
    read-only catalogue from the user-level native Codex `[projects]` table and the
    static `projectCatalog.entries` overlay, canonicalizes and filters candidates
    against the access root, and returns relative selectors without reading project
    content or creating a binding.
-6. `set_project_root` canonicalizes an existing directory below the configured
+7. `set_project_root` canonicalizes an existing directory below the configured
    access root. With `openai/session`, it writes an immutable conversation binding
    through the shared `ProjectBindingStore`; without it, the root is stored in the
    current `SessionState`. Re-selecting the same canonical root is idempotent and
    selecting a different root is rejected.
-7. Other project-scoped calls resolve the durable conversation binding first, or
+8. Other project-scoped calls resolve the durable conversation binding first, or
    the transport-session fallback when no conversation identity exists, then
    receive an effective clone of `AppConfig` whose `work_dir` is that root. Before
    the first such call, the review manager captures the scoped project-open snapshot.
    Non-Git projects report review as unavailable; a Git snapshot failure blocks
    mutating tools before dispatch.
-8. Tool dispatch supplies a request context containing the stable conversation
-   identity and shared review manager; tools that do not need it use the default
-   context-free implementation. The server fills in default `structuredContent`
-   when appropriate. Dispatch also emits diagnostic tracing and, when audit
+9. Tool dispatch supplies a request context containing the stable conversation
+   identity, shared authorization store, and shared review manager; tools that do
+   not need it use the default context-free implementation. The server fills in
+   default `structuredContent` when appropriate. Dispatch also emits diagnostic tracing and, when audit
    logging is enabled, paired JSONL `tool_start` / `tool_finish` records: identity
    and project values are hashed, and scalar argument values and returned payloads
    are replaced by schema-bounded shape and size accounting (unknown argument keys
    and dynamic-map keys are not recorded).
-9. `exec_command` and `write_stdin` opt into resident-process routing. With a
+10. `exec_command` and `write_stdin` opt into resident-process routing. With a
    ChatGPT conversation identity, dispatch substitutes the shared conversation's
    exec state while retaining the transport's other mutable state. Without one,
    the ordinary transport-owned state is used.
-10. When a transport session ends, rmcp drops the `CodexHandler`: its
+11. When a transport session ends, rmcp drops the `CodexHandler`: its
     generic-client exec state loses its last owner and kills resident process
     trees. Conversation-owned process state remains in the server for later
     connector calls, subject to idle cleanup; server shutdown drops the shared
-    store and kills anything still running. Project bindings and ChatGPT review
-    refs are independently durable on disk across server restarts, but process
-    handles are not.
+    store and kills anything still running. Project bindings, conversation grants,
+    and ChatGPT review refs are independently durable on disk across server
+    restarts, but process handles are not.
 
 Cross-cutting HTTP concerns live in the axum layer: a `/health` route, a
 bearer-auth middleware that bypasses `/health`, and—in externally exposed
@@ -182,6 +199,17 @@ hash, written atomically under a per-record lock, and validated again on every
 load so a deleted project or changed symlink fails closed. A new store instance
 can recover the same binding after a server restart.
 
+### `ConversationAuthorizationStore` (`conversation_auth.rs`)
+Optional conversation-level access control. The configured token is validated at
+startup and compared by fixed-size digest. A successful ChatGPT call writes a
+private marker whose filename uses the existing hashed `ConversationIdentity`;
+marker contents contain only the authorization decision. Markers are grouped
+under a digest of the canonical work directory and current token, which avoids
+plaintext token storage and makes rotation a new authorization namespace. The
+in-memory set avoids disk reads after recovery. Generic clients have no durable
+conversation identity, so their grant is an atomic flag shared only by the current
+`SessionState` views.
+
 ### Worktree isolation (`worktrees.rs`)
 In multi-project mode, `set_project_root` can bind a conversation to a **detached
 managed Git worktree** instead of the source checkout, so two chats editing the
@@ -217,8 +245,8 @@ the source repository's local Git config and the script runs outside the
 
 ### `ConversationExecSessionStore` and `SessionState` (`exec_sessions.rs`)
 `SessionState` is the per-MCP-transport view: it owns the optional fallback
-project root for generic clients, the current plan, a transport-owned exec
-state, and the generic-client review fallback. The exec state is
+project root and authorization flag for generic clients, the current plan, a
+transport-owned exec state, and the generic-client review fallback. The exec state is
 reference-counted and kills running process trees when its last owner disappears.
 
 `ConversationExecSessionStore` is shared by all handlers in the server process.
@@ -252,6 +280,9 @@ call and substitutes the conversation's selected root—or the transport fallbac
 `work_dir`; the static server policy, catalogue overlay, and bridge configuration
 remain shared. Native Codex project entries are intentionally re-read when the
 catalogue tool is called rather than copied into `AppConfig` at startup.
+`conversationAuthToken` is a top-level optional secret with no CLI override; its
+presence also controls registry inclusion of the `authenticate` tool and the
+authentication-only initialization instructions.
 
 ### `quickstart` CLI (`quickstart.rs`)
 The `quickstart` subcommand runs before server configuration is loaded. It uses a
@@ -263,6 +294,9 @@ project behind an absolute `file:` reference. Config and credential replacement
 use temporary files in the destination directory. Once setup is complete, the
 same process can pass the generated paths back through `load_config` and enter the
 ordinary supervised server lifecycle; there is no separate quickstart runtime.
+The wizard can additionally generate `conversationAuthToken`, protect the config
+as a private file on Unix, and print a one-line instruction suitable for an
+individual chat or ChatGPT Project instructions.
 
 ---
 
@@ -276,12 +310,13 @@ ordinary supervised server lifecycle; there is no separate quickstart runtime.
   loopback authorities, omits permissive CORS, and requires a random
   process-private bearer token generated at startup.
 - **Session model**: the factory runs per MCP transport session. `SessionState`
-  owns the generic-client root fallback, current plan, and generic-client
+  owns the generic-client root and authorization fallbacks, current plan, and generic-client
   resident commands. ChatGPT identity is taken from
   `RequestContext::meta["openai/session"]`: the persistent
-  `ProjectBindingStore` resolves its project, while the in-memory
+  `ProjectBindingStore` resolves its project, the persistent
+  `ConversationAuthorizationStore` resolves the optional token grant, and the in-memory
   `ConversationExecSessionStore` resolves resident commands across replacement
-  transports. Upstream MCP connections, both stores, and the tool registry are
+  transports. Upstream MCP connections, all three stores, and the tool registry are
   shared (`Arc`) across transports.
 - **`get_info`** advertises server name `codex-free` (wire-compatible identity),
   version, tools/resources capabilities, the `io.modelcontextprotocol/ui` extension,
@@ -343,9 +378,11 @@ a private per-run temporary directory and are removed after shutdown.
 | Timing | `clock_curr_time`, `clock_sleep` |
 | Project selection (multi-project only) | `list_projects`, `set_project_root` |
 
-Multi-project mode prepends `list_projects` and `set_project_root`. Both are
-omitted entirely in the default registry, preserving the 27-tool default surface
-and behaviour. `artifactIngress.enabled = false` independently removes
+Conversation authorization prepends `authenticate`; multi-project mode then
+prepends `list_projects` and `set_project_root`. The optional tools are omitted
+from the ordinary single-project registry, preserving the 27-tool default surface
+and behaviour. Enabling the gate raises the applicable count by one.
+`artifactIngress.enabled = false` independently removes
 `import_host_file`, reducing either count by one. Catalogue discovery, selection,
 clocks, and bridged/gateway tools are project-independent; every other native tool
 is blocked until a conversation binding or transport fallback is available.
@@ -364,6 +401,7 @@ the original order and rejects duplicate names.
 | `logging.rs` | Tracing initialization with default filters for normal, `-v`, and `-vv` operation (an explicit `RUST_LOG` remains authoritative), plus a non-overridable filter that suppresses RMCP framework events, preventing native-file bearer URLs from appearing in logs before tool dispatch or malformed-session errors. |
 | `output_budget.rs` | Line/byte windowing and list caps, each cut announced with the continuation argument. |
 | `audit.rs` | Private append-only JSONL tool lifecycle records, stable hashed identities, redacted argument summaries, output accounting, and opt-in bounded command previews. |
+| `conversation_auth.rs` | Token generation and validation, fixed-size digest comparison, copyable ChatGPT instruction rendering, durable per-conversation authorization markers, and transport-session fallback. |
 | `ignore_rules.rs` | One `.gitignore`-accurate matcher (the `ignore` crate) shared by glob/grep/tree/list_directory. |
 | `exec_policy.rs` | Shell-string allowlist guard for `exec_command` (a guardrail, not a sandbox). |
 | `project_bindings.rs` | Canonical project-root validation plus durable ChatGPT conversation bindings keyed by a hash of `openai/session`, namespaced by access root, locked per record, and atomically written. |
@@ -374,14 +412,14 @@ the original order and rejects duplicate names.
 | `review_ui.rs` | Embedded MCP Apps resource and compatibility metadata for the interactive `show_changes` review card. |
 | `apply_patch.rs` | The Codex patch format: parse then apply, atomically, with fuzzy context matching and CRLF preservation. |
 | `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized active root, with `O_EXCL` locking and atomic writes. In multi-project mode, a configured `memory.dir` is a base containing one hashed child per project. |
-| `quickstart.rs` | Interactive first-install wizard for project scope, native tunnel credentials, JSON config merging, and the ChatGPT developer-mode connector handoff. |
+| `quickstart.rs` | Interactive first-install wizard for project scope, native tunnel credentials, optional conversation-token generation, JSON config merging, and the ChatGPT developer-mode connector handoff. |
 | `openai_tunnel.rs` | Verified installation and lifecycle supervision for OpenAI's outbound Secure MCP Tunnel runtime. |
 | `process_env.rs` | Child-process environment boundaries: isolate the tunnel runtime and remove tunnel credentials from model-controlled and upstream subprocesses. |
 | `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. Multi-project mode treats the selected directory as the exact project root and never walks into the common access-root parent. |
 | `skills.rs` | `SKILL.md` discovery (see §8). |
 | `codex_config.rs` | Shared secret-safe resolver and TOML reader for `$CODEX_HOME/config.toml` or `~/.codex/config.toml`. |
 | `codex_mcp.rs` | Read-only import of local stdio and remote Streamable HTTP MCP definitions from the shared native Codex configuration reader, plus bounded `codex mcp list/get --json` enrichment for plugin-provided servers, with secret-safe diagnostics. |
-| `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc. Multi-project initialization emits a project-neutral selector brief because conversation metadata is available only on subsequent tool calls; `get_agent_brief` builds the full brief after restoring or creating a binding. |
+| `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc. Authentication-enabled initialization emits only the gate protocol; otherwise multi-project initialization emits a project-neutral selector brief because conversation metadata is available only on subsequent tool calls. `get_agent_brief` builds the full brief after authorization and project resolution. |
 | `environment.rs` | OS / shell / policy description, shared by `get_environment` and the instructions. |
 
 ---
@@ -507,6 +545,7 @@ startup banner prints the exact file with `Config:`). All fields optional.
 {
   "port": 3000,
   "apiKey": "…",                      // or --api-key; bearer token
+  "conversationAuthToken": "codex_free_chat_…", // optional per-chat tool gate
   "multiProject": false,               // or --multi-project; work-dir becomes access root
   "allowedCommands": ["git", "node", …],   // run_command allowlist
   "allowedHosts": [],                  // DNS-rebinding allowlist; empty = any host
@@ -576,10 +615,11 @@ The banner is designed so failures are never silent:
 
 ```
 Config: D:\codex-bridge\codex.config.json          ← which file actually loaded
-Tools loaded (27): 26 native + 1 bridged from upstream MCP servers
+Tools loaded (29): 28 native + 1 bridged from upstream MCP servers
 Upstream MCP servers:
   remote-exec -> gateway (84 functions via `remote_exec`)
 Auth: disabled (no --api-key)
+Conversation auth: enabled (one token verification per chat)
 Audit log: /private/path/tools.jsonl
 Audit command previews: disabled
 ```
@@ -594,6 +634,9 @@ Audit command previews: disabled
 - Multi-project startup also prints `Project access root:`, `Project mode:
   persistent ChatGPT conversation binding`, and the conversation-binding state
   directory; its native count is 29 because the selectors are present.
+- Conversation authorization adds one native tool and prints only whether the
+  gate is enabled; neither the token nor its derived authorization namespace is
+  printed.
 - `-v` and `-vv` increase Codex Free diagnostics without dumping raw tool payloads;
   `RUST_LOG` overrides those defaults. When audit logging is configured, the banner
   prints its destination and whether command previews are enabled.

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -732,7 +732,7 @@ mod tests {
         config.audit.include_command_preview = true;
         config.api_key = Some("literal-known-secret".to_string());
         config.conversation_auth_token =
-            Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+            Some("codex_free_chat_0123456789abcdef0123456789abcdef".into());
         let logger = AuditLogger::open(&config).unwrap().unwrap();
         let redacted = logger.redact_command(
             "tool --github-token prefixed-token OPENAI_API_KEY=assigned-key literal-known-secret codex_free_chat_0123456789abcdef0123456789abcdef \"api_key\": \"json-secret\" Authorization: Basic basic-token Bearer abc.def",

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -499,6 +499,9 @@ fn collect_secret_values(config: &AppConfig) -> Zeroizing<Vec<String>> {
     if let Some(api_key) = config.api_key.as_deref() {
         push_secret(&mut values, api_key, false);
     }
+    if let Some(token) = config.conversation_auth_token.as_deref() {
+        push_secret(&mut values, token, false);
+    }
     for server in config.mcp_servers.values() {
         for value in server.env.values() {
             push_secret(&mut values, value, false);
@@ -728,13 +731,16 @@ mod tests {
         config.audit.log_file = Some(root.path().join("audit.jsonl"));
         config.audit.include_command_preview = true;
         config.api_key = Some("literal-known-secret".to_string());
+        config.conversation_auth_token =
+            Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
         let logger = AuditLogger::open(&config).unwrap().unwrap();
         let redacted = logger.redact_command(
-            "tool --github-token prefixed-token OPENAI_API_KEY=assigned-key literal-known-secret \"api_key\": \"json-secret\" Authorization: Basic basic-token Bearer abc.def",
+            "tool --github-token prefixed-token OPENAI_API_KEY=assigned-key literal-known-secret codex_free_chat_0123456789abcdef0123456789abcdef \"api_key\": \"json-secret\" Authorization: Basic basic-token Bearer abc.def",
         );
         assert!(!redacted.contains("prefixed-token"));
         assert!(!redacted.contains("assigned-key"));
         assert!(!redacted.contains("literal-known-secret"));
+        assert!(!redacted.contains("codex_free_chat_0123456789abcdef"));
         assert!(!redacted.contains("json-secret"), "{redacted}");
         assert!(!redacted.contains("basic-token"));
         assert!(!redacted.contains("abc.def"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ use crate::codex_config::codex_config_path;
 use crate::codex_mcp::{
     CodexMcpImport, discover_additional_codex_mcp_servers_with_cli, discover_codex_mcp_servers,
 };
+use crate::conversation_auth::validate_conversation_auth_token;
 use crate::openai_tunnel::validate_tunnel_id;
 use crate::project_catalog::{ProjectCatalog, discover_project_catalog_at};
 use crate::types::{
@@ -431,6 +432,7 @@ impl PartialMcpServerSpec {
 #[serde(rename_all = "camelCase")]
 struct FileConfig {
     api_key: Option<String>,
+    conversation_auth_token: Option<String>,
     port: Option<u16>,
     multi_project: Option<bool>,
     worktrees: Option<PartialWorktrees>,
@@ -628,6 +630,7 @@ pub fn default_config(work_dir: std::path::PathBuf) -> AppConfig {
         project_catalog: ProjectCatalogConfig::default(),
         worktrees: default_worktree_config(),
         api_key: None,
+        conversation_auth_token: None,
         port: 3000,
         allowed_commands: default_allowed_commands(),
         tree: default_tree(),
@@ -965,6 +968,10 @@ fn resolve_audit(file: Option<PartialAudit>, cli: &Cli) -> Result<AuditConfig, S
 pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
     let work_dir = resolve_cli_work_dir(&cli)?;
     let mut file = load_file_config(&cli, true)?;
+    let conversation_auth_token = file.conversation_auth_token.take();
+    if let Some(token) = conversation_auth_token.as_deref() {
+        validate_conversation_auth_token(token)?;
+    }
 
     let mut tree = default_tree();
     if let Some(t) = file.tree.take() {
@@ -1027,6 +1034,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
         project_catalog,
         worktrees,
         api_key,
+        conversation_auth_token,
         port: cli.port.or(file.port).unwrap_or(3000),
         allowed_commands: file
             .allowed_commands
@@ -1130,6 +1138,41 @@ mod tests {
         assert_eq!(parsed.audit_log.as_deref(), Some("/tmp/audit.jsonl"));
         assert!(parsed.audit_command_preview);
         assert_eq!(parsed.audit_redact_env, ["GITHUB_TOKEN", "CUSTOM_SECRET"]);
+    }
+
+    #[test]
+    fn loads_conversation_auth_token_from_the_config_file() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.json");
+        let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
+        std::fs::write(
+            &config_path,
+            serde_json::to_vec(&json!({
+                "codexMcp": { "enabled": false },
+                "conversationAuthToken": token
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let config = load_config(cli(root.path(), &config_path)).unwrap();
+
+        assert_eq!(config.conversation_auth_token.as_deref(), Some(token));
+    }
+
+    #[test]
+    fn rejects_malformed_conversation_auth_tokens() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.json");
+        std::fs::write(
+            &config_path,
+            r#"{"codexMcp":{"enabled":false},"conversationAuthToken":"too short"}"#,
+        )
+        .unwrap();
+
+        let error = load_config(cli(root.path(), &config_path)).unwrap_err();
+
+        assert!(error.contains("conversationAuthToken"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,9 +21,10 @@ use crate::openai_tunnel::validate_tunnel_id;
 use crate::project_catalog::{ProjectCatalog, discover_project_catalog_at};
 use crate::types::{
     AppConfig, ArtifactIngressConfig, AuditConfig, CodexProjectCatalogConfig, CommandConfig,
-    ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig, OpenAiTunnelConfig,
-    OutputConfig, ProjectCatalogConfig, ProjectCatalogEntryConfig, ProjectDocConfig, ReviewConfig,
-    SkillsConfig, TreeConfig, WorktreeConfig, WorktreeMode, WorktreeUpstreamRefreshMode,
+    ConversationAuthToken, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig,
+    OpenAiTunnelConfig, OutputConfig, ProjectCatalogConfig, ProjectCatalogEntryConfig,
+    ProjectDocConfig, ReviewConfig, SkillsConfig, TreeConfig, WorktreeConfig, WorktreeMode,
+    WorktreeUpstreamRefreshMode,
 };
 use crate::util::home_dir;
 
@@ -972,6 +973,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
     if let Some(token) = conversation_auth_token.as_deref() {
         validate_conversation_auth_token(token)?;
     }
+    let conversation_auth_token = conversation_auth_token.map(ConversationAuthToken::from);
 
     let mut tree = default_tree();
     if let Some(t) = file.tree.take() {
@@ -1158,6 +1160,9 @@ mod tests {
         let config = load_config(cli(root.path(), &config_path)).unwrap();
 
         assert_eq!(config.conversation_auth_token.as_deref(), Some(token));
+        let debug = format!("{config:?}");
+        assert!(debug.contains("conversation_auth_token: Some(<redacted>)"));
+        assert!(!debug.contains(token));
     }
 
     #[test]

--- a/src/conversation_auth.rs
+++ b/src/conversation_auth.rs
@@ -346,7 +346,7 @@ fn private_file_permissions(metadata: &std::fs::Metadata) -> bool {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        return metadata.permissions().mode() & 0o077 == 0;
+        metadata.permissions().mode() & 0o077 == 0
     }
     #[cfg(not(unix))]
     {
@@ -359,7 +359,7 @@ fn private_directory_permissions(metadata: &std::fs::Metadata) -> bool {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        return metadata.permissions().mode() & 0o077 == 0;
+        metadata.permissions().mode() & 0o077 == 0
     }
     #[cfg(not(unix))]
     {

--- a/src/conversation_auth.rs
+++ b/src/conversation_auth.rs
@@ -1,0 +1,477 @@
+use std::collections::HashSet;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use sha2::{Digest, Sha256};
+
+use crate::exec_sessions::SessionState;
+use crate::project_bindings::ConversationIdentity;
+use crate::types::AppConfig;
+use crate::util::home_dir;
+
+pub const AUTHENTICATE_TOOL_NAME: &str = "authenticate";
+pub const MIN_CONVERSATION_AUTH_TOKEN_BYTES: usize = 32;
+pub const MAX_CONVERSATION_AUTH_TOKEN_BYTES: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversationAuthorizationScope {
+    ChatGptConversation,
+    McpTransportSession,
+}
+
+impl ConversationAuthorizationScope {
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::ChatGptConversation => "this ChatGPT conversation",
+            Self::McpTransportSession => "this MCP transport session",
+        }
+    }
+}
+
+pub struct ConversationAuthorizationStore {
+    authorized: Mutex<HashSet<ConversationIdentity>>,
+    persistence_dir: Option<PathBuf>,
+}
+
+impl Default for ConversationAuthorizationStore {
+    fn default() -> Self {
+        Self {
+            authorized: Mutex::new(HashSet::new()),
+            persistence_dir: None,
+        }
+    }
+}
+
+impl ConversationAuthorizationStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn for_current_user(config: &AppConfig) -> Self {
+        let Some(token) = config.conversation_auth_token.as_deref() else {
+            return Self::new();
+        };
+        let Some(home) = home_dir() else {
+            return Self::new();
+        };
+        Self::persistent(
+            home.join(".codex-free").join("conversation-authorizations"),
+            &config.work_dir,
+            token,
+        )
+    }
+
+    pub fn persistent(base_dir: PathBuf, work_dir: &Path, token: &str) -> Self {
+        Self {
+            authorized: Mutex::new(HashSet::new()),
+            persistence_dir: Some(base_dir.join(authorization_scope_key(work_dir, token))),
+        }
+    }
+
+    pub fn is_authorized(
+        &self,
+        conversation: Option<&ConversationIdentity>,
+        session: &SessionState,
+    ) -> bool {
+        match conversation {
+            Some(identity) => {
+                let mut authorized = self.authorized.lock().unwrap();
+                if authorized.contains(identity) {
+                    return true;
+                }
+                if self.persisted_authorization_exists(identity) {
+                    authorized.insert(identity.clone());
+                    return true;
+                }
+                false
+            }
+            None => session.connector_authorized(),
+        }
+    }
+
+    pub fn authorize(
+        &self,
+        conversation: Option<&ConversationIdentity>,
+        session: &SessionState,
+    ) -> Result<ConversationAuthorizationScope, String> {
+        match conversation {
+            Some(identity) => {
+                self.persist_authorization(identity)?;
+                self.authorized.lock().unwrap().insert(identity.clone());
+                Ok(ConversationAuthorizationScope::ChatGptConversation)
+            }
+            None => {
+                session.authorize_connector();
+                Ok(ConversationAuthorizationScope::McpTransportSession)
+            }
+        }
+    }
+
+    fn authorization_path(&self, identity: &ConversationIdentity) -> Option<PathBuf> {
+        self.persistence_dir
+            .as_ref()
+            .map(|directory| directory.join(format!("{}.allowed", identity.stable_key())))
+    }
+
+    fn persisted_authorization_exists(&self, identity: &ConversationIdentity) -> bool {
+        let Some(path) = self.authorization_path(identity) else {
+            return false;
+        };
+        let Some(directory) = path.parent() else {
+            return false;
+        };
+        let Ok(directory_metadata) = std::fs::symlink_metadata(directory) else {
+            return false;
+        };
+        if !directory_metadata.is_dir()
+            || directory_metadata.file_type().is_symlink()
+            || !private_directory_permissions(&directory_metadata)
+        {
+            return false;
+        }
+        let Ok(metadata) = std::fs::symlink_metadata(&path) else {
+            return false;
+        };
+        if !metadata.is_file()
+            || metadata.file_type().is_symlink()
+            || !private_file_permissions(&metadata)
+        {
+            return false;
+        }
+        std::fs::read(path).is_ok_and(|contents| contents == b"authorized\n")
+    }
+
+    fn persist_authorization(&self, identity: &ConversationIdentity) -> Result<(), String> {
+        let Some(path) = self.authorization_path(identity) else {
+            return Ok(());
+        };
+        let directory = path
+            .parent()
+            .ok_or_else(|| "conversation authorization path has no parent".to_string())?;
+        ensure_private_directory(directory)?;
+
+        if path.exists() {
+            return if self.persisted_authorization_exists(identity) {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Refusing to use an invalid conversation authorization marker at {}",
+                    path.display()
+                ))
+            };
+        }
+
+        let mut temporary = tempfile::NamedTempFile::new_in(directory).map_err(|error| {
+            format!(
+                "Could not create a temporary conversation authorization in {}: {error}",
+                directory.display()
+            )
+        })?;
+        temporary.write_all(b"authorized\n").map_err(|error| {
+            format!(
+                "Could not write conversation authorization for {}: {error}",
+                path.display()
+            )
+        })?;
+        temporary.as_file().sync_all().map_err(|error| {
+            format!(
+                "Could not flush conversation authorization for {}: {error}",
+                path.display()
+            )
+        })?;
+        make_private_file(temporary.path()).map_err(|error| {
+            format!(
+                "Could not restrict conversation authorization for {}: {error}",
+                path.display()
+            )
+        })?;
+
+        match temporary.persist_noclobber(&path) {
+            Ok(_) => Ok(()),
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if self.persisted_authorization_exists(identity) {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "Refusing to use an invalid conversation authorization marker at {}",
+                        path.display()
+                    ))
+                }
+            }
+            Err(error) => Err(format!(
+                "Could not persist conversation authorization at {}: {}",
+                path.display(),
+                error.error
+            )),
+        }
+    }
+}
+
+pub fn generate_conversation_auth_token() -> anyhow::Result<String> {
+    let mut bytes = [0_u8; 32];
+    getrandom::getrandom(&mut bytes)
+        .map_err(|error| anyhow::anyhow!("generate conversation authentication token: {error}"))?;
+    Ok(format!("codex_free_chat_{}", URL_SAFE_NO_PAD.encode(bytes)))
+}
+
+pub fn validate_conversation_auth_token(token: &str) -> Result<(), String> {
+    let length = token.len();
+    if !(MIN_CONVERSATION_AUTH_TOKEN_BYTES..=MAX_CONVERSATION_AUTH_TOKEN_BYTES).contains(&length) {
+        return Err(format!(
+            "conversationAuthToken must contain between {MIN_CONVERSATION_AUTH_TOKEN_BYTES} and {MAX_CONVERSATION_AUTH_TOKEN_BYTES} bytes"
+        ));
+    }
+    if !token
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-'))
+    {
+        return Err(
+            "conversationAuthToken may contain only ASCII letters, digits, `_`, and `-`"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
+pub fn conversation_auth_tokens_match(expected: &str, provided: &str) -> bool {
+    let expected = Sha256::digest(expected.as_bytes());
+    let provided = Sha256::digest(provided.as_bytes());
+    expected
+        .iter()
+        .zip(provided.iter())
+        .fold(0_u8, |difference, (left, right)| {
+            difference | (left ^ right)
+        })
+        == 0
+}
+
+pub fn conversation_auth_prompt(token: &str) -> String {
+    format!(
+        "To use this connector in a chat, call its `{AUTHENTICATE_TOOL_NAME}` tool once with token `{token}`."
+    )
+}
+
+fn authorization_scope_key(work_dir: &Path, token: &str) -> String {
+    let work_dir = std::fs::canonicalize(work_dir).unwrap_or_else(|_| work_dir.to_path_buf());
+    let mut hasher = Sha256::new();
+    hasher.update(b"codex-free/conversation-authorization-scope/v1\0");
+    hasher.update(work_dir.to_string_lossy().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(token.as_bytes());
+    encode_hex(&hasher.finalize())
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(encoded, "{byte:02x}");
+    }
+    encoded
+}
+
+fn make_private_directory(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn ensure_private_directory(path: &Path) -> Result<(), String> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() && !metadata.file_type().is_symlink() => {}
+        Ok(_) => {
+            return Err(format!(
+                "Refusing to use a non-directory conversation-authorization path at {}",
+                path.display()
+            ));
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            std::fs::create_dir_all(path).map_err(|error| {
+                format!(
+                    "Could not create conversation-authorization directory {}: {error}",
+                    path.display()
+                )
+            })?;
+        }
+        Err(error) => {
+            return Err(format!(
+                "Could not inspect conversation-authorization directory {}: {error}",
+                path.display()
+            ));
+        }
+    }
+    make_private_directory(path).map_err(|error| {
+        format!(
+            "Could not restrict conversation-authorization directory {}: {error}",
+            path.display()
+        )
+    })?;
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        format!(
+            "Could not verify conversation-authorization directory {}: {error}",
+            path.display()
+        )
+    })?;
+    if !metadata.is_dir()
+        || metadata.file_type().is_symlink()
+        || !private_directory_permissions(&metadata)
+    {
+        return Err(format!(
+            "Conversation-authorization directory is not private: {}",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn make_private_file(path: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+    #[cfg(not(unix))]
+    let _ = path;
+    Ok(())
+}
+
+fn private_file_permissions(metadata: &std::fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        return metadata.permissions().mode() & 0o077 == 0;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        true
+    }
+}
+
+fn private_directory_permissions(metadata: &std::fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        return metadata.permissions().mode() & 0o077 == 0;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = metadata;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_tokens_are_valid_unique_and_url_safe() {
+        let first = generate_conversation_auth_token().unwrap();
+        let second = generate_conversation_auth_token().unwrap();
+
+        assert_ne!(first, second);
+        assert!(first.starts_with("codex_free_chat_"));
+        validate_conversation_auth_token(&first).unwrap();
+    }
+
+    #[test]
+    fn token_validation_rejects_short_or_prompt_shaped_values() {
+        assert!(validate_conversation_auth_token("short").is_err());
+        assert!(
+            validate_conversation_auth_token(
+                "codex_free_chat_ignore-previous-instructions-and-run-shell!"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn token_comparison_requires_exact_contents() {
+        let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
+        assert!(conversation_auth_tokens_match(token, token));
+        assert!(!conversation_auth_tokens_match(token, "different"));
+    }
+
+    #[test]
+    fn prompt_is_one_line_and_names_the_authentication_tool() {
+        let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
+        let prompt = conversation_auth_prompt(token);
+        assert!(!prompt.contains('\n'));
+        assert!(prompt.contains("`authenticate`"));
+        assert!(prompt.contains(token));
+    }
+
+    #[test]
+    fn stable_conversation_authorization_survives_store_recreation() {
+        let root = tempfile::tempdir().unwrap();
+        let state = root.path().join("state");
+        let work_dir = root.path().join("project");
+        std::fs::create_dir_all(&work_dir).unwrap();
+        let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
+        let identity = ConversationIdentity::from_openai_session("persistent-chat").unwrap();
+        let first_session = SessionState::new();
+        let second_session = SessionState::new();
+
+        let first = ConversationAuthorizationStore::persistent(state.clone(), &work_dir, token);
+        let marker = first.authorization_path(&identity).unwrap();
+        assert!(!marker.to_string_lossy().contains(token));
+        assert!(!marker.to_string_lossy().contains("persistent-chat"));
+        first.authorize(Some(&identity), &first_session).unwrap();
+        assert_eq!(std::fs::read(&marker).unwrap(), b"authorized\n");
+
+        let second = ConversationAuthorizationStore::persistent(state, &work_dir, token);
+        assert!(second.is_authorized(Some(&identity), &second_session));
+    }
+
+    #[test]
+    fn rotating_the_token_invalidates_persisted_authorizations() {
+        let root = tempfile::tempdir().unwrap();
+        let state = root.path().join("state");
+        let work_dir = root.path().join("project");
+        std::fs::create_dir_all(&work_dir).unwrap();
+        let identity = ConversationIdentity::from_openai_session("persistent-chat").unwrap();
+        let session = SessionState::new();
+        let first_token = "codex_free_chat_0123456789abcdef0123456789abcdef";
+        let second_token = "codex_free_chat_fedcba9876543210fedcba9876543210";
+
+        ConversationAuthorizationStore::persistent(state.clone(), &work_dir, first_token)
+            .authorize(Some(&identity), &session)
+            .unwrap();
+        let rotated = ConversationAuthorizationStore::persistent(state, &work_dir, second_token);
+
+        assert!(!rotated.is_authorized(Some(&identity), &SessionState::new()));
+    }
+
+    #[test]
+    fn incomplete_or_permissive_markers_do_not_authorize() {
+        let root = tempfile::tempdir().unwrap();
+        let state = root.path().join("state");
+        let work_dir = root.path().join("project");
+        std::fs::create_dir_all(&work_dir).unwrap();
+        let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
+        let identity = ConversationIdentity::from_openai_session("persistent-chat").unwrap();
+        let store = ConversationAuthorizationStore::persistent(state, &work_dir, token);
+        let path = store.authorization_path(&identity).unwrap();
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, b"").unwrap();
+        make_private_file(&path).unwrap();
+
+        assert!(!store.is_authorized(Some(&identity), &SessionState::new()));
+
+        std::fs::write(&path, b"authorized\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+            assert!(!store.is_authorized(Some(&identity), &SessionState::new()));
+        }
+    }
+}

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -7,7 +7,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
@@ -568,6 +568,7 @@ fn reap_conversation_states(
 /// backed by [`ConversationExecSessionStore`].
 pub struct SessionState {
     exec: Arc<ExecSessionState>,
+    connector_authorized: Arc<AtomicBool>,
     pub plan: Arc<StdMutex<Option<PlanState>>>,
     /// The transport-session project binding. Shared (behind `Arc`) with any
     /// conversation-scoped view derived through `with_exec_state`, and carries
@@ -595,6 +596,7 @@ impl Default for SessionState {
     fn default() -> Self {
         Self {
             exec: Arc::new(ExecSessionState::new()),
+            connector_authorized: Arc::new(AtomicBool::new(false)),
             plan: Arc::new(StdMutex::new(None)),
             project_binding: Arc::new(StdMutex::new(None)),
             project_selection_lock: Arc::new(TokioMutex::new(())),
@@ -612,6 +614,7 @@ impl SessionState {
     fn with_exec_state(&self, exec: Arc<ExecSessionState>) -> Self {
         Self {
             exec,
+            connector_authorized: self.connector_authorized.clone(),
             plan: self.plan.clone(),
             project_binding: self.project_binding.clone(),
             project_selection_lock: self.project_selection_lock.clone(),
@@ -623,6 +626,14 @@ impl SessionState {
     /// The stable per-transport identifier stamped into audit-log events.
     pub fn audit_id(&self) -> u64 {
         self.audit_id
+    }
+
+    pub fn connector_authorized(&self) -> bool {
+        self.connector_authorized.load(Ordering::Acquire)
+    }
+
+    pub fn authorize_connector(&self) {
+        self.connector_authorized.store(true, Ordering::Release);
     }
 
     /// Starts cleanup for generic-client, transport-owned resident commands.

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -10,6 +10,8 @@ use crate::project_doc::{PROJECT_DOC_SEPARATOR, load_project_doc};
 use crate::skills::{discover_skills, render_skill_catalog};
 use crate::types::AppConfig;
 
+pub const CONVERSATION_AUTH_INSTRUCTIONS: &str = "This connector requires per-conversation authentication. Before calling any other tool, call `authenticate` once with the token supplied in the chat or ChatGPT Project instructions. After authentication, follow the tool response to load the project brief.";
+
 /// The behavioural half of what Codex tells its model, ported from
 /// `codex-rs/core/gpt-5.2-codex_prompt.md`.
 pub const AGENT_BRIEF: &str = concat!(
@@ -75,6 +77,9 @@ fn configured_agent_brief(config: &AppConfig) -> String {
 /// omits project state because ChatGPT's conversation ID arrives on tool calls,
 /// after the MCP initialize exchange.
 pub fn build_initial_instructions(config: &AppConfig) -> String {
+    if config.conversation_auth_token.is_some() {
+        return CONVERSATION_AUTH_INSTRUCTIONS.to_string();
+    }
     if !config.multi_project {
         return build_instructions(config);
     }
@@ -158,4 +163,25 @@ pub fn build_instructions(config: &AppConfig) -> String {
     }
 
     lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversation_auth_initialization_withholds_project_context() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("AGENTS.md"), "private project instruction").unwrap();
+        let mut config = crate::config::default_config(root.path().to_path_buf());
+        config.conversation_auth_token =
+            Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+
+        let initial = build_initial_instructions(&config);
+
+        assert_eq!(initial, CONVERSATION_AUTH_INSTRUCTIONS);
+        assert!(!initial.contains("private project instruction"));
+        assert!(!initial.contains(&root.path().display().to_string()));
+        assert!(build_instructions(&config).contains("private project instruction"));
+    }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -175,7 +175,7 @@ mod tests {
         std::fs::write(root.path().join("AGENTS.md"), "private project instruction").unwrap();
         let mut config = crate::config::default_config(root.path().to_path_buf());
         config.conversation_auth_token =
-            Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+            Some("codex_free_chat_0123456789abcdef0123456789abcdef".into());
 
         let initial = build_initial_instructions(&config);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod bridge;
 pub mod codex_config;
 pub mod codex_mcp;
 pub mod config;
+pub mod conversation_auth;
 pub mod environment;
 pub mod exec_policy;
 pub mod exec_sessions;

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -9,6 +9,9 @@ use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use zeroize::Zeroizing;
 
+use crate::conversation_auth::{
+    conversation_auth_prompt, generate_conversation_auth_token, validate_conversation_auth_token,
+};
 use crate::openai_tunnel::{validate_runtime_api_key, validate_tunnel_id};
 use crate::util::home_dir;
 
@@ -219,6 +222,26 @@ where
 
     let default_connector_name = connector_name_default(&work_dir, multi_project);
     let connector_name = prompt_connector_name(&mut wizard, &default_connector_name)?;
+    let existing_conversation_auth_token = configured_conversation_auth_token(&file_config)?;
+    let conversation_auth_enabled = wizard.confirm(
+        "Require each new ChatGPT conversation to authenticate with a token?",
+        existing_conversation_auth_token.is_some(),
+    )?;
+    let conversation_auth_token = if conversation_auth_enabled {
+        match existing_conversation_auth_token {
+            Some(token)
+                if !wizard.confirm(
+                    "Generate a new conversation token and invalidate the current one after restart?",
+                    false,
+                )? =>
+            {
+                Some(token)
+            }
+            _ => Some(generate_conversation_auth_token()?),
+        }
+    } else {
+        None
+    };
 
     if file_config
         .get("apiKey")
@@ -243,17 +266,36 @@ where
     print_api_key_step(&mut wizard, &key_path)?;
     configure_runtime_key(&mut wizard, &key_path)?;
 
-    merge_tunnel_config(&mut file_config, &tunnel_id, &key_path, multi_project)?;
-    write_config(&config_path, &file_config)?;
+    merge_tunnel_config(
+        &mut file_config,
+        &tunnel_id,
+        &key_path,
+        multi_project,
+        conversation_auth_token.as_deref(),
+    )?;
+    write_config(
+        &config_path,
+        &file_config,
+        conversation_auth_token.is_some(),
+    )?;
 
     writeln!(wizard.output, "\nLocal configuration complete.")?;
     writeln!(wizard.output, "  Config: {}", config_path.display())?;
     writeln!(wizard.output, "  Runtime key: {}", key_path.display())?;
     writeln!(wizard.output, "  Project directory: {}", work_dir.display())?;
+    if conversation_auth_token.is_some() {
+        writeln!(
+            wizard.output,
+            "  Conversation token: stored in the config file; do not commit or share that file"
+        )?;
+    }
     let command = launch_command(&environment.executable, &work_dir, &config_path);
     writeln!(wizard.output, "\nLaunch command:\n  {command}")?;
 
     print_connector_step(&mut wizard, &connector_name, &tunnel_id, multi_project)?;
+    if let Some(token) = conversation_auth_token.as_deref() {
+        print_conversation_auth_step(&mut wizard, token)?;
+    }
     let start_server = wizard.confirm(
         "Start Codex Free now and keep this terminal open while ChatGPT scans the connector?",
         true,
@@ -544,6 +586,27 @@ where
     Ok(())
 }
 
+fn print_conversation_auth_step<R, W, F>(
+    wizard: &mut Wizard<'_, R, W, F>,
+    token: &str,
+) -> anyhow::Result<()>
+where
+    R: BufRead,
+    W: Write,
+    F: FnMut(&str, &mut W) -> io::Result<String>,
+{
+    writeln!(
+        wizard.output,
+        "\n4. Configure ChatGPT conversation authentication"
+    )?;
+    writeln!(
+        wizard.output,
+        "   Paste this instruction into a chat, or add it to the ChatGPT Project's Project instructions:"
+    )?;
+    writeln!(wizard.output, "   {}", conversation_auth_prompt(token))?;
+    Ok(())
+}
+
 fn connector_name_default(work_dir: &Path, multi_project: bool) -> String {
     let suffix = if multi_project {
         "Projects".to_string()
@@ -567,6 +630,22 @@ fn configured_tunnel_id(config: &Map<String, Value>) -> Option<String> {
         .map(str::to_string)
 }
 
+fn configured_conversation_auth_token(
+    config: &Map<String, Value>,
+) -> anyhow::Result<Option<String>> {
+    let Some(value) = config.get("conversationAuthToken") else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let token = value
+        .as_str()
+        .context("conversationAuthToken in the existing config must be a string or null")?;
+    validate_conversation_auth_token(token).map_err(anyhow::Error::msg)?;
+    Ok(Some(token.to_string()))
+}
+
 fn credential_path(home_dir: &Path, tunnel_id: &str) -> PathBuf {
     home_dir
         .join(".codex-free")
@@ -580,6 +659,7 @@ fn merge_tunnel_config(
     tunnel_id: &str,
     key_path: &Path,
     multi_project: bool,
+    conversation_auth_token: Option<&str>,
 ) -> anyhow::Result<()> {
     let tunnel = config
         .entry("openaiTunnel".to_string())
@@ -593,6 +673,17 @@ fn merge_tunnel_config(
         Value::String(format!("file:{}", key_path.display())),
     );
     config.insert("multiProject".to_string(), Value::Bool(multi_project));
+    match conversation_auth_token {
+        Some(token) => {
+            config.insert(
+                "conversationAuthToken".to_string(),
+                Value::String(token.to_string()),
+            );
+        }
+        None => {
+            config.remove("conversationAuthToken");
+        }
+    }
     Ok(())
 }
 
@@ -608,7 +699,11 @@ fn read_config(path: &Path) -> anyhow::Result<Map<String, Value>> {
     }
 }
 
-fn write_config(path: &Path, config: &Map<String, Value>) -> anyhow::Result<()> {
+fn write_config(
+    path: &Path,
+    config: &Map<String, Value>,
+    contains_conversation_token: bool,
+) -> anyhow::Result<()> {
     refuse_symlinked_config(path)?;
     let parent = path
         .parent()
@@ -622,7 +717,11 @@ fn write_config(path: &Path, config: &Map<String, Value>) -> anyhow::Result<()> 
     bytes.push(b'\n');
     temp.write_all(&bytes)?;
     temp.as_file().sync_all()?;
-    preserve_permissions(path, temp.path())?;
+    if contains_conversation_token {
+        make_private(temp.path())?;
+    } else {
+        preserve_permissions(path, temp.path())?;
+    }
     persist_replacing(temp, path)
         .with_context(|| format!("replace config file {}", path.display()))?;
     Ok(())
@@ -766,6 +865,7 @@ mod tests {
 
     const TUNNEL_ID: &str = "tunnel_0123456789abcdef0123456789abcdef";
     const RUNTIME_KEY: &str = "sk-runtime-test-key_123";
+    const CONVERSATION_TOKEN: &str = "codex_free_chat_0123456789abcdef0123456789abcdef";
 
     struct GuardedPromptOutput {
         bytes: Vec<u8>,
@@ -907,7 +1007,7 @@ mod tests {
         let config_path = project.join("codex.config.json");
         let environment = environment(&root, &project);
         let home_dir = environment.home_dir.clone();
-        let input = format!("\n\n\n\n{TUNNEL_ID}\nn\n");
+        let input = format!("\n\n\n\n\n{TUNNEL_ID}\nn\n");
 
         let (result, output) = run_test_wizard(
             args(config_path.clone(), &project),
@@ -925,6 +1025,7 @@ mod tests {
         let config: Value =
             serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
         assert_eq!(config["multiProject"], json!(false));
+        assert!(config.get("conversationAuthToken").is_none());
         assert_eq!(config["openaiTunnel"]["tunnelId"], json!(TUNNEL_ID));
         assert_eq!(
             config["openaiTunnel"]["apiKeyRef"],
@@ -964,6 +1065,41 @@ mod tests {
     }
 
     #[test]
+    fn new_install_can_generate_a_conversation_token_and_project_instruction() {
+        let root = TempDir::new().unwrap();
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        let config_path = project.join("codex.config.json");
+        let environment = environment(&root, &project);
+        let input = format!("\n\n\ny\n\n{TUNNEL_ID}\nn\n");
+
+        let (result, output) = run_test_wizard(
+            args(config_path.clone(), &project),
+            environment,
+            &input,
+            &[RUNTIME_KEY],
+        );
+        result.unwrap();
+
+        let config: Value =
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+        let token = config["conversationAuthToken"].as_str().unwrap();
+        validate_conversation_auth_token(token).unwrap();
+        assert!(output.contains(&conversation_auth_prompt(token)));
+        assert!(output.contains("ChatGPT Project's Project instructions"));
+        assert!(!output.contains(RUNTIME_KEY));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&config_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[test]
     fn rerun_preserves_unrelated_config_and_can_keep_the_stored_key() {
         let root = TempDir::new().unwrap();
         let project = root.path().join("projects");
@@ -974,6 +1110,7 @@ mod tests {
             serde_json::to_vec_pretty(&json!({
                 "apiKey": "legacy-local-token",
                 "multiProject": true,
+                "conversationAuthToken": CONVERSATION_TOKEN,
                 "allowedCommands": ["git"],
                 "openaiTunnel": {
                     "tunnelId": TUNNEL_ID,
@@ -991,7 +1128,7 @@ mod tests {
         let (result, output) = run_test_wizard(
             args(config_path.clone(), &project),
             environment,
-            "\n\n\n\n\n\nn\n",
+            "\n\n\n\n\n\n\n\nn\n",
             &[""],
         );
         let outcome = result.unwrap();
@@ -1003,6 +1140,8 @@ mod tests {
             serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
         assert!(config.get("apiKey").is_none());
         assert_eq!(config["multiProject"], json!(true));
+        assert_eq!(config["conversationAuthToken"], json!(CONVERSATION_TOKEN));
+        assert!(output.contains(&conversation_auth_prompt(CONVERSATION_TOKEN)));
         assert_eq!(config["allowedCommands"], json!(["git"]));
         assert_eq!(
             config["openaiTunnel"]["organizationId"],
@@ -1021,7 +1160,7 @@ mod tests {
         fs::create_dir_all(&project).unwrap();
         let config_path = project.join("codex.config.json");
         let environment = environment(&root, &project);
-        let input = format!("\nn\n\n\ninvalid-tunnel\n{TUNNEL_ID}\nn\n");
+        let input = format!("\nn\n\n\n\ninvalid-tunnel\n{TUNNEL_ID}\nn\n");
         let invalid_key = "not a valid key!";
 
         let (result, output) = run_test_wizard(
@@ -1035,6 +1174,35 @@ mod tests {
         assert!(output.contains("OpenAI tunnel API key is malformed"));
         assert!(!output.contains(invalid_key));
         assert!(!output.contains(RUNTIME_KEY));
+    }
+
+    #[test]
+    fn malformed_existing_conversation_token_fails_before_writing_credentials() {
+        let root = TempDir::new().unwrap();
+        let project = root.path().join("project");
+        fs::create_dir_all(&project).unwrap();
+        let config_path = project.join("codex.config.json");
+        fs::write(
+            &config_path,
+            r#"{"conversationAuthToken":"not valid whitespace"}"#,
+        )
+        .unwrap();
+        let environment = environment(&root, &project);
+        let credentials = environment.home_dir.join(".codex-free");
+
+        let (result, _) = run_test_wizard(
+            args(config_path.clone(), &project),
+            environment,
+            "\n\n\n",
+            &[],
+        );
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("conversationAuthToken"));
+        assert_eq!(
+            fs::read_to_string(config_path).unwrap(),
+            r#"{"conversationAuthToken":"not valid whitespace"}"#
+        );
+        assert!(!credentials.exists());
     }
 
     #[test]

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -10,12 +10,18 @@ use crate::tools;
 use crate::types::{AppConfig, DEFAULT_ARTIFACT_MAX_CONCURRENT_DOWNLOADS};
 
 pub fn load_tools() -> Vec<Box<dyn Tool>> {
-    load_tools_with_options(false, true, DEFAULT_ARTIFACT_MAX_CONCURRENT_DOWNLOADS)
+    load_tools_with_options(
+        false,
+        false,
+        true,
+        DEFAULT_ARTIFACT_MAX_CONCURRENT_DOWNLOADS,
+    )
 }
 
 pub fn load_tools_for_mode(multi_project: bool) -> Vec<Box<dyn Tool>> {
     load_tools_with_options(
         multi_project,
+        false,
         true,
         DEFAULT_ARTIFACT_MAX_CONCURRENT_DOWNLOADS,
     )
@@ -24,6 +30,7 @@ pub fn load_tools_for_mode(multi_project: bool) -> Vec<Box<dyn Tool>> {
 pub fn load_tools_for_config(config: &AppConfig) -> Vec<Box<dyn Tool>> {
     load_tools_with_options(
         config.multi_project,
+        config.conversation_auth_token.is_some(),
         config.artifact_ingress.enabled,
         config.artifact_ingress.max_concurrent_downloads,
     )
@@ -31,10 +38,14 @@ pub fn load_tools_for_config(config: &AppConfig) -> Vec<Box<dyn Tool>> {
 
 fn load_tools_with_options(
     multi_project: bool,
+    conversation_auth: bool,
     artifact_ingress_enabled: bool,
     max_concurrent_downloads: usize,
 ) -> Vec<Box<dyn Tool>> {
     let mut all: Vec<Box<dyn Tool>> = Vec::new();
+    if conversation_auth {
+        all.push(Box::new(tools::authenticate::Authenticate));
+    }
     if multi_project {
         all.push(Box::new(tools::list_projects::ListProjects));
         all.push(Box::new(tools::set_project_root::SetProjectRoot));

--- a/src/server.rs
+++ b/src/server.rs
@@ -981,7 +981,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let mut config = crate::config::default_config(root.path().to_path_buf());
         config.conversation_auth_token =
-            Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+            Some("codex_free_chat_0123456789abcdef0123456789abcdef".into());
         let tools = crate::registry::load_tools_for_config(&config);
         let authorizations = Arc::new(ConversationAuthorizationStore::new());
         let handler = CodexHandler {

--- a/src/server.rs
+++ b/src/server.rs
@@ -35,6 +35,7 @@ use crate::audit::{
     AuditLogger, AuditScope, argument_field_names, summarize_arguments, summarize_output,
 };
 use crate::auth::{generate_internal_bearer_token, require_auth};
+use crate::conversation_auth::{AUTHENTICATE_TOOL_NAME, ConversationAuthorizationStore};
 use crate::exec_sessions::{ConversationExecSessionStore, SessionState};
 use crate::instructions::build_initial_instructions;
 use crate::openai_tunnel::TunnelHealth;
@@ -71,6 +72,7 @@ pub struct CodexHandler {
     config: Arc<AppConfig>,
     tools: Arc<Vec<Box<dyn Tool>>>,
     project_bindings: Arc<ProjectBindingStore>,
+    conversation_authorizations: Arc<ConversationAuthorizationStore>,
     conversation_exec_sessions: Arc<ConversationExecSessionStore>,
     review_checkpoints: Arc<ReviewCheckpointManager>,
     audit: Option<Arc<AuditLogger>>,
@@ -103,6 +105,30 @@ impl CodexHandler {
             &self.config.work_dir,
             project_root.as_deref(),
         )
+    }
+
+    fn conversation_auth_error(
+        &self,
+        tool_name: &str,
+        conversation: Option<&ConversationIdentity>,
+    ) -> Option<ToolResult> {
+        if self.config.conversation_auth_token.is_none()
+            || tool_name == AUTHENTICATE_TOOL_NAME
+            || self
+                .conversation_authorizations
+                .is_authorized(conversation, &self.session)
+        {
+            return None;
+        }
+
+        let scope = if conversation.is_some() {
+            "This ChatGPT conversation"
+        } else {
+            "This MCP transport session"
+        };
+        Some(ToolResult::error(format!(
+            "{scope} is not authorized to use the connector. Call the `authenticate` tool once with the configured conversation token, then retry."
+        )))
     }
 }
 
@@ -218,6 +244,7 @@ impl ServerHandler for CodexHandler {
         let args = request.arguments.map(Value::Object).unwrap_or(Value::Null);
         let tool_context = ToolRequestContext {
             conversation: conversation.clone(),
+            conversation_authorizations: self.conversation_authorizations.clone(),
             review_checkpoints: self.review_checkpoints.clone(),
             cancellation: context.ct.clone(),
         };
@@ -260,106 +287,119 @@ impl ServerHandler for CodexHandler {
             );
         }
 
-        // A ChatGPT conversation gets its own exec-session view (#12); generic MCP
-        // clients fall back to the transport-owned session.
-        let conversation_exec_session = if tool.is_some_and(|t| t.uses_exec_session_state()) {
-            conversation.as_ref().map(|identity| {
-                self.conversation_exec_sessions
-                    .session_for(identity, &self.session)
-            })
-        } else {
-            None
-        };
-        let session = conversation_exec_session.as_ref().unwrap_or(&self.session);
-
         let started = Instant::now();
-        let mut result = match tool {
-            None => ToolResult::error(format!("Unknown tool: {name}")),
-            Some(tool) if name == SetProjectRoot::NAME => {
-                if let Some(identity) = conversation.as_ref() {
-                    select_and_render(&args, |path| async move {
-                        self.project_bindings
-                            .select_project_root(&self.config, identity, &path)
-                            .await
-                    })
-                    .await
-                } else {
-                    tool.call_with_context(args, &self.config, session, &tool_context)
-                        .await
-                }
-            }
-            Some(tool) if tool.requires_project_root() => {
-                let resolved = match conversation.as_ref() {
-                    Some(identity) => self
-                        .project_bindings
-                        .effective_config(&self.config, identity),
-                    None => session.effective_config(&self.config),
-                };
-                match resolved {
-                    Err(error) => ToolResult::error(error),
-                    Ok(effective_config) => {
-                        let owner = match conversation.as_ref() {
-                            Some(identity) => ReviewOwner::conversation(identity),
-                            None => ReviewOwner::transport(self.session.review_state()),
-                        };
-                        if tool.may_modify_project() {
-                            // Fail closed: refuse a mutating tool when the review
-                            // checkpoint cannot be captured. The refusal is returned
-                            // as a value (not an early return) so the audit
-                            // finish_tool below still pairs with begin_tool.
-                            match self
-                                .review_checkpoints
-                                .begin_mutation(&effective_config, owner)
+        let mut result = if let Some(error) =
+            self.conversation_auth_error(&name, conversation.as_ref())
+        {
+            error
+        } else {
+            // A ChatGPT conversation gets its own exec-session view (#12); generic MCP
+            // clients fall back to the transport-owned session.
+            let conversation_exec_session = if tool.is_some_and(|t| t.uses_exec_session_state()) {
+                conversation.as_ref().map(|identity| {
+                    self.conversation_exec_sessions
+                        .session_for(identity, &self.session)
+                })
+            } else {
+                None
+            };
+            let session = conversation_exec_session.as_ref().unwrap_or(&self.session);
+
+            match tool {
+                None => ToolResult::error(format!("Unknown tool: {name}")),
+                Some(tool) if name == SetProjectRoot::NAME => {
+                    if let Some(identity) = conversation.as_ref() {
+                        select_and_render(&args, |path| async move {
+                            self.project_bindings
+                                .select_project_root(&self.config, identity, &path)
                                 .await
-                            {
-                                Ok((availability, guard)) => {
-                                    if let ReviewAvailability::Unavailable(reason) = &availability {
+                        })
+                        .await
+                    } else {
+                        tool.call_with_context(args, &self.config, session, &tool_context)
+                            .await
+                    }
+                }
+                Some(tool) if tool.requires_project_root() => {
+                    let resolved = match conversation.as_ref() {
+                        Some(identity) => self
+                            .project_bindings
+                            .effective_config(&self.config, identity),
+                        None => session.effective_config(&self.config),
+                    };
+                    match resolved {
+                        Err(error) => ToolResult::error(error),
+                        Ok(effective_config) => {
+                            let owner = match conversation.as_ref() {
+                                Some(identity) => ReviewOwner::conversation(identity),
+                                None => ReviewOwner::transport(self.session.review_state()),
+                            };
+                            if tool.may_modify_project() {
+                                // Fail closed: refuse a mutating tool when the review
+                                // checkpoint cannot be captured. The refusal is returned
+                                // as a value (not an early return) so the audit
+                                // finish_tool below still pairs with begin_tool.
+                                match self
+                                    .review_checkpoints
+                                    .begin_mutation(&effective_config, owner)
+                                    .await
+                                {
+                                    Ok((availability, guard)) => {
+                                        if let ReviewAvailability::Unavailable(reason) =
+                                            &availability
+                                        {
+                                            tracing::debug!(
+                                                "review checkpoints unavailable for {name}: {reason}"
+                                            );
+                                        }
+                                        let result = tool
+                                            .call_with_context(
+                                                args,
+                                                &effective_config,
+                                                session,
+                                                &tool_context,
+                                            )
+                                            .await;
+                                        drop(guard);
+                                        result
+                                    }
+                                    Err(error) => ToolResult::error(format!(
+                                        "Refusing to run mutating tool `{name}` because the project review checkpoint could not be captured: {error}"
+                                    )),
+                                }
+                            } else {
+                                match self
+                                    .review_checkpoints
+                                    .ensure_initialized(&effective_config, owner)
+                                    .await
+                                {
+                                    Ok(ReviewAvailability::Ready) => {}
+                                    Ok(ReviewAvailability::Unavailable(reason)) => {
                                         tracing::debug!(
                                             "review checkpoints unavailable for {name}: {reason}"
                                         );
                                     }
-                                    let result = tool
-                                        .call_with_context(
-                                            args,
-                                            &effective_config,
-                                            session,
-                                            &tool_context,
-                                        )
-                                        .await;
-                                    drop(guard);
-                                    result
+                                    Err(error) => {
+                                        tracing::debug!(
+                                            "review checkpoint initialization skipped for {name}: {error}"
+                                        );
+                                    }
                                 }
-                                Err(error) => ToolResult::error(format!(
-                                    "Refusing to run mutating tool `{name}` because the project review checkpoint could not be captured: {error}"
-                                )),
-                            }
-                        } else {
-                            match self
-                                .review_checkpoints
-                                .ensure_initialized(&effective_config, owner)
+                                tool.call_with_context(
+                                    args,
+                                    &effective_config,
+                                    session,
+                                    &tool_context,
+                                )
                                 .await
-                            {
-                                Ok(ReviewAvailability::Ready) => {}
-                                Ok(ReviewAvailability::Unavailable(reason)) => {
-                                    tracing::debug!(
-                                        "review checkpoints unavailable for {name}: {reason}"
-                                    );
-                                }
-                                Err(error) => {
-                                    tracing::debug!(
-                                        "review checkpoint initialization skipped for {name}: {error}"
-                                    );
-                                }
                             }
-                            tool.call_with_context(args, &effective_config, session, &tool_context)
-                                .await
                         }
                     }
                 }
-            }
-            Some(tool) => {
-                tool.call_with_context(args, &self.config, session, &tool_context)
-                    .await
+                Some(tool) => {
+                    tool.call_with_context(args, &self.config, session, &tool_context)
+                        .await
+                }
             }
         };
 
@@ -433,6 +473,8 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     conversation_exec_sessions
         .spawn_idle_reaper(Duration::from_millis(config.exec.idle_timeout_ms));
     let review_checkpoints = Arc::new(ReviewCheckpointManager::new());
+    let conversation_authorizations =
+        Arc::new(ConversationAuthorizationStore::for_current_user(&config));
 
     // Sweep managed worktrees left by conversations that are no longer bound
     // before taking ownership of `config` behind an `Arc`.
@@ -496,6 +538,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     let factory_config = config.clone();
     let factory_tools = tools.clone();
     let factory_project_bindings = project_bindings.clone();
+    let factory_conversation_authorizations = conversation_authorizations.clone();
     let factory_conversation_exec_sessions = conversation_exec_sessions.clone();
     let factory_review_checkpoints = review_checkpoints.clone();
     let factory_audit = audit.clone();
@@ -507,6 +550,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
                 config: factory_config.clone(),
                 tools: factory_tools.clone(),
                 project_bindings: factory_project_bindings.clone(),
+                conversation_authorizations: factory_conversation_authorizations.clone(),
                 conversation_exec_sessions: factory_conversation_exec_sessions.clone(),
                 review_checkpoints: factory_review_checkpoints.clone(),
                 audit: factory_audit.clone(),
@@ -579,6 +623,11 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
         println!("Auth: enabled (bearer token)");
     } else {
         println!("Auth: disabled (no --api-key)");
+    }
+    if config.conversation_auth_token.is_some() {
+        println!("Conversation auth: enabled (one token verification per chat)");
+    } else {
+        println!("Conversation auth: disabled");
     }
     if let Some(audit) = audit.as_ref() {
         println!("Audit log: {}", audit.path().display());
@@ -908,6 +957,7 @@ mod tests {
             config: Arc::new(crate::config::default_config(root.path().to_path_buf())),
             tools: Arc::new(crate::registry::load_tools()),
             project_bindings: Arc::new(ProjectBindingStore::new(root.path().join("bindings"))),
+            conversation_authorizations: Arc::new(ConversationAuthorizationStore::new()),
             conversation_exec_sessions: Arc::new(ConversationExecSessionStore::new()),
             review_checkpoints: Arc::new(ReviewCheckpointManager::new()),
             audit: None,
@@ -923,6 +973,53 @@ mod tests {
                 .is_some_and(|extensions| {
                     extensions.contains_key(review_ui::MCP_APPS_EXTENSION_ID)
                 })
+        );
+    }
+
+    #[test]
+    fn conversation_auth_gate_is_scoped_to_the_stable_chat_identity() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = crate::config::default_config(root.path().to_path_buf());
+        config.conversation_auth_token =
+            Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+        let tools = crate::registry::load_tools_for_config(&config);
+        let authorizations = Arc::new(ConversationAuthorizationStore::new());
+        let handler = CodexHandler {
+            config: Arc::new(config),
+            tools: Arc::new(tools),
+            project_bindings: Arc::new(ProjectBindingStore::new(root.path().join("bindings"))),
+            conversation_authorizations: authorizations.clone(),
+            conversation_exec_sessions: Arc::new(ConversationExecSessionStore::new()),
+            review_checkpoints: Arc::new(ReviewCheckpointManager::new()),
+            audit: None,
+            session: SessionState::new(),
+        };
+        let first = ConversationIdentity::from_openai_session("first-chat").unwrap();
+        let second = ConversationIdentity::from_openai_session("second-chat").unwrap();
+
+        let blocked = handler
+            .conversation_auth_error("read_file", Some(&first))
+            .unwrap();
+        assert!(blocked.is_error);
+        assert!(blocked.joined_text().contains("not authorized"));
+        assert!(
+            handler
+                .conversation_auth_error(AUTHENTICATE_TOOL_NAME, Some(&first))
+                .is_none()
+        );
+
+        authorizations
+            .authorize(Some(&first), &handler.session)
+            .unwrap();
+        assert!(
+            handler
+                .conversation_auth_error("read_file", Some(&first))
+                .is_none()
+        );
+        assert!(
+            handler
+                .conversation_auth_error("read_file", Some(&second))
+                .is_some()
         );
     }
 

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -11,6 +11,7 @@ use rmcp::model::{MetaObject, ToolAnnotations};
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 
+use crate::conversation_auth::ConversationAuthorizationStore;
 use crate::exec_sessions::SessionState;
 use crate::project_bindings::ConversationIdentity;
 use crate::review::ReviewCheckpointManager;
@@ -19,6 +20,7 @@ use crate::types::{AppConfig, ToolResult};
 #[derive(Clone)]
 pub struct ToolRequestContext {
     pub conversation: Option<ConversationIdentity>,
+    pub conversation_authorizations: Arc<ConversationAuthorizationStore>,
     pub review_checkpoints: Arc<ReviewCheckpointManager>,
     /// Cancelled when the transport drops or a per-call deadline (e.g. the
     /// artifact-ingress idle timeout) fires, so long-running tools can abort.

--- a/src/tools/authenticate.rs
+++ b/src/tools/authenticate.rs
@@ -1,0 +1,197 @@
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::conversation_auth::{
+    AUTHENTICATE_TOOL_NAME, MAX_CONVERSATION_AUTH_TOKEN_BYTES, MIN_CONVERSATION_AUTH_TOKEN_BYTES,
+    conversation_auth_tokens_match, validate_conversation_auth_token,
+};
+use crate::exec_sessions::SessionState;
+use crate::tool::{Tool, ToolRequestContext, arg_str};
+use crate::types::{AppConfig, ToolResult};
+
+pub struct Authenticate;
+
+#[async_trait]
+impl Tool for Authenticate {
+    fn name(&self) -> &'static str {
+        AUTHENTICATE_TOOL_NAME
+    }
+
+    fn description(&self) -> String {
+        "Authorize this ChatGPT conversation to use the connector. Call once with the token supplied by the user or in ChatGPT Project instructions. After verification, only the authorization decision is cached; the submitted token is not retained.".into()
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "description": "The connector conversation-authentication token.",
+                    "minLength": MIN_CONVERSATION_AUTH_TOKEN_BYTES,
+                    "maxLength": MAX_CONVERSATION_AUTH_TOKEN_BYTES,
+                    "pattern": "^[A-Za-z0-9_-]+$",
+                    "writeOnly": true
+                }
+            },
+            "required": ["token"],
+            "additionalProperties": false
+        })
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "content": { "type": "string" }
+            },
+            "required": ["content"],
+            "additionalProperties": false
+        }))
+    }
+
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, _args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
+        ToolResult::error("Authentication requires request metadata.")
+    }
+
+    async fn call_with_context(
+        &self,
+        args: Value,
+        config: &AppConfig,
+        session: &SessionState,
+        context: &ToolRequestContext,
+    ) -> ToolResult {
+        let Some(expected) = config.conversation_auth_token.as_deref() else {
+            return ToolResult::error("Conversation authentication is not enabled.");
+        };
+        let Some(provided) = arg_str(&args, "token") else {
+            return ToolResult::error("Authentication failed.");
+        };
+        if validate_conversation_auth_token(provided).is_err()
+            || !conversation_auth_tokens_match(expected, provided)
+        {
+            return ToolResult::error("Authentication failed.");
+        }
+
+        let scope = context
+            .conversation_authorizations
+            .authorize(context.conversation.as_ref(), session)
+            .map_err(ToolResult::error);
+        let scope = match scope {
+            Ok(scope) => scope,
+            Err(error) => return error,
+        };
+        let next_step = if config.multi_project {
+            "Select the project for this conversation, then call `get_agent_brief`."
+        } else {
+            "Call `get_agent_brief` before using project tools."
+        };
+        ToolResult::text(format!(
+            "Authentication succeeded for {}. {next_step}",
+            scope.description()
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::config::default_config;
+    use crate::conversation_auth::ConversationAuthorizationStore;
+    use crate::project_bindings::ConversationIdentity;
+    use crate::review::ReviewCheckpointManager;
+
+    fn context(
+        identity: Option<ConversationIdentity>,
+        authorizations: Arc<ConversationAuthorizationStore>,
+    ) -> ToolRequestContext {
+        ToolRequestContext {
+            conversation: identity,
+            conversation_authorizations: authorizations,
+            review_checkpoints: Arc::new(ReviewCheckpointManager::new()),
+            cancellation: tokio_util::sync::CancellationToken::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_token_authorizes_only_the_current_conversation() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = default_config(root.path().to_path_buf());
+        let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
+        config.conversation_auth_token = Some(token.to_string());
+        let store = Arc::new(ConversationAuthorizationStore::new());
+        let session = SessionState::new();
+        let first = ConversationIdentity::from_openai_session("first").unwrap();
+        let second = ConversationIdentity::from_openai_session("second").unwrap();
+        let request_context = context(Some(first.clone()), store.clone());
+
+        let result = Authenticate
+            .call_with_context(
+                json!({ "token": token }),
+                &config,
+                &session,
+                &request_context,
+            )
+            .await;
+
+        assert!(!result.is_error);
+        assert!(store.is_authorized(Some(&first), &session));
+        assert!(!store.is_authorized(Some(&second), &session));
+    }
+
+    #[tokio::test]
+    async fn invalid_token_does_not_authorize_or_echo_the_value() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = default_config(root.path().to_path_buf());
+        config.conversation_auth_token =
+            Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+        let store = Arc::new(ConversationAuthorizationStore::new());
+        let session = SessionState::new();
+        let identity = ConversationIdentity::from_openai_session("first").unwrap();
+        let request_context = context(Some(identity.clone()), store.clone());
+        let invalid = "codex_free_chat_invalid-invalid-invalid-invalid";
+
+        let result = Authenticate
+            .call_with_context(
+                json!({ "token": invalid }),
+                &config,
+                &session,
+                &request_context,
+            )
+            .await;
+
+        assert!(result.is_error);
+        assert!(!result.joined_text().contains(invalid));
+        assert!(!store.is_authorized(Some(&identity), &session));
+    }
+
+    #[tokio::test]
+    async fn clients_without_conversation_metadata_use_transport_scope() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = default_config(root.path().to_path_buf());
+        let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
+        config.conversation_auth_token = Some(token.to_string());
+        let store = Arc::new(ConversationAuthorizationStore::new());
+        let first_session = SessionState::new();
+        let second_session = SessionState::new();
+        let request_context = context(None, store.clone());
+
+        Authenticate
+            .call_with_context(
+                json!({ "token": token }),
+                &config,
+                &first_session,
+                &request_context,
+            )
+            .await;
+
+        assert!(store.is_authorized(None, &first_session));
+        assert!(!store.is_authorized(None, &second_session));
+    }
+}

--- a/src/tools/authenticate.rs
+++ b/src/tools/authenticate.rs
@@ -124,7 +124,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let mut config = default_config(root.path().to_path_buf());
         let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
-        config.conversation_auth_token = Some(token.to_string());
+        config.conversation_auth_token = Some(token.into());
         let store = Arc::new(ConversationAuthorizationStore::new());
         let session = SessionState::new();
         let first = ConversationIdentity::from_openai_session("first").unwrap();
@@ -150,7 +150,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let mut config = default_config(root.path().to_path_buf());
         config.conversation_auth_token =
-            Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+            Some("codex_free_chat_0123456789abcdef0123456789abcdef".into());
         let store = Arc::new(ConversationAuthorizationStore::new());
         let session = SessionState::new();
         let identity = ConversationIdentity::from_openai_session("first").unwrap();
@@ -176,7 +176,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let mut config = default_config(root.path().to_path_buf());
         let token = "codex_free_chat_0123456789abcdef0123456789abcdef";
-        config.conversation_auth_token = Some(token.to_string());
+        config.conversation_auth_token = Some(token.into());
         let store = Arc::new(ConversationAuthorizationStore::new());
         let first_session = SessionState::new();
         let second_session = SessionState::new();

--- a/src/tools/import_host_file.rs
+++ b/src/tools/import_host_file.rs
@@ -277,6 +277,9 @@ mod tests {
         cancellation.cancel();
         let context = ToolRequestContext {
             conversation: None,
+            conversation_authorizations: Arc::new(
+                crate::conversation_auth::ConversationAuthorizationStore::new(),
+            ),
             review_checkpoints: Arc::new(crate::review::ReviewCheckpointManager::new()),
             cancellation,
         };

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -1,6 +1,7 @@
 //! Tool implementations. Each file is one Codex-style MCP tool.
 
 pub mod apply_patch;
+pub mod authenticate;
 pub mod clock_curr_time;
 pub mod clock_sleep;
 pub mod exec_command;

--- a/src/types.rs
+++ b/src/types.rs
@@ -548,6 +548,7 @@ pub struct AppConfig {
     pub project_catalog: ProjectCatalogConfig,
     pub worktrees: WorktreeConfig,
     pub api_key: Option<String>,
+    pub conversation_auth_token: Option<String>,
     pub port: u16,
     pub allowed_commands: Vec<String>,
     pub tree: TreeConfig,

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,8 +4,12 @@
 //! are kept camelCase on the wire (`allowedCommands`, `maxSessions`, …) via
 //! serde renames so an existing `codex.config.json` keeps parsing unchanged.
 
+use std::fmt;
+use std::ops::Deref;
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use zeroize::Zeroize;
 
 // ─── Tool results ──────────────────────────────────────────────────────
 
@@ -140,6 +144,47 @@ pub struct PlanState {
 }
 
 // ─── Config ────────────────────────────────────────────────────────────
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct ConversationAuthToken(String);
+
+impl From<String> for ConversationAuthToken {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for ConversationAuthToken {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl Deref for ConversationAuthToken {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<str> for ConversationAuthToken {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for ConversationAuthToken {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("<redacted>")
+    }
+}
+
+impl Drop for ConversationAuthToken {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -548,7 +593,7 @@ pub struct AppConfig {
     pub project_catalog: ProjectCatalogConfig,
     pub worktrees: WorktreeConfig,
     pub api_key: Option<String>,
-    pub conversation_auth_token: Option<String>,
+    pub conversation_auth_token: Option<ConversationAuthToken>,
     pub port: u16,
     pub allowed_commands: Vec<String>,
     pub tree: TreeConfig,

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -54,7 +54,7 @@ fn artifact_ingress_can_be_omitted_by_configuration() {
 fn conversation_auth_mode_adds_authenticate_before_protected_tools() {
     let mut config = default_config(PathBuf::from("/tmp"));
     config.conversation_auth_token =
-        Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+        Some("codex_free_chat_0123456789abcdef0123456789abcdef".into());
     let tools = load_tools_for_config(&config);
     assert_eq!(tools.len(), 28);
     assert_eq!(tools[0].name(), "authenticate");

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -51,6 +51,23 @@ fn artifact_ingress_can_be_omitted_by_configuration() {
 }
 
 #[test]
+fn conversation_auth_mode_adds_authenticate_before_protected_tools() {
+    let mut config = default_config(PathBuf::from("/tmp"));
+    config.conversation_auth_token =
+        Some("codex_free_chat_0123456789abcdef0123456789abcdef".to_string());
+    let tools = load_tools_for_config(&config);
+    assert_eq!(tools.len(), 28);
+    assert_eq!(tools[0].name(), "authenticate");
+
+    config.multi_project = true;
+    let tools = load_tools_for_config(&config);
+    assert_eq!(tools.len(), 30);
+    assert_eq!(tools[0].name(), "authenticate");
+    assert_eq!(tools[1].name(), "list_projects");
+    assert_eq!(tools[2].name(), "set_project_root");
+}
+
+#[test]
 fn all_tools_have_unique_names() {
     let tools = load_tools();
     let mut names: Vec<&str> = tools.iter().map(|t| t.name()).collect();


### PR DESCRIPTION
## Goal

This PR adds an **explicit per-ChatGPT-conversation admission gate** for the connector.

Once a connector is enabled in ChatGPT, it may be available to conversations other than the ones where the user actually intends to grant access to the local machine. The purpose of this feature is to make the connector unusable from a new conversation unless that conversation has been intentionally provisioned with a token.

With the option enabled:

- a new ChatGPT conversation can see the authentication operation, but cannot use any other connector capability;
- the conversation must provide the operator-generated token once to prove that it is allowed to use the connector;
- after successful verification, only the fact that this particular conversation is allowed is cached;
- another conversation remains blocked until it independently provides the token.

This is conversation-level admission control, not a replacement for tunnel, HTTP, operating-system, or ChatGPT workspace security.

## Intended user workflow

1. During `codex-free quickstart`, enable conversation authentication.
2. Codex Free generates a 256-bit random token and persists it as `conversationAuthToken` in the normal JSON config.
3. Quickstart prints this short instruction with the real token substituted:

   > To use this connector in a chat, call its `authenticate` tool once with token `[TOKEN]`.

4. Authorize conversations in either of two ways:
   - paste the instruction into one specific chat for one-off access; or
   - place it in a ChatGPT Web Project's [Project instructions](https://help.openai.com/en/articles/10169521-projects-in-chatgpt), so new conversations created inside that ChatGPT Project can authenticate automatically.
5. On the first connector use, the conversation calls `authenticate`. Once accepted, later tool calls in that same conversation do not resend or retain the token.

Here, **ChatGPT Project** means the project feature in ChatGPT Web. It is unrelated to Codex projects, codex-free project roots, `multiProject`, `list_projects`, or `set_project_root`.

## Authorization semantics

- `authenticate` is the only operation available before authorization.
- The gate is enforced at the central tool-dispatch boundary, covering native tools, bridged tools, gateway tools, project selection, command execution, and tools registered in the future.
- ChatGPT's stable `openai/session` request metadata identifies the conversation. The server hashes that identity and uses it to look up a server-managed authorization marker.
- The submitted token is used only for verification. It is **not** written into conversation metadata or the authorization cache.
- The cached marker contains only the authorization decision, so the same conversation remains authorized across connector transport replacement and Codex Free restarts.
- Authorization does not cross conversation identities.
- Rotating `conversationAuthToken` selects a new authorization namespace and invalidates grants made with the previous token.
- MCP clients without stable conversation metadata receive only a transport-session grant, which does not survive reconnecting.

The implementation deliberately does not trust client-controlled metadata as an authorization flag. Stable metadata identifies the conversation; the authorization decision remains server-managed.

## Configuration and secret handling

The feature is opt-in. Without `conversationAuthToken`, the connector retains its existing behavior and tool surface.

When enabled, quickstart:

- generates the token with a cryptographically secure random source;
- preserves an existing token unless the user explicitly chooses to rotate it;
- persists the token in the selected config file;
- restricts that config to mode `0600` on Unix;
- prints the copyable one-line ChatGPT instruction.

The resolved token is held in a redacted, zeroizing config type. Authentication failures do not echo either token, and the configured value is redacted from debug formatting and optional audit command previews. Persistent authorization markers contain neither the plaintext token nor the raw ChatGPT conversation identifier.

A token intentionally placed in ChatGPT Project instructions is available to conversations in that ChatGPT Project by design. The security objective is to separate explicitly provisioned chats or projects from unrelated new conversations, not to conceal the token from chats that are meant to receive it.

## Implementation outline

- Add the optional `conversationAuthToken` configuration field.
- Extend quickstart with token generation, persistence, safe rotation behavior, and prompt output.
- Add the conditional `authenticate` tool.
- Add a shared `ConversationAuthorizationStore` keyed by the hashed stable conversation identity.
- Gate all non-authentication tools centrally before project resolution or tool dispatch.
- Withhold the project-aware initialization brief until authentication succeeds.
- Preserve the existing transport-session fallback for MCP clients without `openai/session`.
- Document the workflow and clearly distinguish ChatGPT Web Projects from codex-free project selection.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` — all 548 tests passed after rebasing onto current upstream `master`
- `git diff --check origin/master...HEAD`

Coverage includes disabled mode, unauthenticated protected calls, wrong and correct tokens, same-conversation reuse, cross-conversation isolation, transport fallback, restart persistence, token rotation, marker integrity and permissions, config/debug/audit redaction, quickstart persistence and prompt output, and pre-authentication availability of only the authentication operation.
