### PR TITLE
feat(config): discover user-level config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- User-level config discovery through `~/.codex-free/codex.config.json` and the
+  `CODEX_FREE_CONFIG` environment variable. Explicit `--config` remains highest
+  priority; the old working-directory `codex.config.json` is retained as a warned
+  compatibility fallback only when no user config exists.
+
+### Changed
+
+- `quickstart` now writes the user-level config by default and omits `--config`
+  from its generated launch command for that canonical path. Explicit CLI or
+  environment-selected paths continue to be preserved.
+
 ## [1.6.0] - 2026-08-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ connection values to use.
 The runtime key is entered without terminal echo and stored in a dedicated
 per-tunnel file under `~/.codex-free/openai-tunnel/credentials/`. On Unix, the
 wizard restricts the credential directory and file to the current user.
-`codex.config.json` receives only a `file:` reference, and unrelated existing JSON
-settings are preserved. At the end, the wizard can start Codex Free immediately
-so ChatGPT can scan the live connector. Keep that process running while using the
-connector.
+The wizard writes `~/.codex-free/codex.config.json` by default; that file receives
+only a `file:` reference, and unrelated existing JSON settings are preserved. At
+the end, the wizard can start Codex Free immediately so ChatGPT can scan the live
+connector. Keep that process running while using the connector.
 
 The optional conversation token is deliberately different from the tunnel runtime
 key: it is stored directly as `conversationAuthToken` in the JSON config so the
@@ -135,15 +135,16 @@ server can verify chat-supplied values. When enabled, quickstart restricts the
 config file to the current user on Unix. Keep that config out of version control
 and do not share it.
 
-Use `codex-free quickstart --config /path/to/codex.config.json` to update a
-different config file, or `--work-dir /path/to/project` to change the directory
-initially shown by the wizard.
+Set `CODEX_FREE_CONFIG=/path/to/codex.config.json` or use
+`codex-free quickstart --config /path/to/codex.config.json` to update a different
+config file. `--work-dir /path/to/project` changes the directory initially shown
+by the wizard.
 
 ### Manual native OpenAI tunnel setup
 
 1. Create or obtain a tunnel ID in [OpenAI Platform tunnel settings](https://platform.openai.com/settings/organization/tunnels).
 2. Create a restricted [runtime API key](https://platform.openai.com/settings/organization/api-keys) whose principal has Tunnels **Read** + **Use** for that tunnel. Keep tunnel-management/admin credentials separate.
-3. Add the tunnel to `codex.config.json`:
+3. Add the tunnel to `~/.codex-free/codex.config.json`:
 
    ```json
    {
@@ -236,7 +237,8 @@ Each release ships a compiled binary per platform — `windows-x64`, `linux-x64`
 |---------|-------------|
 | `quickstart` | Interactively configure the project scope, native OpenAI tunnel credentials, JSON config, and ChatGPT developer-mode connector; optionally start the server when setup is complete |
 
-`quickstart` accepts `--config <PATH>` (default `./codex.config.json`) and
+`quickstart` writes `~/.codex-free/codex.config.json` by default. It accepts
+`--config <PATH>` (or `CODEX_FREE_CONFIG`) to select another file and
 `--work-dir <DIR>` as the initial project-directory prompt value.
 
 ### Server flags
@@ -250,7 +252,7 @@ Each release ships a compiled binary per platform — `windows-x64`, `linux-x64`
 | `--worktree-root` | No | Codex worktree location | Directory for managed conversation worktrees |
 | `--port` | No | `3000` | Server port |
 | `--api-key` | No | - | Bearer token for auth |
-| `--config` | No | `./codex.config.json` | Config file path (tolerated if missing) |
+| `--config` | No | `CODEX_FREE_CONFIG`, user config, then legacy `./codex.config.json` | Explicit config file path. The user config is `~/.codex-free/codex.config.json`; relative explicit paths resolve from the startup directory, and a missing file is tolerated |
 | `--codex-cli` | No | Auto when available | Require successful Codex CLI-backed MCP discovery. When omitted, failure produces a warning and direct `config.toml` parsing remains the fallback |
 | `-v`, `--verbose` | No | Info logs | Enable Codex Free debug diagnostics; repeat (`-vv`) for trace diagnostics (`--log-tool-calls` is an alias) |
 | `--audit <FILE>` | No | Disabled | Append privacy-preserving tool activity events to a JSONL file (`--audit-log` is an alias) |
@@ -357,7 +359,27 @@ All project-scoped paths are resolved relative to the active project root: `--wo
 
 ## Config file
 
-`codex.config.json` in the project root, or pass a custom path with `--config`. Every field is optional and uses the same camelCase names as the original TypeScript project, so an existing config keeps working. A missing config file is tolerated — the built-in defaults are used and the startup banner says so.
+Codex Free resolves one server-level JSON config in this order:
+
+1. `--config <PATH>`;
+2. the non-empty `CODEX_FREE_CONFIG` environment variable;
+3. an existing `~/.codex-free/codex.config.json`;
+4. an existing `./codex.config.json` as a legacy compatibility fallback;
+5. built-in defaults.
+
+Relative paths supplied through `--config` or `CODEX_FREE_CONFIG` resolve against
+the process's startup directory. Explicit CLI and environment paths are
+authoritative even when missing; a missing file is tolerated and built-in defaults
+are used. The startup banner prints the selected path and its source. Selecting the
+legacy working-directory file also prints a migration warning because process
+authority should not normally depend on which repository happened to be the launch
+directory. Move that file to `~/.codex-free/codex.config.json`, or make its location
+explicit with `--config` or `CODEX_FREE_CONFIG`.
+
+`quickstart` always chooses the user-level path when neither explicit source is
+set; it does not update the legacy working-directory fallback. Every field is
+optional and uses the same camelCase names as the original TypeScript project, so
+an existing config keeps working.
 
 ```json
 {
@@ -459,9 +481,11 @@ CLI flags override values from the config file.
 256 ASCII bytes using only letters, digits, `_`, and `-`. `quickstart` generates a
 256-bit URL-safe token with the `codex_free_chat_` prefix and writes the copyable
 ChatGPT instruction shown above. Because the token is intentionally stored in
-this file, use a config path outside the repository or add it to the repository's
-ignore rules. On Unix, quickstart changes the config mode to `0600` when this
-feature is enabled; manually created configs should be protected equivalently.
+this file, keep the config outside the repository; the default
+`~/.codex-free/codex.config.json` location does so. When using a custom
+repository-local path, add it to the repository's ignore rules. On Unix,
+quickstart changes the config mode to `0600` when this feature is enabled;
+manually created configs should be protected equivalently.
 
 ## Diagnostics and audit logging
 
@@ -1105,6 +1129,7 @@ Native tunnel mode ignores `allowedHosts` and forces the accepted authorities to
 ## Security
 
 - **Path traversal prevention**: every filesystem tool — including `apply_patch` and `view_image` — resolves paths through a guard that rejects anything outside the active project root. In multi-project mode, both catalogue discovery and `set_project_root` canonicalize the configured access root and candidate directory, so `..` and symlinks cannot expose or bind a project outside the access root.
+- **Stable server-config authority**: the implicit config is user-scoped at `~/.codex-free/codex.config.json`, so changing the launch directory does not normally change command, MCP-server, network, tunnel, or worktree policy. `--config` and `CODEX_FREE_CONFIG` remain explicit overrides. The old `./codex.config.json` behavior is retained only as a warned compatibility fallback when no user config exists.
 - **Bounded GitHub cloning and target fetching**: URL-based project selection accepts only normalized HTTPS/SSH repository roots plus HTTPS branch and PR URLs on `github.com`. It separates owner/repository identity from the exact checkout target, rejects embedded credentials, unsupported subpages, and non-GitHub/insecure transports, and disables interactive Git credential prompts. The configured clone directory is canonicalized inside the access root at startup and revalidated at use time. Resolution uses per-repository cross-process locks, bounded subprocess timeouts, private temporary clone destinations, remote verification, exact branch/PR refspecs, and collision refusal. Existing source checkouts are fetched without moving `HEAD`; a conversation already bound to another selection is rejected before the network/disk side effect.
 - **Host-authorized native-file ingress**: `import_host_file` accepts only ChatGPT's declared native-file object, rejects local source paths, constrains the download URL and every redirect hop to the configurable `artifactIngress.allowedHosts` allowlist (default `"*"`, which admits any public HTTPS host but never a loopback, private, link-local, unique-local, CGNAT, `localhost`, or metadata address), ignores ambient proxy credentials, and enforces whole-request, idle, size and concurrency limits. Its signed URL and file ID are never logged or returned: RMCP debug/trace payload logging is unconditionally suppressed even when `RUST_LOG` requests it. Destination publication uses a capability-confined directory handle, canonical-path and file-identity revalidation, a private partial file, SHA-256, and atomic no-overwrite linking so traversal, moved roots, symlink escapes, partial visibility and replacement races fail closed.
 - **One bounded exception in single-project mode**: [AGENTS.md](#agentsmd) discovery may read above `--work-dir`, up to the nearest `.git`. It is read-only, opens only `AGENTS.override.md`, `AGENTS.md` and any `projectDoc.fallbackFilenames`, and `get_project_doc` reports the absolute path of every file it used. Set `projectDoc.maxBytes` to `0` to switch it off, or `projectDoc.rootMarkers` to `[]` to keep the search inside the work directory. Multi-project mode does not perform this upward walk; its selected directory is the exact project root.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -306,18 +306,20 @@ compare-and-swap. The same per-owner/project lock spans mutating tool calls thro
 completion so reviews cannot capture an in-process write halfway through.
 
 ### `AppConfig` (`types.rs`)
-The fully-resolved config handed to every tool. `config.rs` parses
-`codex.config.json` with camelCase field names for backward compatibility, imports
+The fully-resolved config handed to every tool. `config.rs` selects one JSON file
+from explicit `--config`, `CODEX_FREE_CONFIG`, the user-level
+`~/.codex-free/codex.config.json`, or the warned legacy working-directory fallback,
+in that order. It parses camelCase fields for backward compatibility, imports
 user-level Codex MCP definitions through `codex_mcp.rs`, opportunistically adds
 plugin-provided entries from the Codex CLI's effective catalogue, then applies
 explicit `mcpServers` entries as field overlays. Optional sub-configs (`projectDoc`,
-`projectCatalog`, `output`, `review`, `artifactIngress`, `worktrees`, `memory`, `skills`, `ignore`, `audit`) fall
-back to per-module defaults, as does `codexMcp` (Codex MCP import and CLI enrichment).
-In multi-project mode, dispatch clones this config per
-call and substitutes the conversation's selected root—or the transport fallback—for
-`work_dir`; the static server policy, catalogue overlay, and bridge configuration
-remain shared. Native Codex project entries are intentionally re-read when the
-catalogue tool is called rather than copied into `AppConfig` at startup.
+`projectCatalog`, `output`, `review`, `artifactIngress`, `worktrees`, `memory`,
+`skills`, `ignore`, `audit`) fall back to per-module defaults, as does `codexMcp`
+(Codex MCP import and CLI enrichment). In multi-project mode, dispatch clones this
+config per call and substitutes the conversation's selected root—or the transport
+fallback—for `work_dir`; the static server policy, catalogue overlay, and bridge
+configuration remain shared. Native Codex project entries are intentionally re-read
+when the catalogue tool is called rather than copied into `AppConfig` at startup.
 `conversationAuthToken` is a top-level optional secret with no CLI override; its
 presence also controls registry inclusion of the `authenticate` tool and the
 authentication-only initialization instructions.
@@ -325,13 +327,17 @@ authentication-only initialization instructions.
 ### `quickstart` CLI (`quickstart.rs`)
 The `quickstart` subcommand runs before server configuration is loaded. It uses a
 testable line-oriented wizard for ordinary prompts and terminal-hidden input for
-the runtime API key. The wizard canonicalizes the project directory, validates
-the tunnel credentials with the same helpers as normal startup, merges only the
-managed fields into the existing JSON object, and stores the key outside the
-project behind an absolute `file:` reference. Config and credential replacement
-use temporary files in the destination directory. Once setup is complete, the
-same process can pass the generated paths back through `load_config` and enter the
-ordinary supervised server lifecycle; there is no separate quickstart runtime.
+the runtime API key. Without an explicit CLI or environment override, it writes
+`~/.codex-free/codex.config.json` and its generated launch command relies on normal
+user-config discovery rather than adding `--config`. The wizard canonicalizes the
+project directory, validates the tunnel credentials with the same helpers as normal
+startup, merges only the managed fields into the existing JSON object, and stores
+the key outside the project behind an absolute `file:` reference. Config and
+credential replacement use temporary files in the destination directory. Once
+setup is complete, the same process can pass the selected work directory through
+`load_config`; normal config discovery reselects the file the wizard just wrote
+before entering the ordinary supervised server lifecycle. There is no separate
+quickstart runtime.
 The wizard can additionally generate `conversationAuthToken`, protect the config
 as a private file on Unix, and print a one-line instruction suitable for an
 individual chat or ChatGPT Project instructions.
@@ -577,8 +583,13 @@ read through `skills_read`. Scope `plugin`.
 
 ## 9. Configuration reference
 
-`codex.config.json` (loaded from the current directory, or `--config`; the
-startup banner prints the exact file with `Config:`). All fields optional.
+The server selects one `codex.config.json`: `--config`, then
+`CODEX_FREE_CONFIG`, then an existing `~/.codex-free/codex.config.json`, then an
+existing `./codex.config.json` compatibility fallback. If none exists, built-in
+defaults are used. Relative explicit paths resolve from the startup directory; the
+startup banner prints the exact source, and selecting the legacy fallback emits a
+migration warning. `quickstart` writes the user-level path by default rather than
+the legacy fallback. All fields are optional.
 
 ```jsonc
 {
@@ -654,7 +665,7 @@ startup banner prints the exact file with `Config:`). All fields optional.
 The banner is designed so failures are never silent:
 
 ```
-Config: D:\codex-bridge\codex.config.json          ← which file actually loaded
+Config: C:\Users\alice\.codex-free\codex.config.json (user config)
 Tools loaded (29): 28 native + 1 bridged from upstream MCP servers
 Upstream MCP servers:
   remote-exec -> gateway (84 functions via `remote_exec`)
@@ -664,8 +675,10 @@ Audit log: /private/path/tools.jsonl
 Audit command previews: disabled
 ```
 
-- `Config:` reveals the common mistake of editing a different file than the one
-  loaded (config is resolved relative to the launch directory unless `--config`).
+- `Config:` names both the selected file and its source. Explicit relative paths
+  resolve from the launch directory; implicit discovery normally selects the
+  stable user-level file instead. The legacy working-directory fallback also
+  emits a migration warning on stderr.
 - The `Upstream MCP servers:` block reports each server's outcome.
 - In native tunnel mode, the banner also reports loopback-only exposure, the
   internal-auth boundary, managed runtime version or operator-supplied client,
@@ -738,7 +751,7 @@ Run: `cargo test`. Build a standalone binary: `cargo build --release`.
 | Symptom | Cause / fix |
 |---------|-------------|
 | Bridged tools don't appear; banner shows `-> FAILED` | For stdio, verify that `command` is runnable on the machine where Codex Free runs. For Streamable HTTP, verify the URL, TLS trust, bearer/header environment variables, and upstream authentication. |
-| Banner shows a server you didn't configure (e.g. `idasql -> disabled`) | codex-free loaded a *different* `codex.config.json` than you edited. Check the `Config:` line and edit that file, or pass `--config`. |
+| Banner shows a server you didn't configure (e.g. `idasql -> disabled`) | Codex Free loaded a *different* `codex.config.json` than you edited. Check the `Config:` line and edit that file, set `CODEX_FREE_CONFIG`, or pass `--config`. |
 | codex-free exposes a newer tool set but the client still shows the old one | The client caches the tool manifest — **remove and re-add the connector** so it re-fetches `tools/list`. |
 | A client won't surface a large bridged set at all | Use `"mode": "gateway"` to collapse the server into one tool + a skill, or `"tools": [...]` to expose a curated few. |
 | Upstream uses `type: "sse"` or `"websocket"` | Current Codex transport parity is stdio plus Streamable HTTP. Point the entry at a Streamable HTTP endpoint and use `url` (or an HTTP type alias). |

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,9 +2,12 @@
 //!
 //! An existing `codex.config.json` keeps working: every field is read with its
 //! original camelCase name, absent sections fall back to the same defaults the
-//! TypeScript used, and a missing config file is tolerated.
+//! TypeScript used, and a missing config file is tolerated. Server-level config
+//! defaults to `~/.codex-free/codex.config.json`; the old working-directory file
+//! remains a warned compatibility fallback.
 
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
+use std::io;
 use std::path::{Path, PathBuf};
 
 use clap::{ArgAction, Args, Parser, Subcommand};
@@ -27,6 +30,10 @@ use crate::types::{
     WorktreeUpstreamRefreshMode,
 };
 use crate::util::home_dir;
+
+pub const CODEX_FREE_CONFIG_ENV: &str = "CODEX_FREE_CONFIG";
+const CONFIG_FILE_NAME: &str = "codex.config.json";
+const CONFIG_HOME_DIR: &str = ".codex-free";
 
 #[derive(Parser, Debug)]
 #[command(
@@ -79,7 +86,8 @@ pub struct Cli {
     #[arg(long = "api-key")]
     pub api_key: Option<String>,
 
-    /// Config file path. Default: ./codex.config.json (tolerated if missing).
+    /// Config file path. Default: CODEX_FREE_CONFIG, then ~/.codex-free/codex.config.json.
+    /// A working-directory codex.config.json remains a warned legacy fallback.
     #[arg(long, global = true)]
     pub config: Option<String>,
 
@@ -131,7 +139,7 @@ pub enum CliCommand {
     },
     /// Interactively configure a native OpenAI tunnel and ChatGPT connector.
     ///
-    /// The wizard reads the global `--config` and `--work-dir` options.
+    /// The wizard reads `--config`, CODEX_FREE_CONFIG, and the global `--work-dir` option.
     Quickstart,
 }
 
@@ -852,39 +860,248 @@ fn resolve_project_clone_dir(
     Ok(clone_dir)
 }
 
-fn config_file_path(cli: &Cli) -> PathBuf {
-    cli.config
-        .as_deref()
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("codex.config.json"))
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigPathSource {
+    CommandLine,
+    Environment,
+    User,
+    LegacyWorkingDirectory,
+    Defaults,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConfigPathSelection {
+    path: Option<PathBuf>,
+    source: ConfigPathSource,
+    user_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QuickstartConfigSelection {
+    pub path: PathBuf,
+    pub explicit: bool,
+}
+
+pub fn user_config_path(home: &Path) -> PathBuf {
+    home.join(CONFIG_HOME_DIR).join(CONFIG_FILE_NAME)
+}
+
+fn absolute_config_path(current_dir: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        current_dir.join(path)
+    }
+}
+
+fn explicit_config_path(
+    cli_config: Option<&str>,
+    env_config: Option<&OsStr>,
+    current_dir: &Path,
+) -> Option<(PathBuf, ConfigPathSource)> {
+    if let Some(path) = cli_config {
+        return Some((
+            absolute_config_path(current_dir, Path::new(path)),
+            ConfigPathSource::CommandLine,
+        ));
+    }
+    env_config.filter(|value| !value.is_empty()).map(|path| {
+        (
+            absolute_config_path(current_dir, Path::new(path)),
+            ConfigPathSource::Environment,
+        )
+    })
+}
+
+fn config_path_is_present(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(error) => error.kind() != io::ErrorKind::NotFound,
+    }
+}
+
+fn select_config_path_with(
+    cli_config: Option<&str>,
+    env_config: Option<&OsStr>,
+    current_dir: &Path,
+    home: Option<&Path>,
+) -> ConfigPathSelection {
+    let user_path = home
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(user_config_path)
+        .map(|path| absolute_config_path(current_dir, &path));
+    if let Some((path, source)) = explicit_config_path(cli_config, env_config, current_dir) {
+        return ConfigPathSelection {
+            path: Some(path),
+            source,
+            user_path,
+        };
+    }
+    if let Some(path) = user_path
+        .as_ref()
+        .filter(|path| config_path_is_present(path))
+    {
+        return ConfigPathSelection {
+            path: Some(path.clone()),
+            source: ConfigPathSource::User,
+            user_path,
+        };
+    }
+
+    let legacy_path = current_dir.join(CONFIG_FILE_NAME);
+    if config_path_is_present(&legacy_path) {
+        return ConfigPathSelection {
+            path: Some(legacy_path),
+            source: ConfigPathSource::LegacyWorkingDirectory,
+            user_path,
+        };
+    }
+
+    match user_path {
+        Some(path) => ConfigPathSelection {
+            path: Some(path.clone()),
+            source: ConfigPathSource::User,
+            user_path: Some(path),
+        },
+        None => ConfigPathSelection {
+            path: None,
+            source: ConfigPathSource::Defaults,
+            user_path: None,
+        },
+    }
+}
+
+fn select_config_path(cli: &Cli) -> Result<ConfigPathSelection, String> {
+    let current_dir = std::env::current_dir()
+        .map_err(|error| format!("could not determine the current directory: {error}"))?;
+    let env_config = std::env::var_os(CODEX_FREE_CONFIG_ENV);
+    let home = home_dir();
+    Ok(select_config_path_with(
+        cli.config.as_deref(),
+        env_config.as_deref(),
+        &current_dir,
+        home.as_deref(),
+    ))
+}
+
+fn config_path_for_quickstart_with(
+    cli_config: Option<&str>,
+    env_config: Option<&OsStr>,
+    current_dir: &Path,
+    home: Option<&Path>,
+) -> Result<QuickstartConfigSelection, String> {
+    if let Some((path, _)) = explicit_config_path(cli_config, env_config, current_dir) {
+        return Ok(QuickstartConfigSelection {
+            path,
+            explicit: true,
+        });
+    }
+    home.filter(|path| !path.as_os_str().is_empty())
+        .map(user_config_path)
+        .map(|path| absolute_config_path(current_dir, &path))
+        .map(|path| QuickstartConfigSelection {
+            path,
+            explicit: false,
+        })
+        .ok_or_else(|| {
+            format!(
+                "quickstart cannot locate the user's home directory; pass --config or set {CODEX_FREE_CONFIG_ENV}"
+            )
+        })
+}
+
+pub fn config_path_for_quickstart(cli: &Cli) -> Result<QuickstartConfigSelection, String> {
+    let current_dir = std::env::current_dir()
+        .map_err(|error| format!("could not determine the current directory: {error}"))?;
+    let env_config = std::env::var_os(CODEX_FREE_CONFIG_ENV);
+    let home = home_dir();
+    config_path_for_quickstart_with(
+        cli.config.as_deref(),
+        env_config.as_deref(),
+        &current_dir,
+        home.as_deref(),
+    )
+}
+
+fn warn_legacy_config(selection: &ConfigPathSelection, path: &Path) {
+    if selection.source != ConfigPathSource::LegacyWorkingDirectory {
+        return;
+    }
+    match &selection.user_path {
+        Some(user_path) => eprintln!(
+            "Warning: using legacy working-directory config at {}. Move it to {} or select it explicitly with --config or {CODEX_FREE_CONFIG_ENV}.",
+            path.display(),
+            user_path.display()
+        ),
+        None => eprintln!(
+            "Warning: using legacy working-directory config at {}. Select it explicitly with --config or {CODEX_FREE_CONFIG_ENV}.",
+            path.display()
+        ),
+    }
+}
+
+fn announce_loaded_config(selection: &ConfigPathSelection, path: &Path) {
+    match selection.source {
+        ConfigPathSource::CommandLine => println!("Config: {} (from --config)", path.display()),
+        ConfigPathSource::Environment => {
+            println!("Config: {} (from {CODEX_FREE_CONFIG_ENV})", path.display())
+        }
+        ConfigPathSource::LegacyWorkingDirectory => println!(
+            "Config: {} (legacy working-directory fallback)",
+            path.display()
+        ),
+        ConfigPathSource::User => println!("Config: {} (user config)", path.display()),
+        ConfigPathSource::Defaults => {}
+    }
+}
+
+fn announce_missing_config(selection: &ConfigPathSelection) {
+    match (&selection.path, selection.source) {
+        (Some(path), ConfigPathSource::CommandLine) => println!(
+            "Config: no file at {} selected by --config — using built-in defaults",
+            path.display()
+        ),
+        (Some(path), ConfigPathSource::Environment) => println!(
+            "Config: no file at {} selected by {CODEX_FREE_CONFIG_ENV} — using built-in defaults",
+            path.display()
+        ),
+        (Some(path), _) => println!(
+            "Config: no file at {} — using built-in defaults (override with --config or {CODEX_FREE_CONFIG_ENV})",
+            path.display()
+        ),
+        (None, _) => println!(
+            "Config: no user home or legacy working-directory config available — using built-in defaults (set --config or {CODEX_FREE_CONFIG_ENV})"
+        ),
+    }
 }
 
 fn load_file_config(cli: &Cli, announce: bool) -> Result<FileConfig, String> {
-    let config_path = config_file_path(cli);
-    let display_path = if config_path.is_absolute() {
-        config_path.clone()
-    } else {
-        std::env::current_dir()
-            .unwrap_or_default()
-            .join(&config_path)
+    let selection = select_config_path(cli)?;
+    let Some(config_path) = selection.path.as_deref() else {
+        if announce {
+            announce_missing_config(&selection);
+        }
+        return Ok(FileConfig::default());
     };
-    match std::fs::read_to_string(&config_path) {
+    match std::fs::read_to_string(config_path) {
         Ok(text) => {
+            warn_legacy_config(&selection, config_path);
             if announce {
-                println!("Config: {}", display_path.display());
+                announce_loaded_config(&selection, config_path);
             }
             serde_json::from_str(&text)
                 .map_err(|error| format!("invalid config file {}: {error}", config_path.display()))
         }
-        Err(_) => {
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
             if announce {
-                println!(
-                    "Config: no file at {} — using built-in defaults (pass --config to point elsewhere)",
-                    display_path.display()
-                );
+                announce_missing_config(&selection);
             }
             Ok(FileConfig::default())
         }
+        Err(error) => Err(format!(
+            "could not read config file {}: {error}",
+            config_path.display()
+        )),
     }
 }
 
@@ -1177,6 +1394,126 @@ mod tests {
             openai_tunnel_client: None,
             openai_tunnel_organization_id: None,
         }
+    }
+
+    #[test]
+    fn config_path_precedence_is_cli_env_user_legacy_then_defaults() {
+        let root = tempfile::tempdir().unwrap();
+        let current_dir = root.path().join("cwd");
+        let home = root.path().join("home");
+        std::fs::create_dir_all(&current_dir).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+
+        let user_path = user_config_path(&home);
+        std::fs::create_dir_all(user_path.parent().unwrap()).unwrap();
+        std::fs::write(&user_path, "{}").unwrap();
+        let legacy_path = current_dir.join(CONFIG_FILE_NAME);
+        std::fs::write(&legacy_path, "{}").unwrap();
+
+        let selected = select_config_path_with(
+            Some("cli.json"),
+            Some(OsStr::new("env.json")),
+            &current_dir,
+            Some(&home),
+        );
+        assert_eq!(selected.source, ConfigPathSource::CommandLine);
+        assert_eq!(
+            selected.path.as_deref(),
+            Some(current_dir.join("cli.json").as_path())
+        );
+
+        let selected = select_config_path_with(
+            None,
+            Some(OsStr::new("env.json")),
+            &current_dir,
+            Some(&home),
+        );
+        assert_eq!(selected.source, ConfigPathSource::Environment);
+        assert_eq!(
+            selected.path.as_deref(),
+            Some(current_dir.join("env.json").as_path())
+        );
+
+        let selected =
+            select_config_path_with(None, Some(OsStr::new("")), &current_dir, Some(&home));
+        assert_eq!(selected.source, ConfigPathSource::User);
+        assert_eq!(selected.path.as_deref(), Some(user_path.as_path()));
+
+        let selected = select_config_path_with(None, None, &current_dir, Some(&home));
+        assert_eq!(selected.source, ConfigPathSource::User);
+        assert_eq!(selected.path.as_deref(), Some(user_path.as_path()));
+
+        std::fs::remove_file(&user_path).unwrap();
+        let selected = select_config_path_with(None, None, &current_dir, Some(&home));
+        assert_eq!(selected.source, ConfigPathSource::LegacyWorkingDirectory);
+        assert_eq!(selected.path.as_deref(), Some(legacy_path.as_path()));
+        assert_eq!(selected.user_path.as_deref(), Some(user_path.as_path()));
+
+        std::fs::remove_file(&legacy_path).unwrap();
+        let selected = select_config_path_with(None, None, &current_dir, Some(&home));
+        assert_eq!(selected.source, ConfigPathSource::User);
+        assert_eq!(selected.path.as_deref(), Some(user_path.as_path()));
+
+        let selected = select_config_path_with(None, None, &current_dir, None);
+        assert_eq!(selected.source, ConfigPathSource::Defaults);
+        assert!(selected.path.is_none());
+
+        let selected = select_config_path_with(None, None, &current_dir, Some(Path::new("")));
+        assert_eq!(selected.source, ConfigPathSource::Defaults);
+        assert!(selected.path.is_none());
+    }
+
+    #[test]
+    fn quickstart_defaults_to_user_config_but_honors_explicit_sources() {
+        let root = tempfile::tempdir().unwrap();
+        let current_dir = root.path().join("cwd");
+        let home = root.path().join("home");
+
+        let selected =
+            config_path_for_quickstart_with(None, None, &current_dir, Some(&home)).unwrap();
+        assert_eq!(selected.path, user_config_path(&home));
+        assert!(!selected.explicit);
+
+        let selected = config_path_for_quickstart_with(
+            None,
+            Some(OsStr::new("env.json")),
+            &current_dir,
+            Some(&home),
+        )
+        .unwrap();
+        assert_eq!(selected.path, current_dir.join("env.json"));
+        assert!(selected.explicit);
+
+        let selected = config_path_for_quickstart_with(
+            Some("cli.json"),
+            Some(OsStr::new("env.json")),
+            &current_dir,
+            Some(&home),
+        )
+        .unwrap();
+        assert_eq!(selected.path, current_dir.join("cli.json"));
+        assert!(selected.explicit);
+
+        let selected = config_path_for_quickstart_with(
+            Some(user_config_path(&home).to_str().unwrap()),
+            None,
+            &current_dir,
+            Some(&home),
+        )
+        .unwrap();
+        assert_eq!(selected.path, user_config_path(&home));
+        assert!(selected.explicit);
+
+        assert!(
+            config_path_for_quickstart_with(None, None, &current_dir, None)
+                .unwrap_err()
+                .contains(CODEX_FREE_CONFIG_ENV)
+        );
+        assert!(
+            config_path_for_quickstart_with(None, None, &current_dir, Some(Path::new("")))
+                .unwrap_err()
+                .contains(CODEX_FREE_CONFIG_ENV)
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@ use serde::Serialize;
 
 use anyhow::Context;
 use codex_free::config::{
-    Cli, CliCommand, ProjectsCommand, ProjectsListArgs, load_config, load_project_catalog_for_cli,
+    Cli, CliCommand, ProjectsCommand, ProjectsListArgs, config_path_for_quickstart, load_config,
+    load_project_catalog_for_cli,
 };
 use codex_free::logging;
 use codex_free::project_catalog::{
@@ -139,12 +140,10 @@ async fn run() -> anyhow::Result<()> {
     if let Some(command) = cli.command.take() {
         match command {
             CliCommand::Quickstart => {
+                let config = config_path_for_quickstart(&cli).map_err(anyhow::Error::msg)?;
                 let args = quickstart::QuickstartArgs {
-                    config: cli
-                        .config
-                        .clone()
-                        .map(PathBuf::from)
-                        .unwrap_or_else(|| PathBuf::from("codex.config.json")),
+                    config: config.path,
+                    config_explicit: config.explicit,
                     work_dir: cli.work_dir.clone().map(PathBuf::from),
                 };
                 let outcome = quickstart::run(args)?;
@@ -152,7 +151,6 @@ async fn run() -> anyhow::Result<()> {
                     return Ok(());
                 }
                 cli.work_dir = Some(outcome.work_dir.to_string_lossy().into_owned());
-                cli.config = Some(outcome.config_path.to_string_lossy().into_owned());
             }
             CliCommand::Projects { .. } => {
                 // Project catalogue subcommands are dispatched in `main` before

--- a/src/quickstart.rs
+++ b/src/quickstart.rs
@@ -21,12 +21,15 @@ pub const DEVELOPER_MODE_GUIDE_URL: &str =
     "https://developers.openai.com/api/docs/guides/developer-mode";
 pub const CHATGPT_PLUGINS_URL: &str = "https://chatgpt.com/plugins";
 
-/// Inputs for the quickstart wizard, resolved from the global `--config` and
-/// `--work-dir` options before dispatch.
+/// Inputs for the quickstart wizard, resolved from `--config`,
+/// `CODEX_FREE_CONFIG`, and the global `--work-dir` option before dispatch.
 #[derive(Debug, Clone)]
 pub struct QuickstartArgs {
     /// Config file to create or update.
     pub config: PathBuf,
+
+    /// Preserve an explicit CLI or environment selection in the launch command.
+    pub config_explicit: bool,
 
     /// Initial directory shown by the project-directory prompt.
     pub work_dir: Option<PathBuf>,
@@ -289,7 +292,12 @@ where
             "  Conversation token: stored in the config file; do not commit or share that file"
         )?;
     }
-    let command = launch_command(&environment.executable, &work_dir, &config_path);
+    let command = launch_command(
+        &environment.executable,
+        &work_dir,
+        &config_path,
+        args.config_explicit,
+    );
     writeln!(wizard.output, "\nLaunch command:\n  {command}")?;
 
     print_connector_step(&mut wizard, &connector_name, &tunnel_id, multi_project)?;
@@ -830,13 +838,22 @@ fn resolve_user_path(raw: &str, current_dir: &Path, home_dir: &Path) -> PathBuf 
     absolute_path(current_dir, Path::new(raw))
 }
 
-fn launch_command(executable: &Path, work_dir: &Path, config_path: &Path) -> String {
-    format!(
-        "{} --work-dir {} --config {}",
+fn launch_command(
+    executable: &Path,
+    work_dir: &Path,
+    config_path: &Path,
+    config_explicit: bool,
+) -> String {
+    let mut command = format!(
+        "{} --work-dir {}",
         quote_shell_arg(&executable.to_string_lossy()),
-        quote_shell_arg(&work_dir.to_string_lossy()),
-        quote_shell_arg(&config_path.to_string_lossy())
-    )
+        quote_shell_arg(&work_dir.to_string_lossy())
+    );
+    if config_explicit {
+        command.push_str(" --config ");
+        command.push_str(&quote_shell_arg(&config_path.to_string_lossy()));
+    }
+    command
 }
 
 #[cfg(not(windows))]
@@ -901,6 +918,7 @@ mod tests {
     fn args(config: PathBuf, work_dir: &Path) -> QuickstartArgs {
         QuickstartArgs {
             config,
+            config_explicit: true,
             work_dir: Some(work_dir.to_path_buf()),
         }
     }
@@ -997,6 +1015,21 @@ mod tests {
             error.contains("--work-dir"),
             "expected a missing work-dir error, got: {error}"
         );
+    }
+
+    #[test]
+    fn launch_command_omits_only_the_implicit_user_config() {
+        let root = TempDir::new().unwrap();
+        let executable = root.path().join("bin").join("codex-free");
+        let work_dir = root.path().join("project");
+        let config = root.path().join("home/.codex-free/codex.config.json");
+
+        let default_command = launch_command(&executable, &work_dir, &config, false);
+        assert!(!default_command.contains("--config"));
+
+        let explicit_default_command = launch_command(&executable, &work_dir, &config, true);
+        assert!(explicit_default_command.contains("--config"));
+        assert!(explicit_default_command.contains("codex.config.json"));
     }
 
     #[test]

--- a/tests/project_catalog_cli.rs
+++ b/tests/project_catalog_cli.rs
@@ -32,6 +32,107 @@ fn write_native_config(codex_home: &Path, project: &Path, trust: &str) -> PathBu
     path
 }
 
+fn write_catalog_config(path: &Path, project: &Path, name: &str) {
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(
+        path,
+        serde_json::to_vec_pretty(&serde_json::json!({
+            "codexMcp": { "enabled": false },
+            "projectCatalog": {
+                "codexConfig": { "enabled": false },
+                "entries": [{ "path": project, "name": name }]
+            }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+fn run_discovered_config(
+    access: &Path,
+    current_dir: &Path,
+    home: &Path,
+    codex_home: &Path,
+    env_config: Option<&Path>,
+) -> (Value, String) {
+    let mut command = Command::new(binary());
+    command
+        .args([
+            "projects",
+            "list",
+            "--work-dir",
+            access.to_str().unwrap(),
+            "--json",
+        ])
+        .current_dir(current_dir)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .env("CODEX_HOME", codex_home);
+    match env_config {
+        Some(path) => {
+            command.env("CODEX_FREE_CONFIG", path);
+        }
+        None => {
+            command.env_remove("CODEX_FREE_CONFIG");
+        }
+    }
+    let output = command.output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    (
+        serde_json::from_slice(&output.stdout).unwrap(),
+        String::from_utf8(output.stderr).unwrap(),
+    )
+}
+
+#[test]
+fn config_discovery_prefers_env_then_user_then_legacy() {
+    let root = TempDir::new().unwrap();
+    let access = root.path().join("projects");
+    let current_dir = root.path().join("cwd");
+    let home = root.path().join("home");
+    let codex_home = root.path().join("codex-home");
+    let env_project = access.join("env-project");
+    let user_project = access.join("user-project");
+    let legacy_project = access.join("legacy-project");
+    for directory in [
+        &access,
+        &current_dir,
+        &home,
+        &codex_home,
+        &env_project,
+        &user_project,
+        &legacy_project,
+    ] {
+        fs::create_dir_all(directory).unwrap();
+    }
+
+    let env_config = root.path().join("env.json");
+    let user_config = home.join(".codex-free").join("codex.config.json");
+    let legacy_config = current_dir.join("codex.config.json");
+    write_catalog_config(&env_config, &env_project, "Environment");
+    write_catalog_config(&user_config, &user_project, "User");
+    write_catalog_config(&legacy_config, &legacy_project, "Legacy");
+
+    let (value, stderr) =
+        run_discovered_config(&access, &current_dir, &home, &codex_home, Some(&env_config));
+    assert_eq!(value["projects"][0]["name"], "Environment");
+    assert!(!stderr.contains("legacy working-directory config"));
+
+    let (value, stderr) = run_discovered_config(&access, &current_dir, &home, &codex_home, None);
+    assert_eq!(value["projects"][0]["name"], "User");
+    assert!(!stderr.contains("legacy working-directory config"));
+
+    fs::remove_file(user_config).unwrap();
+    let (value, stderr) = run_discovered_config(&access, &current_dir, &home, &codex_home, None);
+    assert_eq!(value["projects"][0]["name"], "Legacy");
+    assert!(stderr.contains("legacy working-directory config"));
+    assert!(stderr.contains(".codex-free"));
+}
+
 #[test]
 fn json_command_lists_native_projects_with_explicit_metadata() {
     let root = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- make `~/.codex-free/codex.config.json` the canonical implicit server configuration
- add `CODEX_FREE_CONFIG` as an explicit environment-level override below `--config`
- retain `./codex.config.json` as a warned compatibility fallback only when no user config exists
- make explicit CLI and environment paths authoritative even when the selected file is missing
- update quickstart to write the canonical user config by default and omit `--config` only for that implicit selection
- preserve explicit quickstart selections in the generated launch command, including an explicitly selected canonical path

## Resolution order

1. `--config <path>`
2. non-empty `CODEX_FREE_CONFIG`
3. existing `~/.codex-free/codex.config.json`
4. existing `./codex.config.json` with a migration warning
5. built-in defaults

Relative explicit paths resolve from the process startup directory. An empty or unavailable home directory cannot turn the user-level path into a working-directory-relative path.

## Compatibility and diagnostics

Existing working-directory configurations continue to load when no user-level file exists, but Codex Free now warns that the file should be moved or selected explicitly. The startup banner identifies whether the loaded path came from `--config`, `CODEX_FREE_CONFIG`, the user-level default, or the legacy fallback. Non-server commands keep machine-readable stdout clean while still emitting the legacy migration warning on stderr.

## Validation

- `cargo fmt --all --check`
- `cargo test --all` — 575 tests passed
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check origin/master`
