### PR TITLE
fix: keep conversation auth out of quickstart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the access root). Branch and PR selections fetch the requested ref and use an
   isolated detached worktree when the source checkout is on another commit.
 
+### Changed
+
+- Quickstart no longer offers to enable, generate, or rotate the advanced
+  `conversationAuthToken` gate. Conversation authorization remains disabled unless
+  configured manually; rerunning quickstart preserves an existing valid token and
+  prints its required ChatGPT instruction without surfacing the feature to new
+  installs.
+
 ### Security
 
 - GitHub project cloning and target fetching are restricted to normalized

--- a/README.md
+++ b/README.md
@@ -115,11 +115,10 @@ cargo run --release -- quickstart
 The wizard asks which project directory ChatGPT may access and whether that
 directory is one project or a multi-project access root. It then walks through
 creating an OpenAI Secure MCP Tunnel, entering the tunnel ID and runtime API key,
-and creating the matching ChatGPT developer-mode connector. It can also generate
-an optional per-conversation authorization token and prints the exact one-line
-instruction to paste into a chat or into a ChatGPT Project's Project instructions.
-The relevant OpenAI and ChatGPT links are printed together with the exact
-connection values to use.
+and creating the matching ChatGPT developer-mode connector. Advanced policies,
+including optional per-conversation authorization, are configured manually rather
+than presented during first-run onboarding. The relevant OpenAI and ChatGPT links
+are printed together with the exact connection values to use.
 
 The runtime key is entered without terminal echo and stored in a dedicated
 per-tunnel file under `~/.codex-free/openai-tunnel/credentials/`. On Unix, the
@@ -129,10 +128,10 @@ settings are preserved. At the end, the wizard can start Codex Free immediately
 so ChatGPT can scan the live connector. Keep that process running while using the
 connector.
 
-The optional conversation token is deliberately different from the tunnel runtime
-key: it is stored directly as `conversationAuthToken` in the JSON config so the
-server can verify chat-supplied values. When enabled, quickstart restricts the
-config file to the current user on Unix. Keep that config out of version control
+When an existing config already contains `conversationAuthToken`, quickstart
+preserves it, restricts the config file to the current user on Unix, and prints the
+one-line instruction required to authorize a chat. It does not offer to enable or
+rotate this advanced feature. Keep a token-bearing config out of version control
 and do not share it.
 
 Use `codex-free quickstart --config /path/to/codex.config.json` to update a
@@ -183,7 +182,12 @@ Here `--work-dir` is an **access root**, not the active project. In ChatGPT, cal
 
 ### Optional per-conversation authorization
 
-Set a high-entropy token in the config, or let `quickstart` generate one:
+Set a high-entropy token manually in the config. For example, this generates a
+256-bit URL-safe value:
+
+```bash
+python -c 'import secrets; print("codex_free_chat_" + secrets.token_urlsafe(32))'
+```
 
 ```json
 {
@@ -456,12 +460,14 @@ All project-scoped paths are resolved relative to the active project root: `--wo
 CLI flags override values from the config file.
 
 `conversationAuthToken` has no CLI override. A non-null value must contain 32 to
-256 ASCII bytes using only letters, digits, `_`, and `-`. `quickstart` generates a
-256-bit URL-safe token with the `codex_free_chat_` prefix and writes the copyable
-ChatGPT instruction shown above. Because the token is intentionally stored in
-this file, use a config path outside the repository or add it to the repository's
-ignore rules. On Unix, quickstart changes the config mode to `0600` when this
-feature is enabled; manually created configs should be protected equivalently.
+256 ASCII bytes using only letters, digits, `_`, and `-`. Generate it with a
+cryptographically secure random source. `quickstart` does not enable or rotate the
+feature; if the selected config already contains a valid token, it preserves the
+value and prints the copyable ChatGPT instruction shown above. Because the token
+is intentionally stored in this file, use a config path outside the repository or
+add it to the repository's ignore rules. On Unix, quickstart changes the config
+mode to `0600` when it preserves a token-bearing config; manually created configs
+should be protected equivalently.
 
 ## Diagnostics and audit logging
 
@@ -1083,7 +1089,7 @@ When `remote-exec` was imported from Codex, that overlay is sufficient; include 
 3. In ChatGPT's connector/plugin settings, create a developer-mode connector with **Connection type: Tunnel**.
 4. Select the same tunnel ID that Codex Free reports as ready. Set **Authentication** to **None**.
 5. Set the connector's permissions to **Allow all actions** if you do not want per-call confirmations.
-6. Enable the connector in a new chat. Without conversation authorization, open with `Call get_agent_brief and follow it for the rest of this chat.` With `conversationAuthToken`, first supply the one-line `authenticate` instruction printed by quickstart; after it succeeds, follow its project-selection or `get_agent_brief` direction. See [Acting as a Codex agent](#acting-as-a-codex-agent). In multi-project mode (`--multi-project`), call `set_project_root` first when an exact path or GitHub repository, branch, or pull-request URL is known, or `list_projects` first when only the local project identity is known; later follow-ups in that same chat recover both authorization and the project binding from ChatGPT's conversation metadata.
+6. Enable the connector in a new chat. Without conversation authorization, open with `Call get_agent_brief and follow it for the rest of this chat.` With `conversationAuthToken`, first supply the one-line `authenticate` instruction from [Optional per-conversation authorization](#optional-per-conversation-authorization); after it succeeds, follow its project-selection or `get_agent_brief` direction. In multi-project mode (`--multi-project`), call `set_project_root` first when an exact path or GitHub repository, branch, or pull-request URL is known, or `list_projects` first when only the local project identity is known; later follow-ups in that same chat recover both authorization and the project binding from ChatGPT's conversation metadata.
 
 There is no server URL to enter in this mode. OpenAI routes the selected tunnel to the supervised client, which supplies Codex Free's generated per-process bearer on the local hop. The startup banner prints the runtime-only `/readyz` and `/metrics` URLs. It does not advertise an admin UI because `tunnel-client-runtime` deliberately omits that full-client surface.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -332,9 +332,10 @@ project behind an absolute `file:` reference. Config and credential replacement
 use temporary files in the destination directory. Once setup is complete, the
 same process can pass the generated paths back through `load_config` and enter the
 ordinary supervised server lifecycle; there is no separate quickstart runtime.
-The wizard can additionally generate `conversationAuthToken`, protect the config
-as a private file on Unix, and print a one-line instruction suitable for an
-individual chat or ChatGPT Project instructions.
+The wizard does not expose the advanced `conversationAuthToken` policy as an
+onboarding choice. If an existing config already contains a valid token, it
+preserves the value, protects the config as a private file on Unix, and prints the
+one-line instruction needed by an individual chat or ChatGPT Project.
 
 ---
 
@@ -451,7 +452,7 @@ the original order and rejects duplicate names.
 | `review_ui.rs` | Embedded MCP Apps resource and compatibility metadata for the interactive `show_changes` review card. |
 | `apply_patch.rs` | The Codex patch format: parse then apply, atomically, with fuzzy context matching and CRLF preservation. |
 | `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized active root, with `O_EXCL` locking and atomic writes. In multi-project mode, a configured `memory.dir` is a base containing one hashed child per project. |
-| `quickstart.rs` | Interactive first-install wizard for project scope, native tunnel credentials, optional conversation-token generation, JSON config merging, and the ChatGPT developer-mode connector handoff. |
+| `quickstart.rs` | Interactive first-install wizard for project scope, native tunnel credentials, JSON config merging, preservation of preconfigured advanced conversation authorization, and the ChatGPT developer-mode connector handoff. |
 | `openai_tunnel.rs` | Verified installation and lifecycle supervision for OpenAI's outbound Secure MCP Tunnel runtime. |
 | `process_env.rs` | Child-process environment boundaries: isolate the tunnel runtime and remove tunnel credentials from model-controlled and upstream subprocesses. |
 | `project_doc.rs` | `AGENTS.md` discovery from project root down to the work dir under a byte budget. Multi-project mode treats the selected directory as the exact project root and never walks into the common access-root parent. |

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -9,9 +9,7 @@ use serde_json::{Map, Value};
 use tempfile::NamedTempFile;
 use zeroize::Zeroizing;
 
-use crate::conversation_auth::{
-    conversation_auth_prompt, generate_conversation_auth_token, validate_conversation_auth_token,
-};
+use crate::conversation_auth::{conversation_auth_prompt, validate_conversation_auth_token};
 use crate::openai_tunnel::{validate_runtime_api_key, validate_tunnel_id};
 use crate::util::home_dir;
 
@@ -222,26 +220,7 @@ where
 
     let default_connector_name = connector_name_default(&work_dir, multi_project);
     let connector_name = prompt_connector_name(&mut wizard, &default_connector_name)?;
-    let existing_conversation_auth_token = configured_conversation_auth_token(&file_config)?;
-    let conversation_auth_enabled = wizard.confirm(
-        "Require each new ChatGPT conversation to authenticate with a token?",
-        existing_conversation_auth_token.is_some(),
-    )?;
-    let conversation_auth_token = if conversation_auth_enabled {
-        match existing_conversation_auth_token {
-            Some(token)
-                if !wizard.confirm(
-                    "Generate a new conversation token and invalidate the current one after restart?",
-                    false,
-                )? =>
-            {
-                Some(token)
-            }
-            _ => Some(generate_conversation_auth_token()?),
-        }
-    } else {
-        None
-    };
+    let conversation_auth_token = configured_conversation_auth_token(&file_config)?;
 
     if file_config
         .get("apiKey")
@@ -1007,7 +986,7 @@ mod tests {
         let config_path = project.join("codex.config.json");
         let environment = environment(&root, &project);
         let home_dir = environment.home_dir.clone();
-        let input = format!("\n\n\n\n\n{TUNNEL_ID}\nn\n");
+        let input = format!("\n\n\n\n{TUNNEL_ID}\nn\n");
 
         let (result, output) = run_test_wizard(
             args(config_path.clone(), &project),
@@ -1044,6 +1023,8 @@ mod tests {
         assert!(output.contains("Connection: Tunnel"));
         assert!(output.contains("Authentication: No Authentication"));
         assert!(output.contains(TUNNEL_ID));
+        assert!(!output.contains("Require each new ChatGPT conversation"));
+        assert!(!output.contains("Configure ChatGPT conversation authentication"));
         assert!(!output.contains(RUNTIME_KEY));
 
         #[cfg(unix)]
@@ -1065,42 +1046,7 @@ mod tests {
     }
 
     #[test]
-    fn new_install_can_generate_a_conversation_token_and_project_instruction() {
-        let root = TempDir::new().unwrap();
-        let project = root.path().join("project");
-        fs::create_dir_all(&project).unwrap();
-        let config_path = project.join("codex.config.json");
-        let environment = environment(&root, &project);
-        let input = format!("\n\n\ny\n\n{TUNNEL_ID}\nn\n");
-
-        let (result, output) = run_test_wizard(
-            args(config_path.clone(), &project),
-            environment,
-            &input,
-            &[RUNTIME_KEY],
-        );
-        result.unwrap();
-
-        let config: Value =
-            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
-        let token = config["conversationAuthToken"].as_str().unwrap();
-        validate_conversation_auth_token(token).unwrap();
-        assert!(output.contains(&conversation_auth_prompt(token)));
-        assert!(output.contains("ChatGPT Project's Project instructions"));
-        assert!(!output.contains(RUNTIME_KEY));
-
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            assert_eq!(
-                fs::metadata(&config_path).unwrap().permissions().mode() & 0o777,
-                0o600
-            );
-        }
-    }
-
-    #[test]
-    fn rerun_preserves_unrelated_config_and_can_keep_the_stored_key() {
+    fn rerun_preserves_advanced_conversation_auth_and_unrelated_config() {
         let root = TempDir::new().unwrap();
         let project = root.path().join("projects");
         fs::create_dir_all(&project).unwrap();
@@ -1128,7 +1074,7 @@ mod tests {
         let (result, output) = run_test_wizard(
             args(config_path.clone(), &project),
             environment,
-            "\n\n\n\n\n\n\n\nn\n",
+            "\n\n\n\n\n\nn\n",
             &[""],
         );
         let outcome = result.unwrap();
@@ -1137,11 +1083,13 @@ mod tests {
         assert_eq!(fs::read_to_string(&key_path).unwrap().trim(), RUNTIME_KEY);
 
         let config: Value =
-            serde_json::from_str(&fs::read_to_string(config_path).unwrap()).unwrap();
+            serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
         assert!(config.get("apiKey").is_none());
         assert_eq!(config["multiProject"], json!(true));
         assert_eq!(config["conversationAuthToken"], json!(CONVERSATION_TOKEN));
         assert!(output.contains(&conversation_auth_prompt(CONVERSATION_TOKEN)));
+        assert!(!output.contains("Require each new ChatGPT conversation"));
+        assert!(!output.contains("Generate a new conversation token"));
         assert_eq!(config["allowedCommands"], json!(["git"]));
         assert_eq!(
             config["openaiTunnel"]["organizationId"],
@@ -1151,6 +1099,15 @@ mod tests {
             config["openaiTunnel"]["apiKeyRef"],
             json!(format!("file:{}", key_path.display()))
         );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                fs::metadata(&config_path).unwrap().permissions().mode() & 0o777,
+                0o600
+            );
+        }
     }
 
     #[test]
@@ -1160,7 +1117,7 @@ mod tests {
         fs::create_dir_all(&project).unwrap();
         let config_path = project.join("codex.config.json");
         let environment = environment(&root, &project);
-        let input = format!("\nn\n\n\n\ninvalid-tunnel\n{TUNNEL_ID}\nn\n");
+        let input = format!("\nn\n\n\ninvalid-tunnel\n{TUNNEL_ID}\nn\n");
         let invalid_key = "not a valid key!";
 
         let (result, output) = run_test_wizard(


### PR DESCRIPTION
## Summary

- keep `conversationAuthToken` disabled unless explicitly configured
- remove the quickstart prompts that offered to enable, generate, or rotate a conversation token
- preserve and validate an existing manually configured token when quickstart is rerun
- retain private Unix permissions and print the required ChatGPT instruction when the advanced feature is already enabled
- document manual cryptographically secure token generation

## Rationale

Per-conversation authorization is an advanced, optional hardening policy. Although it was already disabled at runtime when `conversationAuthToken` was absent, quickstart presented it to every user during ordinary onboarding. This keeps first-run setup focused on the required tunnel and connector configuration while retaining the existing authorization semantics for operators who configure the feature manually.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` — all 570 tests passed
- `git diff --check origin/master...HEAD`