### PR TITLE
release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-25
+
 ### Added
 
 - Multi-project `set_project_root` now accepts HTTPS and SSH GitHub repository
@@ -340,7 +342,8 @@ filename sort uses byte/Unicode ordering rather than `localeCompare`;
 `write_file` reports UTF-8 byte counts; `exec_command` uses plain pipes, not a
 PTY. See the README's "Notes on the port" for the full list.
 
-[Unreleased]: https://github.com/hypnguyen1209/codex-free/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/hypnguyen1209/codex-free/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.2.0...v1.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codex-free"
-version = "1.5.0"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-free"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2024"
 description = "Codex Free MCP bridge, ported to Rust: a local Streamable-HTTP MCP server exposing Codex-style agent tools over a chosen work directory."
 license = "MIT"

--- a/src/server.rs
+++ b/src/server.rs
@@ -188,7 +188,7 @@ impl ServerHandler for CodexHandler {
         );
         capabilities.extensions = Some(extensions);
         InitializeResult::new(capabilities)
-            .with_server_info(Implementation::new("codex-free", "1.5.0"))
+            .with_server_info(Implementation::new("codex-free", "1.6.0"))
             .with_instructions(build_initial_instructions(&self.config))
     }
 


### PR DESCRIPTION
Release v1.6.0.

## Added
- Multi-project `set_project_root` accepts HTTPS/SSH GitHub repository URLs, HTTPS branch URLs (`/tree/<branch>`), and HTTPS pull-request URLs (`/pull/<number>`), reusing a local checkout when unambiguous or cloning into `projectCloneDir`; branch/PR selections fetch the ref into an isolated detached worktree.

## Security
- GitHub cloning and fetching are restricted to normalized `github.com` repository/branch/PR URLs; embedded credentials, unsupported subpages, and arbitrary transports are rejected. Clone directory is revalidated under the access root, resolution is serialized, interactive prompts disabled, remotes verified, destination collisions refused. Source checkouts are never switched, and a session already bound to another project is rejected before any clone/fetch side effect.

Version bump only (Cargo.toml, Cargo.lock, server info, CHANGELOG); no code changes.