### PR TITLE
fix(auth): drop conversation-auth lock before probing durable marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `import_host_file` now participates in the same fail-closed, serialized review
   checkpoint protocol as every other project-writing tool, so imports cannot race
   review capture or proceed after a checkpoint-capture failure.
+- The conversation authorization check no longer holds its in-memory lock while
+  probing the durable marker on disk, so a cache miss for one conversation cannot
+  serialize every other conversation's authorization behind blocking filesystem
+  reads.
 
 ### Security
 

--- a/src/conversation_auth.rs
+++ b/src/conversation_auth.rs
@@ -77,12 +77,17 @@ impl ConversationAuthorizationStore {
     ) -> bool {
         match conversation {
             Some(identity) => {
-                let mut authorized = self.authorized.lock().unwrap();
-                if authorized.contains(identity) {
+                // Fast path: an already-cached grant only needs the in-memory set.
+                if self.authorized.lock().unwrap().contains(identity) {
                     return true;
                 }
+                // Probe the disk WITHOUT holding the lock. A cache miss must not
+                // serialize every other conversation's authorization check behind
+                // our blocking filesystem reads. The benign race where two callers
+                // both probe and both insert is harmless: the grant is identical
+                // and the insert is idempotent.
                 if self.persisted_authorization_exists(identity) {
-                    authorized.insert(identity.clone());
+                    self.authorized.lock().unwrap().insert(identity.clone());
                     return true;
                 }
                 false


### PR DESCRIPTION
Addresses review nit **F1** from PR #19.

`is_authorized` held the in-memory `authorized`-set mutex across `persisted_authorization_exists`, which performs up to three blocking syscalls (`symlink_metadata` ×2 + `read`). A cache miss for one conversation therefore serialized every other conversation's authorization check behind blocking filesystem reads.

**Fix:** check the cache under the lock, release it before the disk probe, then re-acquire only to insert on a hit. The benign race where two callers both probe and both insert is harmless — the grant is identical and the `HashSet` insert is idempotent. Fail-closed behavior is unchanged.