### PR TITLE
fix: bad merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Codex CLI enrichment now imports plugin-provided Streamable HTTP MCP servers,
+  including environment-backed bearer authentication, static and environment
+  headers, tool filters, and startup/tool timeouts. Transport-specific fields
+  remain fail-closed, and literal bearer tokens are still rejected.
+- `import_host_file` now participates in the same fail-closed, serialized review
+  checkpoint protocol as every other project-writing tool, so imports cannot race
+  review capture or proceed after a checkpoint-capture failure.
+
+### Security
+
+- Generic MCP transport-session project bindings now revalidate the complete
+  direct-checkout or managed-worktree relationship on every project tool call.
+  A moved, replaced, or internally inconsistent active root cannot escape its
+  selected source or recorded managed-worktree boundary.
+
 ## [1.4.0] - 2026-08-25
 
 ### Fixed

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -700,6 +700,34 @@ mod tests {
     }
 
     #[test]
+    fn native_file_audit_summary_never_contains_capability_values() {
+        let arguments = json!({
+            "file": {
+                "download_url": "https://files.oaiusercontent.com/object?signature=secret-capability",
+                "file_id": "file_sensitive_identifier",
+                "mime_type": "application/octet-stream",
+                "file_name": "input.bin"
+            },
+            "path": "fixtures/private-input.bin"
+        });
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "file": { "type": "object" },
+                "path": { "type": "string" }
+            }
+        });
+
+        let summary = summarize_arguments(&arguments, Some(&schema)).to_string();
+        assert!(!summary.contains("secret-capability"));
+        assert!(!summary.contains("file_sensitive_identifier"));
+        assert!(!summary.contains("private-input.bin"));
+        assert!(!summary.contains("input.bin"));
+        assert!(summary.contains("\"file\""));
+        assert!(summary.contains("\"path\""));
+    }
+
+    #[test]
     fn argument_summary_omits_unknown_and_sensitive_nested_field_names() {
         let arguments = json!({
             "known": true,

--- a/src/codex_mcp.rs
+++ b/src/codex_mcp.rs
@@ -41,6 +41,10 @@ struct CodexCliServer {
     enabled_tools: Option<Vec<String>>,
     #[serde(default)]
     disabled_tools: Option<Vec<String>>,
+    #[serde(default)]
+    startup_timeout_sec: Option<f64>,
+    #[serde(default)]
+    tool_timeout_sec: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -57,6 +61,18 @@ struct CodexCliTransport {
     env_vars: Option<Vec<CodexCliEnvVar>>,
     #[serde(default)]
     cwd: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    bearer_token: Option<String>,
+    #[serde(default)]
+    bearer_token_env_var: Option<String>,
+    #[serde(default)]
+    http_headers: Option<HashMap<String, String>>,
+    #[serde(default)]
+    env_http_headers: Option<HashMap<String, String>>,
+    #[serde(default)]
+    http_headers_helper: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -281,14 +297,66 @@ fn codex_cli_server_to_spec(
     env_lookup: &dyn Fn(&str) -> Option<String>,
 ) -> Result<McpServerSpec, String> {
     let kind = server.transport.kind.to_ascii_lowercase();
+    let startup_timeout_sec =
+        validate_cli_timeout("startup_timeout_sec", server.startup_timeout_sec)?;
+    let tool_timeout_sec = validate_cli_timeout("tool_timeout_sec", server.tool_timeout_sec)?;
+
     if matches!(
         kind.as_str(),
-        "http" | "sse" | "streamable-http" | "streamable_http" | "websocket" | "ws"
+        "http" | "streamable-http" | "streamable_http"
     ) {
-        return Err("streamable HTTP transport is not supported yet".to_string());
+        let Some(url) = server.transport.url.filter(|url| !url.trim().is_empty()) else {
+            return Err("no non-empty Streamable HTTP `url` is configured".to_string());
+        };
+        if server.transport.command.is_some()
+            || server.transport.args.is_some()
+            || server.transport.env.is_some()
+            || server.transport.env_vars.is_some()
+            || server.transport.cwd.is_some()
+        {
+            return Err("streamable HTTP transport contains stdio-only fields".to_string());
+        }
+        if server.transport.bearer_token.is_some() {
+            return Err(
+                "literal bearer tokens are rejected; use `bearer_token_env_var`".to_string(),
+            );
+        }
+        if server.transport.http_headers_helper.is_some() {
+            return Err("`http_headers_helper` is not supported".to_string());
+        }
+
+        return Ok(McpServerSpec {
+            command: None,
+            args: Vec::new(),
+            env: HashMap::new(),
+            cwd: None,
+            disabled: !server.enabled,
+            transport: Some("streamable-http".to_string()),
+            url: Some(url),
+            bearer_token_env_var: server.transport.bearer_token_env_var,
+            http_headers: server.transport.http_headers.unwrap_or_default(),
+            env_http_headers: server.transport.env_http_headers.unwrap_or_default(),
+            startup_timeout_sec,
+            tool_timeout_sec,
+            tools: server.enabled_tools,
+            disabled_tools: server.disabled_tools,
+            mode: None,
+        });
+    }
+    if matches!(kind.as_str(), "sse" | "websocket" | "ws") {
+        return Err(format!("unsupported transport type `{kind}`"));
     }
     if kind != "stdio" {
         return Err(format!("unsupported transport type `{kind}`"));
+    }
+    if server.transport.url.is_some()
+        || server.transport.bearer_token.is_some()
+        || server.transport.bearer_token_env_var.is_some()
+        || server.transport.http_headers.is_some()
+        || server.transport.env_http_headers.is_some()
+        || server.transport.http_headers_helper.is_some()
+    {
+        return Err("stdio transport contains HTTP-only fields".to_string());
     }
 
     let Some(command) = server
@@ -331,14 +399,21 @@ fn codex_cli_server_to_spec(
         transport: None,
         url: None,
         bearer_token_env_var: None,
-        http_headers: std::collections::HashMap::new(),
-        env_http_headers: std::collections::HashMap::new(),
-        startup_timeout_sec: None,
-        tool_timeout_sec: None,
+        http_headers: HashMap::new(),
+        env_http_headers: HashMap::new(),
+        startup_timeout_sec,
+        tool_timeout_sec,
         tools: server.enabled_tools,
         disabled_tools: server.disabled_tools,
         mode: None,
     })
+}
+
+fn validate_cli_timeout(key: &str, timeout: Option<f64>) -> Result<Option<f64>, String> {
+    if timeout.is_some_and(|value| !value.is_finite() || value < 0.0) {
+        return Err(format!("`{key}` must be a non-negative finite number"));
+    }
+    Ok(timeout)
 }
 
 pub fn discover_codex_mcp_servers(path: &Path) -> Result<Option<CodexMcpImport>, String> {
@@ -910,7 +985,9 @@ command = "good-server"
                 "cwd":"/plugins/example"
             },
             "enabled_tools":["read","write"],
-            "disabled_tools":["write"]
+            "disabled_tools":["write"],
+            "startup_timeout_sec":4,
+            "tool_timeout_sec":9.5
         }"#;
         let mut calls = 0;
         let outcome = {
@@ -960,10 +1037,125 @@ command = "good-server"
             plugin.env.get("SECOND_TOKEN").map(String::as_str),
             Some("secret-two")
         );
+        assert_eq!(plugin.startup_timeout_sec, Some(4.0));
+        assert_eq!(plugin.tool_timeout_sec, Some(9.5));
         let report = outcome.report.join("\n");
         assert!(report.contains("plugin -> imported from Codex CLI"));
         assert!(!report.contains("secret-one"));
         assert!(!report.contains("secret-two"));
+    }
+
+    #[test]
+    fn cli_imports_streamable_http_servers_with_auth_headers_and_timeouts() {
+        let list = br#"[{"name":"plugin-web"}]"#;
+        let get = br#"{
+            "name":"plugin-web",
+            "enabled":true,
+            "transport":{
+                "type":"streamable_http",
+                "url":"https://example.invalid/mcp",
+                "bearer_token_env_var":"WEB_TOKEN",
+                "http_headers":{"X-Static":"public"},
+                "env_http_headers":{"X-Tenant":"WEB_TENANT"},
+                "http_headers_helper":null
+            },
+            "enabled_tools":["read"],
+            "disabled_tools":null,
+            "startup_timeout_sec":12,
+            "tool_timeout_sec":34.5
+        }"#;
+        let mut runner = |args: &[OsString]| match args.get(1).and_then(|value| value.to_str()) {
+            Some("list") => Ok(list.to_vec()),
+            Some("get") => Ok(get.to_vec()),
+            other => panic!("unexpected Codex CLI operation: {other:?}"),
+        };
+
+        let outcome = discover_additional_codex_mcp_servers_with_runner(
+            &HashMap::new(),
+            &|_| None,
+            &mut runner,
+        )
+        .unwrap();
+        let server = outcome.servers.get("plugin-web").unwrap();
+        assert_eq!(server.transport.as_deref(), Some("streamable-http"));
+        assert_eq!(server.url.as_deref(), Some("https://example.invalid/mcp"));
+        assert_eq!(server.bearer_token_env_var.as_deref(), Some("WEB_TOKEN"));
+        assert_eq!(
+            server.http_headers.get("X-Static").map(String::as_str),
+            Some("public")
+        );
+        assert_eq!(
+            server.env_http_headers.get("X-Tenant").map(String::as_str),
+            Some("WEB_TENANT")
+        );
+        assert_eq!(server.startup_timeout_sec, Some(12.0));
+        assert_eq!(server.tool_timeout_sec, Some(34.5));
+        assert_eq!(
+            server.tools.as_deref(),
+            Some(["read".to_string()].as_slice())
+        );
+    }
+
+    #[test]
+    fn cli_rejects_unsafe_or_mixed_transport_configuration_without_echoing_secrets() {
+        let secret = "literal-cli-secret";
+        let literal: CodexCliServer = serde_json::from_value(serde_json::json!({
+            "name": "literal",
+            "transport": {
+                "type": "http",
+                "url": "https://example.invalid/mcp",
+                "bearer_token": secret
+            }
+        }))
+        .unwrap();
+        let error = codex_cli_server_to_spec(literal, &|_| None).unwrap_err();
+        assert!(error.contains("literal bearer tokens are rejected"));
+        assert!(!error.contains(secret));
+
+        let mixed: CodexCliServer = serde_json::from_value(serde_json::json!({
+            "name": "mixed",
+            "transport": {
+                "type": "streamable-http",
+                "url": "https://example.invalid/mcp",
+                "command": "should-not-run"
+            }
+        }))
+        .unwrap();
+        assert!(
+            codex_cli_server_to_spec(mixed, &|_| None)
+                .unwrap_err()
+                .contains("stdio-only fields")
+        );
+
+        let helper: CodexCliServer = serde_json::from_value(serde_json::json!({
+            "name": "helper",
+            "transport": {
+                "type": "streamable_http",
+                "url": "https://example.invalid/mcp",
+                "http_headers_helper": "<redacted>"
+            }
+        }))
+        .unwrap();
+        assert!(
+            codex_cli_server_to_spec(helper, &|_| None)
+                .unwrap_err()
+                .contains("http_headers_helper")
+        );
+
+        let negative_timeout: CodexCliServer = serde_json::from_value(serde_json::json!({
+            "name": "negative-timeout",
+            "transport": {
+                "type": "stdio",
+                "command": "server"
+            },
+            "tool_timeout_sec": -1
+        }))
+        .unwrap();
+        assert!(
+            codex_cli_server_to_spec(negative_timeout, &|_| None)
+                .unwrap_err()
+                .contains("non-negative finite number")
+        );
     }
 
     #[test]

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -6,7 +6,7 @@
 //! as the default, so the default path matches — only `tty: true` is unsupported.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::{Duration, Instant};
@@ -22,7 +22,7 @@ use crate::project_bindings::{
 };
 use crate::review::TransportReviewState;
 use crate::types::{AppConfig, PlanState, WorktreeMode};
-use crate::worktrees::create_managed_worktree;
+use crate::worktrees::{create_managed_worktree, load_metadata, metadata_path_for_worktree};
 
 // Codex constants (shell_spec.rs). Kept as code, not config, because they are
 // part of matching Codex's tool semantics rather than local policy.
@@ -591,6 +591,29 @@ struct TransportProjectBinding {
     worktrees_root: Option<PathBuf>,
 }
 
+fn validate_transport_metadata_path(
+    stored: &str,
+    expected: &Path,
+    label: &str,
+    metadata_path: &Path,
+) -> Result<(), String> {
+    let stored_path = PathBuf::from(stored);
+    let canonical = std::fs::canonicalize(&stored_path).map_err(|error| {
+        format!(
+            "The {label} recorded in managed-worktree metadata {} cannot be resolved: {}: {error}. Open a new session for another project.",
+            metadata_path.display(),
+            stored_path.display()
+        )
+    })?;
+    if canonical != expected {
+        return Err(format!(
+            "The {label} recorded in managed-worktree metadata {} does not match the MCP transport-session binding. Open a new session for another project.",
+            metadata_path.display()
+        ));
+    }
+    Ok(())
+}
+
 impl Default for SessionState {
     fn default() -> Self {
         Self {
@@ -668,34 +691,109 @@ impl SessionState {
                 config.work_dir.display()
             )
         })?;
-        // The originally selected source must still resolve inside the access
-        // root; this catches a project deleted, moved, or replaced since it was
-        // bound. A managed worktree lives outside the access root by design, so
-        // this containment check is applied to the source selection, not the
-        // effective work directory below.
-        let source_root = std::fs::canonicalize(&binding.source_project_root).map_err(|error| {
+        let source_project_root =
+            std::fs::canonicalize(&binding.source_project_root).map_err(|error| {
             format!(
-                "The project bound to this MCP transport session no longer exists or cannot be resolved: {}: {error}. Open a new session for another project.",
+                "The source project bound to this MCP transport session no longer exists or cannot be resolved: {}: {error}. Open a new session for another project.",
                 binding.source_project_root.display()
             )
         })?;
-        if source_root != access_root && !source_root.starts_with(&access_root) {
+        if !source_project_root.is_dir() {
             return Err(format!(
-                "The project bound to this MCP transport session now resolves outside the configured access root: {}. Open a new session for another project.",
-                source_root.display()
+                "The source project bound to this MCP transport session is no longer a directory: {}. Open a new session for another project.",
+                source_project_root.display()
             ));
         }
-        // The effective work directory (the source itself, or a managed
-        // worktree created under the worktrees root) must still be a directory.
+        if source_project_root != access_root && !source_project_root.starts_with(&access_root) {
+            return Err(format!(
+                "The source project bound to this MCP transport session now resolves outside the configured access root: {}. Open a new session for another project.",
+                source_project_root.display()
+            ));
+        }
+
         let project_root = std::fs::canonicalize(&binding.project_root).map_err(|error| {
             format!(
-                "The working directory bound to this MCP transport session no longer exists or cannot be resolved: {}: {error}. Open a new session for another project.",
+                "The active project bound to this MCP transport session no longer exists or cannot be resolved: {}: {error}. Open a new session for another project.",
                 binding.project_root.display()
             )
         })?;
         if !project_root.is_dir() {
             return Err(format!(
-                "The working directory bound to this MCP transport session is no longer a directory: {}. Open a new session for another project.",
+                "The active project bound to this MCP transport session is no longer a directory: {}. Open a new session for another project.",
+                project_root.display()
+            ));
+        }
+        if binding.managed_worktree {
+            let worktree_git_root = binding.worktree_git_root.as_ref().ok_or_else(|| {
+                "The managed worktree bound to this MCP transport session has no recorded Git root. Open a new session for another project.".to_string()
+            })?;
+            let worktrees_root = binding.worktrees_root.as_ref().ok_or_else(|| {
+                "The managed worktree bound to this MCP transport session has no recorded worktree root. Open a new session for another project.".to_string()
+            })?;
+            let worktree_git_root = std::fs::canonicalize(worktree_git_root).map_err(|error| {
+                format!(
+                    "The managed worktree Git root bound to this MCP transport session no longer exists or cannot be resolved: {}: {error}. Open a new session for another project.",
+                    worktree_git_root.display()
+                )
+            })?;
+            let worktrees_root = std::fs::canonicalize(worktrees_root).map_err(|error| {
+                format!(
+                    "The managed worktree root bound to this MCP transport session no longer exists or cannot be resolved: {}: {error}. Open a new session for another project.",
+                    worktrees_root.display()
+                )
+            })?;
+            if worktree_git_root == worktrees_root
+                || !worktree_git_root.starts_with(&worktrees_root)
+            {
+                return Err(format!(
+                    "The managed worktree Git root {} is outside its recorded worktree root {}. Open a new session for another project.",
+                    worktree_git_root.display(),
+                    worktrees_root.display()
+                ));
+            }
+            if project_root != worktree_git_root && !project_root.starts_with(&worktree_git_root) {
+                return Err(format!(
+                    "The active project {} is outside its managed worktree Git root {}. Open a new session for another project.",
+                    project_root.display(),
+                    worktree_git_root.display()
+                ));
+            }
+
+            let metadata_path = metadata_path_for_worktree(&worktree_git_root).ok_or_else(|| {
+                format!(
+                    "Could not locate managed-worktree metadata for {}. Open a new session for another project.",
+                    worktree_git_root.display()
+                )
+            })?;
+            let metadata = load_metadata(&metadata_path)?;
+            validate_transport_metadata_path(
+                &metadata.source_project_root,
+                &source_project_root,
+                "source project root",
+                &metadata_path,
+            )?;
+            validate_transport_metadata_path(
+                &metadata.project_root,
+                &project_root,
+                "active project root",
+                &metadata_path,
+            )?;
+            validate_transport_metadata_path(
+                &metadata.worktree_git_root,
+                &worktree_git_root,
+                "worktree Git root",
+                &metadata_path,
+            )?;
+            validate_transport_metadata_path(
+                &metadata.worktrees_root,
+                &worktrees_root,
+                "worktree root",
+                &metadata_path,
+            )?;
+        } else if project_root != source_project_root {
+            return Err(format!(
+                "The direct project binding for this MCP transport session now resolves inconsistently: source {} versus active {}. Open a new session for another project.",
+                source_project_root.display(),
                 project_root.display()
             ));
         }
@@ -1031,6 +1129,79 @@ mod tests {
     fn wrap_only_powershell() {
         assert_eq!(wrap_for_shell("ls", "bash"), "ls");
         assert!(wrap_for_shell("ls", "powershell").contains("$LASTEXITCODE"));
+    }
+
+    #[test]
+    fn direct_transport_binding_rejects_an_active_root_different_from_its_source() {
+        let access = tempfile::tempdir().unwrap();
+        let source = access.path().join("project");
+        std::fs::create_dir(&source).unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let mut config = crate::config::default_config(access.path().to_path_buf());
+        config.multi_project = true;
+        let state = SessionState::new();
+        *state.project_binding.lock().unwrap() = Some(TransportProjectBinding {
+            source_project_root: source,
+            project_root: outside.path().to_path_buf(),
+            managed_worktree: false,
+            worktree_git_root: None,
+            worktrees_root: None,
+        });
+
+        let error = state.effective_config(&config).unwrap_err();
+        assert!(error.contains("direct project binding"), "{error}");
+    }
+
+    #[test]
+    fn managed_transport_binding_rejects_a_git_root_outside_its_recorded_root() {
+        let access = tempfile::tempdir().unwrap();
+        let source = access.path().join("project");
+        std::fs::create_dir(&source).unwrap();
+        let worktrees = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let mut config = crate::config::default_config(access.path().to_path_buf());
+        config.multi_project = true;
+        let state = SessionState::new();
+        *state.project_binding.lock().unwrap() = Some(TransportProjectBinding {
+            source_project_root: source,
+            project_root: outside.path().to_path_buf(),
+            managed_worktree: true,
+            worktree_git_root: Some(outside.path().to_path_buf()),
+            worktrees_root: Some(worktrees.path().to_path_buf()),
+        });
+
+        let error = state.effective_config(&config).unwrap_err();
+        assert!(
+            error.contains("outside its recorded worktree root"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn managed_transport_binding_rejects_an_active_root_outside_its_git_root() {
+        let access = tempfile::tempdir().unwrap();
+        let source = access.path().join("project");
+        std::fs::create_dir(&source).unwrap();
+        let worktrees = tempfile::tempdir().unwrap();
+        let worktree_git_root = worktrees.path().join("managed");
+        std::fs::create_dir(&worktree_git_root).unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let mut config = crate::config::default_config(access.path().to_path_buf());
+        config.multi_project = true;
+        let state = SessionState::new();
+        *state.project_binding.lock().unwrap() = Some(TransportProjectBinding {
+            source_project_root: source,
+            project_root: outside.path().to_path_buf(),
+            managed_worktree: true,
+            worktree_git_root: Some(worktree_git_root),
+            worktrees_root: Some(worktrees.path().to_path_buf()),
+        });
+
+        let error = state.effective_config(&config).unwrap_err();
+        assert!(
+            error.contains("outside its managed worktree Git root"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/src/tools/import_host_file.rs
+++ b/src/tools/import_host_file.rs
@@ -184,6 +184,10 @@ impl Tool for ImportHostFile {
         false
     }
 
+    fn may_modify_project(&self) -> bool {
+        true
+    }
+
     async fn call(&self, args: Value, config: &AppConfig, _session: &SessionState) -> ToolResult {
         self.run(args, config, &CancellationToken::new()).await
     }

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -189,6 +189,7 @@ fn mutating_tools_are_classified_for_checkpoint_fail_closed_behavior() {
             "apply_patch".to_string(),
             "exec_command".to_string(),
             "git_commit".to_string(),
+            "import_host_file".to_string(),
             "run_command".to_string(),
             "write_file".to_string(),
             "write_stdin".to_string(),

--- a/tests/project_selection.rs
+++ b/tests/project_selection.rs
@@ -18,6 +18,7 @@ use codex_free::tools::remember::Remember;
 use codex_free::tools::run_command::RunCommand;
 use codex_free::tools::set_project_root::SetProjectRoot;
 use codex_free::types::WorktreeMode;
+use codex_free::worktrees::metadata_path_for_worktree;
 use rmcp::model::RequestMetaObject;
 use serde_json::json;
 use tempfile::TempDir;
@@ -32,6 +33,37 @@ fn multi_project_config(access_root: &std::path::Path) -> codex_free::types::App
 
 fn conversation_identity(session: &str) -> ConversationIdentity {
     ConversationIdentity::from_openai_session(session).unwrap()
+}
+
+fn initialize_git_project(project: &std::path::Path) {
+    fs::create_dir_all(project).unwrap();
+    fs::write(project.join("tracked.txt"), "tracked\n").unwrap();
+    for args in [
+        vec!["init", "--quiet"],
+        vec!["add", "tracked.txt"],
+        vec![
+            "-c",
+            "user.email=codex-free@example.invalid",
+            "-c",
+            "user.name=Codex Free Tests",
+            "commit",
+            "--quiet",
+            "-m",
+            "initial",
+        ],
+    ] {
+        let output = std::process::Command::new("git")
+            .args(&args)
+            .current_dir(project)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 }
 
 #[test]
@@ -179,6 +211,57 @@ async fn transport_project_binding_rejects_a_replacement_symlink_outside_the_acc
         error.contains("outside the configured access root"),
         "{error}"
     );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn transport_managed_worktree_rejects_a_replaced_active_root() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let project = access.join("demo");
+    initialize_git_project(&project);
+
+    let mut config = multi_project_config(&access);
+    config.worktrees.mode = WorktreeMode::Always;
+    config.worktrees.root = root.path().join("managed-worktrees");
+    config.worktrees.auto_cleanup_enabled = false;
+    let session = SessionState::new();
+    let selection = session.select_project_root(&config, "demo").await.unwrap();
+    assert!(selection.managed_worktree);
+
+    let outside = root.path().join("outside");
+    fs::create_dir(&outside).unwrap();
+    let active_root = selection.worktree_git_root.as_ref().unwrap();
+    fs::remove_dir_all(active_root).unwrap();
+    fs::create_dir_all(active_root.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&outside, active_root).unwrap();
+
+    let error = session.effective_config(&config).unwrap_err();
+    assert!(
+        error.contains("outside its recorded worktree root"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn transport_managed_worktree_requires_matching_metadata() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let project = access.join("demo");
+    initialize_git_project(&project);
+
+    let mut config = multi_project_config(&access);
+    config.worktrees.mode = WorktreeMode::Always;
+    config.worktrees.root = root.path().join("managed-worktrees");
+    config.worktrees.auto_cleanup_enabled = false;
+    let session = SessionState::new();
+    let selection = session.select_project_root(&config, "demo").await.unwrap();
+    let metadata = metadata_path_for_worktree(selection.worktree_git_root.as_ref().unwrap())
+        .expect("managed worktree has a metadata path");
+    fs::remove_file(metadata).unwrap();
+
+    let error = session.effective_config(&config).unwrap_err();
+    assert!(error.contains("metadata"), "{error}");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Restores cross-feature semantics that were lost when the aggregate changes were merged as independent pull requests instead of with my pre-merged PR.

The resulting upstream tree had three composition regressions:

- Codex CLI enrichment still rejected plugin-provided Streamable HTTP MCP servers even though the bridge and direct config-import paths supported them.
- `import_host_file` wrote to the project without being classified as a mutating tool, bypassing fail-closed review-checkpoint capture and per-scope mutation serialization.
- Generic MCP transport-session managed-worktree bindings validated only that their active path remained a directory, unlike persistent ChatGPT bindings, which validate the complete binding and metadata relationship.

## Behavior restored

### Codex CLI Streamable HTTP discovery

Plugin-contributed HTTP servers returned by `codex mcp get --json` now retain:

- URL and transport type
- bearer-token environment reference
- static and environment-backed HTTP headers
- enabled and disabled tool filters
- startup and tool timeouts

Transport validation remains fail-closed. Mixed stdio/HTTP fields, literal bearer tokens, unsupported header helpers, legacy SSE/WebSocket transports, and invalid timeout values are rejected without exposing secret values.

### Native-file mutation checkpoints

`import_host_file` now reports `may_modify_project() == true`, placing it under the same serialized, fail-closed review-checkpoint protocol as the other project-writing tools.

### Transport-session worktree integrity

Before every project-scoped tool call, a generic transport binding now verifies:

- direct bindings still resolve to the selected source project
- managed Git roots remain below their recorded managed-worktree root
- active project roots remain below the managed Git root
- managed-worktree metadata exists
- metadata paths still match the live source, active project, Git root, and managed root

This aligns generic MCP transport behavior with the stronger persistent ChatGPT binding validation.

## Regression evidence

The corresponding proof tests fail against unmodified upstream `master` at `4255079e7063c2a845b10f3570d2e1d3b5b4bc7e`:

1. A CLI-discovered Streamable HTTP server is skipped as unsupported.
2. `import_host_file` is absent from mutating-tool classification.
3. A replaced managed-worktree root is accepted as the effective external project root.

All pass with this branch, including an additional metadata-removal test and secret-redaction coverage for native-file capabilities.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features`

Final result: 539 tests passed, 0 failed.
