### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-08-25
+
 ### Added
 
 - Optional per-conversation connector authorization through
@@ -318,7 +320,8 @@ filename sort uses byte/Unicode ordering rather than `localeCompare`;
 `write_file` reports UTF-8 byte counts; `exec_command` uses plain pipes, not a
 PTY. See the README's "Notes on the port" for the full list.
 
-[Unreleased]: https://github.com/hypnguyen1209/codex-free/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/hypnguyen1209/codex-free/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.1.0...v1.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codex-free"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-free"
-version = "1.4.0"
+version = "1.5.0"
 edition = "2024"
 description = "Codex Free MCP bridge, ported to Rust: a local Streamable-HTTP MCP server exposing Codex-style agent tools over a chosen work directory."
 license = "MIT"

--- a/src/server.rs
+++ b/src/server.rs
@@ -188,7 +188,7 @@ impl ServerHandler for CodexHandler {
         );
         capabilities.extensions = Some(extensions);
         InitializeResult::new(capabilities)
-            .with_server_info(Implementation::new("codex-free", "1.4.0"))
+            .with_server_info(Implementation::new("codex-free", "1.5.0"))
             .with_instructions(build_initial_instructions(&self.config))
     }
 


### PR DESCRIPTION
Bump to **v1.5.0**.

- `Cargo.toml`, `Cargo.lock`, `src/server.rs` → 1.5.0
- `CHANGELOG.md`: promote `[Unreleased]` to `[1.5.0] - 2026-08-25`, refresh compare links

Highlights since v1.4.0: per-conversation connector authorization (#19), Streamable HTTP MCP import + import_host_file checkpoint protocol + auth-lock fix (#21, #22), and the associated authorization/binding hardening. Tag `v1.5.0` will be pushed after this merges.