### PR TITLE
feat: add progressive disclosure for transitive MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Progressive disclosure for transitive MCP tools. Catalog-mode upstreams keep
+  their complete filtered `tools/list` private and share four fixed downstream
+  tools for source discovery, BM25-ranked schema-aware search, exact tool
+  metadata/schema retrieval, and raw-name dispatch. Search indexes source and
+  implementation metadata, tool names/titles/descriptions, and recursively useful
+  input/output-schema fields without registering every transitive definition in
+  the ChatGPT connector catalogue.
 - User-level config discovery through `~/.codex-free/codex.config.json` and the
   `CODEX_FREE_CONFIG` environment variable. Explicit `--config` remains highest
   priority; the old working-directory `codex.config.json` is retained as a warned
@@ -15,6 +22,20 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- MCP servers imported automatically from Codex `config.toml` or the Codex CLI
+  (including plugin-provided servers) now default to catalog mode. Standalone
+  explicit `mcpServers` entries retain the historical direct default, while a
+  same-name explicit overlay preserves imported provenance unless it sets
+  `mode` to `direct`, `gateway`, or `catalog`. This provenance-based policy
+  replaces flattened automatic exposure without relying on a tool-count
+  heuristic; set `"mode": "direct"` on an imported server to restore the prior
+  connector manifest behavior.
+- Direct MCP proxies now retain upstream titles, annotations, icons, `_meta`, and
+  output schemas. Direct, gateway, and catalog calls share cancellable forwarding
+  and preserve text, images, structured content, result metadata, and tool-error
+  state. The generic catalog dispatcher advertises conservative side-effect hints
+  because one downstream capability cannot reproduce the selected upstream
+  tool's per-tool ChatGPT approval semantics.
 - `quickstart` now writes the user-level config by default and omits `--config`
   from its generated launch command for that canonical path. Explicit CLI or
   environment-selected paths continue to be preserved.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In native-tunnel mode, Codex Free listens only on `127.0.0.1`, protects the MCP 
 
 The tool set covers the ones [Codex](https://github.com/openai/codex) gives its own agent — `apply_patch`, `exec_command`/`write_stdin`, `view_image`, `update_plan`, `clock_curr_time`/`clock_sleep` — so ChatGPT Web can work the way Codex does: patch files in place instead of rewriting them, drive interactive and long-running processes, and keep a plan across a task. It also bridges ChatGPT-native attachments and generated files into the active local project without base64 reconstruction. It carries the project's `AGENTS.md` and Codex's own agent brief, so the client is told how to behave and not just what it can call. It bounds what a tool call can return, keeps a plan and notes on disk across conversations, and records project-scoped review checkpoints so ChatGPT can inspect either the full task diff or only changes since the last review. And it loads Codex's skills: a `SKILL.md` in the repo or your home directory teaches the client how *you* do a recurring task, and only the ones that apply are ever read. Schemas and prompt are ported from the Codex source, not reimplemented from guesswork.
 
-Beyond the port, Codex Free can **aggregate other MCP servers** — connecting to local stdio servers or remote Streamable HTTP endpoints and re-exposing their tools through its own endpoint, so the ChatGPT-side agent can call them too.
+Beyond the port, Codex Free can **aggregate other MCP servers**. It connects to local stdio servers or remote Streamable HTTP endpoints, keeps automatically imported Codex/plugin tool catalogues private by default, and gives the ChatGPT-side agent a fixed ranked discovery/schema/call surface. Explicit direct flattening and the older one-tool gateway remain available as compatibility modes.
 
 ## Architecture
 
@@ -340,7 +340,7 @@ Multi-project mode adds two project-control tools:
 
 Codex needs the first three for none of these reasons: it puts its agent brief in the system prompt, the OS and shell in an `<environment_context>` message, and `AGENTS.md` straight into the prompt, all before the first turn. An MCP server has none of those channels — it can only expose tools — so the same facts are tool calls here as well as part of the server's `instructions`. It needs `remember` and `recall` for the opposite reason: its context is large and its session state lives in the CLI process, whereas the client here is a chat window that loses the conversation. See [Context and memory](#context-and-memory), [Acting as a Codex agent](#acting-as-a-codex-agent), [Shells and the host](#shells-and-the-host), [AGENTS.md](#agentsmd) and [Skills](#skills).
 
-That is 27 native tools in the default single-project mode and 29 in multi-project mode. Enabling conversation authorization adds `authenticate`, producing 28 or 30 respectively. Setting `artifactIngress.enabled` to `false` removes `import_host_file`, reducing the applicable count by one. When [MCP bridging](#bridging-other-mcp-servers) is configured, the tools of your other MCP servers are re-exposed here too, on top of these.
+That is 27 native tools in the default single-project mode and 29 in multi-project mode. Enabling conversation authorization adds `authenticate`, producing 28 or 30 respectively. Setting `artifactIngress.enabled` to `false` removes `import_host_file`, reducing the applicable count by one. One or more [catalog-mode MCP upstreams](#catalog-mode-default-for-automatic-imports) add one shared four-tool discovery/call surface regardless of how many transitive tools they contain. Direct mode adds one downstream tool per selected upstream tool; gateway mode adds one downstream dispatcher per upstream server.
 
 Two deliberate differences from Codex:
 
@@ -958,7 +958,42 @@ Discovery runs per MCP session, so adding a skill takes effect on the next conne
 
 ## Bridging other MCP servers
 
-Codex Free can also act as an **MCP aggregator**: it connects to local stdio or remote Streamable HTTP MCP servers as a client, discovers their tools at startup, and re-exposes them through its own `/mcp` endpoint — so the ChatGPT-side agent sees and can call them too.
+Codex Free can also act as an **MCP aggregator**: it connects to local stdio or remote Streamable HTTP MCP servers as a client and materializes their complete paginated `tools/list` catalogues at startup. Catalogue ownership and model exposure are separate. A server can keep its transitive tools private behind a fixed progressive-disclosure surface, expose each tool directly, or use the older one-tool gateway.
+
+### Exposure modes and defaults
+
+| `mode` | Default provenance | Downstream exposure |
+|--------|--------------------|---------------------|
+| `"catalog"` | Servers automatically imported from Codex `config.toml` or the Codex CLI/plugin catalogue | The complete filtered catalogue stays private. All catalog-mode sources share four fixed tools: `mcp_list_sources`, `mcp_search_tools`, `mcp_get_tool`, and `mcp_call_tool` |
+| `"direct"` | A standalone entry declared only in `codex.config.json.mcpServers` | Every selected upstream tool becomes `<server>__<tool>`, preserving the historical bridge behavior |
+| `"gateway"` | Never implicit; explicit compatibility opt-in only | The server becomes one `{ function, arguments }` dispatcher plus a generated skill containing every function schema |
+
+The default is based on **provenance**, not a brittle tool-count threshold. Automatically imported Codex/plugin servers use catalog mode even when they expose only a few tools. Standalone explicit entries remain direct by default for backward compatibility. An explicit entry that overlays an imported server inherits that imported provenance; set `mode` in the overlay to choose another exposure deliberately.
+
+To restore the pre-catalog behavior for an imported server:
+
+```json
+{
+  "mcpServers": {
+    "idasql": { "mode": "direct" }
+  }
+}
+```
+
+To keep a standalone explicit server out of the connector capability catalogue:
+
+```json
+{
+  "mcpServers": {
+    "remote-docs": {
+      "url": "https://mcp.example.com/mcp",
+      "mode": "catalog"
+    }
+  }
+}
+```
+
+`tools` and `disabledTools` are applied to raw upstream tool names before any mode is materialized. The fixed catalog tools and every direct/gateway proxy are project-independent: they remain callable before project selection in multi-project mode, subject to any configured conversation-authentication gate.
 
 ### Automatic discovery from Codex
 
@@ -974,7 +1009,7 @@ For each `[mcp_servers.<name>]` entry, Codex Free imports the fields it can pres
 - `enabled = false` as a disabled upstream;
 - `enabled_tools` as an allow-list and `disabled_tools` as a deny-list applied afterwards.
 
-By default, Codex Free also tries `codex mcp list --json`. Servers present in Codex's effective catalogue but absent from `config.toml` are fetched with `codex mcp get <name> --json` so plugin-provided enablement and tool allow/deny lists are preserved. The executable is selected from `codexMcp.cliPath`, then `CODEX_CLI_PATH`, then `codex` on `PATH`. Each invocation is bounded to 30 seconds and 4 MiB of stdout, and its JSON is parsed in memory without logging literal environment values.
+By default, Codex Free also tries `codex mcp list --json`. Servers present in Codex's effective catalogue but absent from `config.toml` are fetched with `codex mcp get <name> --json` so plugin-provided enablement and tool allow/deny lists are preserved. The executable is selected from `codexMcp.cliPath`, then `CODEX_CLI_PATH`, then `codex` on `PATH`. Each invocation is bounded to 30 seconds and 4 MiB of stdout, and its JSON is parsed in memory without logging literal environment values. Both directly parsed and CLI/plugin imports carry imported provenance and therefore default to catalog exposure.
 
 When the CLI is missing, fails, times out, or returns incompatible JSON, normal startup continues with the direct `config.toml` result and prints a warning that plugin-provided MCP servers may be missing. Pass `--codex-cli` to make successful CLI discovery mandatory instead; the same condition then becomes a startup error. Set `"codexMcp": { "useCli": false }` to suppress CLI invocation while retaining direct config parsing.
 
@@ -999,7 +1034,7 @@ To keep direct Codex config import but never start the Codex CLI:
 
 ### Explicit servers and overrides
 
-The `mcpServers` map in `codex.config.json` remains supported. A local entry is a stdio command that Codex Free launches and drives over stdin/stdout:
+The `mcpServers` map in `codex.config.json` remains supported. A local entry is a stdio command that Codex Free launches and drives over stdin/stdout. Because this entry is standalone and has no `mode`, it uses direct exposure:
 
 ```json
 {
@@ -1060,48 +1095,72 @@ Codex CLI MCP discovery: codex
   idalib -> imported from Codex CLI (not present in config.toml)
 Codex MCP overrides:
   remote-exec -> imported fields overlaid by codex.config.json
-bridged MCP server 'idasql': 12 tool(s)
-Tools loaded (38): 26 native + 12 bridged from upstream MCP servers
-```
-
-Each upstream tool is offered as `<server>__<tool>` (for example `remote_exec__docker_ps`), and calls are forwarded to the upstream verbatim — text, images, structured content and error flags all pass through. An upstream that fails to launch, connect, authenticate, or answer is skipped; it never blocks startup or the native tools.
-
-Every configured server is reported in the startup banner, so a bad path or a failed handshake is never silent:
-
-```
+Tools loaded (31): 27 native + 4 upstream-facing MCP tools
 Upstream MCP servers:
-  remote-exec -> 84 tool(s)
-  idasql      -> FAILED: could not launch 'D:/wrong/path.exe': The system cannot find the path specified. (os error 3)
+  idalib      -> catalog (66 private tool(s))
+  idasql      -> catalog (12 private tool(s))
+  remote-exec -> gateway (2 functions via `remote_exec`)
 ```
 
-- `disabled: true` on an entry keeps its config but skips it (shown as `-> disabled`).
-- `tools: ["exec", "machine_list", ...]` limits which upstream tools are bridged (an allow-list on the upstream's own names).
-- `disabledTools: ["dangerous_write", ...]` removes tools after the allow-list has been applied.
-- `cwd` selects the child process's working directory.
-- `startupTimeoutSec` bounds initialization plus the initial `tools/list`; the default is 20 seconds.
-- `toolTimeoutSec` bounds each forwarded call and sends MCP cancellation when the limit expires.
-- Bridged names are sanitised to `[A-Za-z0-9_]` (e.g. `remote_exec__exec`) so function-calling layers that reject hyphens don't drop them.
-- A bridged name that would collide with a native tool is skipped with a warning.
-- `type` is inferred: `command` means `"stdio"`, while `url` means Streamable HTTP. Explicit HTTP aliases `"http"`, `"streamable-http"`, and `"streamable_http"` are accepted.
-- Legacy SSE and WebSocket transports are rejected explicitly because current Codex supports stdio and Streamable HTTP, not those legacy protocols.
+An upstream that fails to launch, connect, authenticate, or answer is skipped; it never blocks startup or the native tools. Every configured server is reported, so a bad path or failed handshake is not silent.
 
-OAuth authorization-code login and credential persistence are not implemented by this bridge. An OAuth-protected upstream must therefore be supplied a usable bearer token through `bearerTokenEnvVar` or an environment-backed `Authorization` header. MCP resources, resource templates, prompts, upstream initialization instructions, and dynamic `tools/list_changed` forwarding remain separate capability work; this transport support continues to expose tools only.
+### Catalog mode (default for automatic imports)
 
-If your server doesn't show up, **check the banner first** — the most common cause is a wrong `command` path.
+Catalog mode is the closest architecture an MCP-only bridge can provide to Codex's deferred tool exposure. Codex Free still discovers and stores every filtered upstream definition internally, but downstream `tools/list` receives only a small fixed surface:
+
+| Tool | Contract |
+|------|----------|
+| `mcp_list_sources` | List or filter catalog-mode systems. Results include a unique model-facing source ID, the raw configured server name, provenance, transport, tool count, upstream implementation metadata, and initialization instructions when supplied |
+| `mcp_search_tools` | BM25-ranked full-text search over source/server metadata, model-facing and raw tool names, title, description, and recursively useful input/output-schema property names, descriptions, required names, and enum values. It can be restricted to one source ID |
+| `mcp_get_tool` | Return one exact upstream tool definition, including its separate model-facing ID and raw name, title, description, input/output schemas, annotations, icons, and `_meta` |
+| `mcp_call_tool` | Invoke the selected source/tool ID with an `arguments` object. Dispatch resolves the original server and raw tool name exactly |
+
+A typical agent flow is `mcp_list_sources` once when it needs to learn the available systems, `mcp_search_tools` with task-specific terminology, `mcp_get_tool` for the selected match when its exact schema or side-effect metadata matters, then `mcp_call_tool`. Search returns compact summaries rather than every schema, so a 66-tool IDA server still contributes only these four fixed connector capabilities.
+
+Model-facing IDs are sanitized and collision-disambiguated independently from raw names. The raw server/tool strings are never reconstructed from those IDs; dispatch uses the stored originals. This matters for names such as `rename-function` and `rename_function`, which can normalize to the same identifier but remain distinct upstream calls.
+
+Forwarded calls preserve upstream text blocks, images, structured content, the tool-error flag, and result `_meta`. Configured tool timeouts use RMCP cancellable requests, and cancellation of the downstream ChatGPT/MCP request is forwarded upstream. Unsupported content-block variants are retained through the existing JSON-text fallback rather than discarded.
+
+The generic dispatcher cannot reproduce the selected upstream tool's host-level approval semantics in ChatGPT because its downstream annotations are fixed before `source` and `tool` are known. `mcp_call_tool` therefore advertises conservative potentially-destructive/open-world hints. The agent can inspect the selected tool's exact annotations through `mcp_get_tool`, but the connector host still approves the generic dispatcher as one capability. Use direct mode when per-tool connector annotations and approval boundaries are required.
+
+The private catalogue is a startup snapshot. Dynamic upstream `tools/list_changed` notifications are not projected into the fixed surface; restart Codex Free to rematerialize a changed catalogue.
+
+### Direct mode
+
+With `"mode": "direct"`, each upstream tool becomes a `BridgedTool` named `<server>__<tool>` (sanitized to `[A-Za-z0-9_]`, so `remote-exec` becomes `remote_exec__exec`). Calls use the tool's stored **raw upstream name**, not the downstream identifier. Input/output schemas, title, annotations, icons, and `_meta` are preserved in downstream `tools/list`; text, images, structured content, error state, and result metadata pass through on calls. A downstream name colliding with a native or previously registered tool is skipped with a warning.
+
+Direct mode is the strongest compatibility option, but it intentionally places every selected schema in the connector capability catalogue. Use `tools`/`disabledTools` to curate it when full exposure is unnecessary.
 
 ### Gateway mode
 
-Some clients (ChatGPT among them) won't reliably surface a large bridged tool set. **`mode: "gateway"`** collapses a whole server with many tools into a **single** dispatcher tool, plus a generated skill:
+**`mode: "gateway"`** retains the earlier compact compatibility mechanism: a whole server becomes one dispatcher tool plus a generated skill.
 
 ```json
-"mcpServers": {
-  "remote-exec": {
-    "mode": "gateway"
+{
+  "mcpServers": {
+    "remote-exec": {
+      "mode": "gateway"
+    }
   }
 }
 ```
 
-When `remote-exec` was imported from Codex, that overlay is sufficient; include its `command` and other launch fields when it exists only in `codex.config.json`. Gateway mode registers one tool named `remote_exec` taking `{ "function": "<name>", "arguments": { ... } }`, and auto-generates a skill (`skills_read name="remote-exec"`) documenting every function and its argument schema. The agent reads the skill, then calls the one tool — so an 84-tool server shows up as **1 tool + 1 skill** instead of 84 tools. `disabled`, `type`, `tools` and `disabledTools` all still apply.
+When `remote-exec` was imported from Codex, that overlay is sufficient; include its launch fields when it exists only in `codex.config.json`. Gateway mode registers one sanitized tool named `remote_exec` taking `{ "function": "<name>", "arguments": { ... } }`, and generates a skill (`skills_read name="remote-exec"`) documenting every raw function and argument schema. An 84-tool server therefore shows up as one tool plus one skill. This mode does not provide ranked search, exact per-tool metadata retrieval, or per-tool connector approval semantics; catalog mode is the preferred compact architecture for new configurations.
+
+### Common transport and filtering behavior
+
+- `disabled: true` keeps an entry configured but skips it (reported as `-> disabled`).
+- `tools: ["exec", "machine_list", ...]` is an allow-list over raw upstream names.
+- `disabledTools: ["dangerous_write", ...]` removes tools after the allow-list.
+- `cwd` selects a stdio child process's working directory.
+- `startupTimeoutSec` bounds initialization plus complete paginated `tools/list`; the default is 20 seconds.
+- `toolTimeoutSec` bounds each forwarded call and sends MCP cancellation when the limit expires.
+- `type` is inferred: `command` means `"stdio"`, while `url` means Streamable HTTP. Explicit HTTP aliases `"http"`, `"streamable-http"`, and `"streamable_http"` are accepted.
+- Legacy SSE and WebSocket transports are rejected explicitly because current Codex supports stdio and Streamable HTTP, not those legacy protocols.
+
+OAuth authorization-code login and credential persistence are not implemented by this bridge. An OAuth-protected upstream must therefore be supplied a usable bearer token through `bearerTokenEnvVar` or an environment-backed `Authorization` header. MCP resources, resource templates, and prompts remain separate capability work. Catalog mode reports upstream initialization instructions as source metadata, but does not inject them into Codex Free's own initialization instructions.
+
+If your server doesn't show up, **check the banner first** — the most common cause is a wrong `command` path.
 
 ## Connecting to ChatGPT
 
@@ -1143,7 +1202,7 @@ Native tunnel mode ignores `allowedHosts` and forces the accepted authorities to
 - **Bounded reads outside the work directory**: [skills](#skills) may live in `~/.agents/skills`, `~/.codex/skills`, `~/.claude/skills` or an installed Claude Code plugin. `skills_read` opens files there, but only inside a skill package that already exists — the `resource` path is checked against the skill's own directory, so it cannot walk out into the rest of your home directory. `skills_list` reports the absolute path of every skill it found. Set `skills.enabled` to `false` to switch it off, or `skills.dirs` to point the user scope somewhere you choose.
 - **Read-only Codex configuration discovery**: MCP import and the project catalogue read the user-level Codex `config.toml` without rewriting it. Project discovery inspects only the top-level `projects` table, does not read candidate project contents, and suppresses rejected absolute paths from MCP output. Set `projectCatalog.codexConfig.enabled` to `false` to disable that provider. Native Codex trust does not override the Codex Free access-root boundary.
 - **Command allowlist**: `run_command` only runs binaries listed in `allowedCommands`; everything else is rejected. `exec_command` checks the same list plus `exec.extraAllowedCommands`, at every command position in the string.
-- **Bridged servers carry delegated authority**: an explicit `mcpServers` entry or an automatically imported Codex MCP—including one contributed by a Codex plugin—forwards the model's calls verbatim. A stdio upstream launches a real process that runs as your OS user; a Streamable HTTP upstream receives model-directed calls plus its configured bearer token and HTTP headers. Only bridge servers you trust, prefer `tools`/`disabledTools` filters or `gateway` mode to keep the exposed surface small, keep secrets in `bearerTokenEnvVar`/`envHttpHeaders` rather than static JSON, set `codexMcp.useCli` to `false` to exclude plugin-only discovery, or set `codexMcp.enabled` to `false` to disable all automatic Codex import. Launch, connection, authentication, and handshake failures are reported rather than silently ignored.
+- **Bridged servers carry delegated authority**: an explicit `mcpServers` entry or an automatically imported Codex MCP—including one contributed by a Codex plugin—can receive model-directed calls. A stdio upstream launches a real process that runs as your OS user; a Streamable HTTP upstream receives calls plus its configured bearer token and HTTP headers. Catalog mode reduces connector-schema exposure, not runtime authority: `mcp_call_tool` can still dispatch any filtered catalogue entry. Only bridge servers you trust, use `tools`/`disabledTools` to narrow callable operations, prefer catalog mode to keep transitive schemas private, keep secrets in `bearerTokenEnvVar`/`envHttpHeaders` rather than static JSON, set `codexMcp.useCli` to `false` to exclude plugin-only discovery, or set `codexMcp.enabled` to `false` to disable all automatic Codex import. Launch, connection, authentication, and handshake failures are reported rather than silently ignored.
 - **Native OpenAI tunnel is outbound-only**: Codex Free binds its MCP listener to loopback and supervises OpenAI's official runtime-only tunnel client. Startup fails unless the runtime reports `/readyz` and completes a control-plane poll. Failure of either process stops the other, and HTTP shutdown has a bounded grace period before remaining connections are aborted.
 - **The loopback MCP hop is authenticated**: native mode generates a random per-process bearer token and configures the tunnel runtime to send it on MCP requests and discovery probes. The token is never printed, written to the config file, or inherited by model-launched commands and bridged MCP children.
 - **Optional conversation-level authorization**: `conversationAuthToken` blocks all tools except `authenticate` until the stable ChatGPT conversation presents the token. Successful grants persist by hashed conversation identity and are invalidated by token rotation; clients without `openai/session` get transport-only grants. Initialization withholds the project-aware brief until authentication. This gate controls model conversations, not network callers: keep the native tunnel, reverse proxy, ChatGPT workspace, and local account secured independently. The token itself remains plaintext in `codex.config.json` because the server must compare chat-supplied values, so keep that file private and out of version control.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,8 +39,9 @@ ChatGPT / MCP client
 │    • + authenticate when token-gated          │
 │    • + list_projects + set_project_root       │
 │      in multi-project mode                    │
-│    • bridged tools  ← upstream MCP servers    │
-│    • gateway tools  ← upstream MCP servers    │
+│    • 4 catalog tools ← private upstream index │
+│    • direct tools    ← upstream MCP servers   │
+│    • gateway tools   ← upstream MCP servers   │
 │                                               │
 │  shared ProjectBindingStore                   │
 │    • openai/session hash → project root       │
@@ -73,7 +74,8 @@ ChatGPT / MCP client
 
 Five surfaces reach the model:
 
-- **Tools** — `tools/list` + `tools/call` (native, bridged, gateway).
+- **Tools** — `tools/list` + `tools/call` (native, fixed catalog discovery/call,
+  direct compatibility proxies, and gateway compatibility dispatchers).
 - **Skills** — a catalogue in the server `instructions` plus the `skills_list` /
   `skills_read` tools, discovered from disk.
 - **Instructions** — the agent brief + environment + memory + project doc,
@@ -101,7 +103,9 @@ Five surfaces reach the model:
    on tool calls, after initialization.
 3. `tools/list` → `CodexHandler::list_tools` maps the shared tool registry into
    rmcp `Tool` definitions, including optional titles, behavioral annotations,
-   OpenAI file-parameter metadata, and MCP Apps resource metadata.
+   icons, input/output schemas, OpenAI file-parameter metadata, and MCP Apps
+   resource metadata. Transitive definitions held by the private MCP catalog are
+   deliberately absent from this registry.
    `resources/list` / `resources/read` expose the embedded review HTML.
 4. `tools/call` → `CodexHandler::call_tool` reads `openai/session` from rmcp's
    `RequestContext::meta`. rmcp moves wire-level request `_meta` into that context
@@ -428,9 +432,10 @@ prepends `list_projects` and `set_project_root`. The optional tools are omitted
 from the ordinary single-project registry, preserving the 27-tool default surface
 and behaviour. Enabling the gate raises the applicable count by one.
 `artifactIngress.enabled = false` independently removes
-`import_host_file`, reducing either count by one. Catalogue discovery, selection,
-clocks, and bridged/gateway tools are project-independent; every other native tool
-is blocked until a conversation binding or transport fallback is available.
+`import_host_file`, reducing either count by one. Project-catalogue discovery and
+selection, clocks, the four transitive-MCP catalog tools, and direct/gateway
+compatibility tools are project-independent; every other native tool is blocked
+until a conversation binding or transport fallback is available.
 
 Each lives in `src/tools/<name>.rs`; the registry (`registry.rs`) lists them in
 the original order and rejects duplicate names.
@@ -465,6 +470,7 @@ the original order and rejects duplicate names.
 | `skills.rs` | `SKILL.md` discovery (see §8). |
 | `codex_config.rs` | Shared secret-safe resolver and TOML reader for `$CODEX_HOME/config.toml` or `~/.codex/config.toml`. |
 | `codex_mcp.rs` | Read-only import of local stdio and remote Streamable HTTP MCP definitions from the shared native Codex configuration reader, plus bounded `codex mcp list/get --json` enrichment for plugin-provided servers, with secret-safe diagnostics. |
+| `mcp_catalog.rs` | Private transitive MCP source/tool catalogue, collision-safe model identifiers, weighted BM25 index, exact metadata/schema lookup, and the fixed source/search/get/call tools. |
 | `instructions.rs` | Assembles the agent brief + environment + saved state + skills + project doc. Authentication-enabled initialization emits only the gate protocol; otherwise multi-project initialization emits a project-neutral selector brief because conversation metadata is available only on subsequent tool calls. `get_agent_brief` builds the full brief after authorization and project resolution. |
 | `environment.rs` | OS / shell / policy description, shared by `get_environment` and the instructions. |
 
@@ -473,84 +479,154 @@ the original order and rejects duplicate names.
 ## 7. MCP bridging (aggregator)
 
 codex-free can act as an MCP **client** to local stdio and remote Streamable HTTP
-servers, discover their tools at startup, and re-expose them. Implemented in `bridge.rs`; wired in
-`server.rs::start_http_server` before the HTTP server starts.
+servers and materialize their complete filtered tool catalogues at startup.
+`bridge.rs` owns transport connection/lifecycle and compatibility proxies;
+`mcp_catalog.rs` owns the private catalogue, index, and fixed progressive-
+disclosure tools. `server.rs::start_http_server` connects upstreams before it
+constructs the downstream registry.
 
-### Discovery
-Before bridging, `config.rs` imports compatible `[mcp_servers.<name>]` entries
-from Codex's user-level config. Unless `codexMcp.useCli = false`, it then runs
-`codex mcp list --json` and fetches each additional server with `codex mcp get`
-so plugin-provided enablement and tool filters are preserved. `CODEX_CLI_PATH`
-or `codexMcp.cliPath` selects the executable; otherwise `codex` is resolved from
-`PATH`. Missing or incompatible CLI discovery is a warning in the default auto
-mode and a startup error when `--codex-cli` is supplied. Explicit
-`codex.config.json.mcpServers` fields overlay the combined imports with the same
-name; `codexMcp.enabled = false` disables automatic Codex import unless
-`--codex-cli` explicitly requires it. Non-local Codex execution environments and
-`http_headers_helper` are reported and skipped because Codex Free cannot delegate
-transport execution to a Codex executor or helper process.
+### 7.1 Configuration provenance and effective exposure
 
-For each resulting server entry (sorted, non-disabled), `connect_one`:
+`config.rs` first imports compatible `[mcp_servers.<name>]` entries from Codex's
+user-level config. Unless `codexMcp.useCli = false`, it then runs
+`codex mcp list --json` and fetches additional servers with `codex mcp get` so
+plugin-provided transport settings, enablement, and tool filters are retained.
+`CODEX_CLI_PATH` or `codexMcp.cliPath` selects the executable; otherwise `codex`
+is resolved from `PATH`. Missing/incompatible CLI discovery warns in automatic
+mode and is fatal only when `--codex-cli` explicitly requires it.
+
+Every `McpServerSpec` retains internal provenance after explicit
+`codex.config.json.mcpServers` overlays are applied:
+
+| Provenance | Default exposure |
+|------------|------------------|
+| `Explicit` (standalone local entry) | `Direct` — backward-compatible flattening |
+| `CodexConfig` | `Catalog` — private catalogue |
+| `CodexCli` (including plugin-only servers) | `Catalog` — private catalogue |
+
+The typed `mode` override (`direct`, `gateway`, or `catalog`) always wins. A
+same-name explicit overlay preserves imported provenance unless it sets `mode`;
+this allows bridge-only fields to be added without accidentally restoring a
+large flattened capability set. Exposure is never inferred from tool count.
+
+For each sorted, non-disabled effective server, `connect_one`:
+
 1. Selects stdio from `command`, or Streamable HTTP from `url`.
-2. For stdio, launches the child through `TokioChildProcess`; for HTTP, resolves
-   the bearer-token environment variable and environment-backed headers, then
-   builds `StreamableHttpClientTransport` with an in-tree reqwest client whose
-   redirect policy is set to `none` (`build_upstream_client`), so a redirecting
-   upstream cannot have the caller-supplied `Authorization`/custom headers
-   replayed to another target.
-3. Runs the MCP handshake (`().serve(transport)`), then `list_all_tools()`, under
+2. For stdio, launches through `TokioChildProcess`. For HTTP, resolves bearer and
+   environment-backed headers and builds a reqwest client with redirects disabled,
+   preventing caller-supplied authorization/custom headers from being replayed to
+   another target.
+3. Runs the MCP handshake and complete paginated `list_all_tools()` under
    `startupTimeoutSec` (20 s by default).
-4. Applies the optional `tools` allow-list, then `disabledTools` deny-list.
+4. Applies `tools` as an allow-list over raw names, then `disabledTools` as a
+   deny-list.
+5. Materializes the filtered definitions according to effective exposure.
 
-Failures are **reported, not fatal** — each server appears in the startup banner
-as `-> N tool(s)`, `-> FAILED: <reason>`, `-> disabled`, or
-`-> gateway (N functions via <tool>)`. The `RunningService` handles are kept in
-`Bridge.services` for the whole server lifetime (dropping one closes the HTTP
-session or kills its child).
+Failures are reported rather than fatal. The banner distinguishes `direct (N
+tool(s))`, `catalog (N private tool(s))`, `gateway (N functions via <tool>)`,
+`disabled`, and `FAILED: <reason>`. `RunningService` handles remain in
+`Bridge.services` for the entire downstream server lifetime; dropping one closes
+the HTTP session or terminates its stdio child.
 
-### Direct mode (default)
-Each upstream tool becomes its own `BridgedTool`, named `<server>__<tool>`
-(sanitised to `[A-Za-z0-9_]`, so `remote-exec` → `remote_exec__exec`). `call`
-forwards `tools/call` to the upstream peer by the tool's **original** name and
-passes the result through verbatim (text, images, structured content, error
-flag). A name colliding with an existing tool is skipped with a warning.
+### 7.2 Catalog mode and ranked progressive disclosure
 
-### Gateway mode (`"mode": "gateway"`)
-For servers with many tools (where a client such as ChatGPT won't reliably
-surface a large set), the whole server collapses into **one** dispatcher tool:
+Each catalog-mode server becomes a private `CatalogSource` containing:
 
-- One `GatewayTool` named `<server>` with input `{ function: <enum>, arguments: object }`.
-  Its `call` validates `function` against the enum, then forwards
-  `call_tool(function, arguments)` to the upstream.
-- Its description carries a compact one-line-per-function list (kept small to stay
-  under per-tool size limits).
-- An **auto-generated skill** documents every function and its full argument
-  schema (see §8.3).
+- its raw configured name, provenance, transport, implementation identity,
+  initialization instructions, upstream `Peer`, and optional call timeout;
+- every filtered raw `rmcp::model::Tool`, including title, description,
+  input/output schemas, annotations, icons, and `_meta`;
+- separate collision-disambiguated model-facing source/tool IDs. Raw names are
+  retained and are the only names used for upstream dispatch.
 
-So an 84-tool upstream shows up as **1 tool + 1 skill** instead of 84 tools.
+All catalog sources share one immutable `Arc<Catalog>` and one set of four
+downstream `Tool` objects. If no source uses catalog mode, these tools are absent:
 
-### Why bridging opts out of default-fill
-Bridged/gateway results are passed through verbatim; `fills_structured_content()`
-returns `false` so the server never synthesises a `{content}` structured result
-that would not match the upstream's own schema.
+| Fixed tool | Internal operation |
+|------------|--------------------|
+| `mcp_list_sources` | Returns source IDs plus raw names, provenance, transport, tool count, implementation metadata, and instructions; optionally token-filters sources |
+| `mcp_search_tools` | Executes ranked full-text search across all documents or one source ID and returns compact matches |
+| `mcp_get_tool` | Serializes the exact selected raw tool definition, augmented with its model-facing ID and source metadata |
+| `mcp_call_tool` | Resolves source/tool IDs to stored raw names and invokes the selected upstream peer |
 
-### Transports
+The local search index is weighted BM25 (`k1 = 1.2`, `b = 0.75`). A document
+includes source ID/name/provenance/transport, upstream implementation metadata and
+instructions, tool ID/raw name/title/description, and recursively useful
+input/output-schema property names, descriptions, required names, and enum values.
+Tool names receive the highest term weights, descriptions and schema text lower
+weights, and exact normalized name/title matches receive deterministic boosts.
+Search returns summaries; full schemas are loaded only through `mcp_get_tool`.
+
+The fixed tool descriptions include a bounded source manifest, making available
+systems visible in the downstream connector catalogue without placing every
+transitive schema there. All four tools return project-independent exposure and
+read-only discovery annotations except `mcp_call_tool`, which advertises
+conservative potentially-destructive/open-world hints.
+
+That conservative dispatcher annotation is an unavoidable semantic loss. The
+downstream host approves one generic tool before its runtime `source`/`tool`
+selection is known, so ChatGPT cannot enforce the selected upstream tool's
+individual read-only/destructive/open-world hints. `mcp_get_tool` exposes those
+exact annotations to the model, but only direct mode preserves them as host-level
+per-tool capabilities. The dispatcher deliberately has no fixed output schema,
+because selected upstream output schemas differ.
+
+`mcp_call_tool`, direct proxies, and the gateway all use `forward_tool_call`.
+Results retain text, images, structured content, `isError`, and result `_meta`;
+unsupported content variants use the existing JSON-text fallback. RMCP request
+handles preserve configured timeouts and emit cancellation. Downstream request
+cancellation is also forwarded to the upstream request and returns promptly.
+
+The catalogue is a startup snapshot. Dynamic `tools/list_changed` notifications
+are not used to mutate the downstream fixed surface; restart the process to
+rematerialize an upstream catalogue.
+
+### 7.3 Direct compatibility mode (`"mode": "direct"`)
+
+Each selected upstream tool becomes a `BridgedTool` named `<server>__<tool>`
+(sanitized to `[A-Za-z0-9_]`, so `remote-exec` becomes
+`remote_exec__exec`). Calls forward by stored raw server/tool name. Direct
+descriptors retain the upstream title, description, input/output schemas,
+annotations, icons, and `_meta`; call results use the common passthrough path. A
+name colliding with an existing downstream tool is skipped with a warning.
+
+This is the default only for standalone explicit `mcpServers` entries. It is the
+strongest compatibility mode and the only mode that preserves per-tool host
+approval semantics, at the cost of placing every selected transitive definition
+in downstream `tools/list` and therefore the ChatGPT connector capability
+catalogue.
+
+### 7.4 Gateway compatibility mode (`"mode": "gateway"`)
+
+The whole server becomes one `GatewayTool` named from the sanitized server name,
+with input `{ function: <enum>, arguments: object }`. It validates the raw
+function name, forwards through the common call path, and writes an auto-generated
+skill containing every raw function and full input schema (see §8.3). Its compact
+description also contains a bounded function summary.
+
+An 84-tool upstream therefore contributes one tool plus one skill. Gateway mode
+is retained unchanged for compatibility, but unlike catalog mode it has no ranked
+search or exact metadata lookup and shares the generic-dispatch approval
+limitation.
+
+### 7.5 Transports and unsupported capabilities
+
 The upstream client supports the two transports exposed by current Codex:
 
 - **stdio**, inferred from `command`;
 - **Streamable HTTP**, inferred from `url`, with `http`, `streamable-http`, and
-  `streamable_http` accepted as explicit aliases.
+  `streamable_http` accepted as aliases.
 
 HTTP configuration supports `bearerTokenEnvVar`, static `httpHeaders`,
 environment-backed `envHttpHeaders`, `startupTimeoutSec`, and `toolTimeoutSec`.
-Environment-backed headers override static headers. Tool timeouts use RMCP's
-cancellable request handle so timeout cleanup sends MCP cancellation and removes
-request bookkeeping. Legacy SSE and WebSocket types are rejected explicitly.
+Environment-backed headers override static headers. Legacy SSE and WebSocket types
+are rejected explicitly.
 
 OAuth login/token persistence, `http_headers_helper`, remote Codex execution
-environments, MCP resources/templates/prompts, upstream initialization
-instructions, and dynamic capability forwarding are not part of this
-tool-transport bridge.
+environments, MCP resources/templates/prompts, and dynamic capability forwarding
+remain outside this tool-transport bridge. Catalog mode exposes upstream
+initialization instructions as source metadata but does not inject them into the
+downstream server's own initialization instructions.
 
 ---
 
@@ -645,7 +721,7 @@ the legacy fallback. All fields are optional.
       "type": "stdio",
       "disabled": false,
       "tools": ["exec", "machine_list"],   // optional allow-list of upstream names
-      "mode": "gateway"                // or omit for "direct"
+      "mode": "gateway"                    // direct | gateway | catalog
     },
     "remote-docs": {
       "url": "https://mcp.example.com/mcp",
@@ -667,9 +743,10 @@ The banner is designed so failures are never silent:
 
 ```
 Config: C:\Users\alice\.codex-free\codex.config.json (user config)
-Tools loaded (29): 28 native + 1 bridged from upstream MCP servers
+Tools loaded (34): 30 native + 4 upstream-facing MCP tools
 Upstream MCP servers:
-  remote-exec -> gateway (84 functions via `remote_exec`)
+  idalib      -> catalog (66 private tool(s))
+  remote-exec -> catalog (84 private tool(s))
 Auth: disabled (no --api-key)
 Conversation auth: enabled (one token verification per chat)
 Audit log: /private/path/tools.jsonl
@@ -717,8 +794,8 @@ units to match the TS `text.length` / `text.slice`.
 
 ## 12. Testing
 
-- **519 tests** — unit tests inside modules plus integration tests under `tests/`
-  (`tempfile`-isolated), ported from the TS Bun suite.
+- Unit tests inside modules plus integration tests under `tests/`
+  (`tempfile`-isolated), including the suite ported from the TS Bun project.
 - Memory / skills tests pin `memory.dir` / `skills.dirs` to temp dirs so they never
   touch the real home; plugin discovery is suppressed when `skills.dirs` is set.
 - `tests/project_selection.rs` covers pre-selection blocking, immutable canonical
@@ -740,8 +817,11 @@ units to match the TS `text.length` / `text.slice`.
   fixed with regression tests in `bridge.rs` / `skills.rs`.
 - `examples/mock_mcp.rs` is a minimal stdio MCP server used to exercise the bridge
   end-to-end.
-- `bridge.rs` starts a loopback Streamable HTTP MCP server to verify bearer and
-  custom headers, remote discovery/calls, and cancellable tool deadlines.
+- `bridge.rs` starts loopback Streamable HTTP MCP servers to verify bearer/custom
+  headers, many-tool private catalogues, source discovery, ranked schema-aware
+  search, exact metadata retrieval, collision-safe IDs, raw dispatch, filters,
+  result passthrough, direct/gateway compatibility, deadlines, and caller
+  cancellation.
 
 Run: `cargo test`. Build a standalone binary: `cargo build --release`.
 
@@ -751,10 +831,10 @@ Run: `cargo test`. Build a standalone binary: `cargo build --release`.
 
 | Symptom | Cause / fix |
 |---------|-------------|
-| Bridged tools don't appear; banner shows `-> FAILED` | For stdio, verify that `command` is runnable on the machine where Codex Free runs. For Streamable HTTP, verify the URL, TLS trust, bearer/header environment variables, and upstream authentication. |
+| An upstream is unavailable; banner shows `-> FAILED` | For stdio, verify that `command` is runnable on the machine where Codex Free runs. For Streamable HTTP, verify the URL, TLS trust, bearer/header environment variables, and upstream authentication. |
 | Banner shows a server you didn't configure (e.g. `idasql -> disabled`) | Codex Free loaded a *different* `codex.config.json` than you edited. Check the `Config:` line and edit that file, set `CODEX_FREE_CONFIG`, or pass `--config`. |
 | codex-free exposes a newer tool set but the client still shows the old one | The client caches the tool manifest — **remove and re-add the connector** so it re-fetches `tools/list`. |
-| A client won't surface a large bridged set at all | Use `"mode": "gateway"` to collapse the server into one tool + a skill, or `"tools": [...]` to expose a curated few. |
+| A direct-mode upstream floods the connector catalogue or some tools disappear | Use `"mode": "catalog"` for ranked progressive disclosure, or keep direct mode and curate raw names with `"tools": [...]`. Gateway mode remains available for compatibility with its generated-skill workflow. |
 | Upstream uses `type: "sse"` or `"websocket"` | Current Codex transport parity is stdio plus Streamable HTTP. Point the entry at a Streamable HTTP endpoint and use `url` (or an HTTP type alias). |
 | Native tunnel never becomes ready | Check the banner's loopback `/readyz` and `/metrics` URLs and the redacted startup error. Codex Free requires runtime readiness plus one successful control-plane poll; the runtime key needs the applicable Tunnels **Read** + **Use** permissions. The runtime-only binary has no `/ui` or `/api/status` surface. |
 | Native tunnel key is rejected before startup | `apiKeyRef` must be `env:NAME` or `file:/path`. The referenced value must exist; on Unix, key files must not grant group/other access. |

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -1,10 +1,9 @@
 //! Bridge to upstream MCP servers.
 //!
-//! codex-free can act as an MCP *client* to other MCP servers, discover their
-//! tools at startup, and re-expose them through its own
-//! `tools/list` / `tools/call` so the ChatGPT-side agent can use them too. Each
-//! upstream tool is offered under a `<server>__<tool>` name and calls are
-//! forwarded to the upstream verbatim.
+//! codex-free can act as an MCP *client* to other MCP servers and discover their
+//! complete tool catalogs at startup. Explicit compatibility modes can re-expose
+//! tools directly or through a gateway; catalog mode keeps transitive definitions
+//! private and exposes a fixed ranked discovery/schema/call surface instead.
 //!
 //! Local servers use stdio; remote servers use MCP Streamable HTTP.
 
@@ -15,8 +14,9 @@ use http::{HeaderName, HeaderValue, header::AUTHORIZATION};
 use rmcp::{
     RoleClient, ServiceExt,
     model::{
-        CallToolRequest, CallToolRequestParams, CallToolResult, ClientRequest, ContentBlock,
-        ServerResult,
+        CallToolRequest, CallToolRequestParams, CallToolResult, CancelledNotification,
+        CancelledNotificationParam, ClientRequest, ContentBlock, Icon, MetaObject, ServerResult,
+        ToolAnnotations,
     },
     service::{Peer, PeerRequestOptions, RunningService, ServiceError},
     transport::{
@@ -26,11 +26,13 @@ use rmcp::{
 };
 use serde_json::{Value, json};
 use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
 
 use crate::exec_sessions::SessionState;
+use crate::mcp_catalog::{CatalogSourceInput, build_catalog_tools};
 use crate::process_env::scrub_untrusted_child_env;
-use crate::tool::Tool;
-use crate::types::{AppConfig, ToolContent, ToolResult};
+use crate::tool::{Tool, ToolRequestContext};
+use crate::types::{AppConfig, McpToolExposure, ToolContent, ToolResult};
 
 /// How long to wait for an upstream to start up and answer `tools/list` before
 /// giving up on it.
@@ -57,11 +59,36 @@ struct BridgedTool {
     original_name: String,
     /// The upstream server's config key, for error messages.
     server: String,
+    title: Option<String>,
     description: String,
     input_schema: Value,
     output_schema: Option<Value>,
+    annotations: Option<ToolAnnotations>,
+    icons: Option<Vec<Icon>>,
+    meta: Option<MetaObject>,
     peer: Peer<RoleClient>,
     tool_timeout: Option<Duration>,
+}
+
+impl BridgedTool {
+    async fn run(&self, args: Value, cancellation: Option<&CancellationToken>) -> ToolResult {
+        let mut params = CallToolRequestParams::new(self.original_name.clone());
+        if let Some(obj) = args.as_object()
+            && !obj.is_empty()
+        {
+            params = params.with_arguments(obj.clone());
+        }
+
+        forward_tool_call(
+            &self.peer,
+            params,
+            &self.server,
+            &self.original_name,
+            self.tool_timeout,
+            cancellation,
+        )
+        .await
+    }
 }
 
 #[async_trait]
@@ -72,6 +99,22 @@ impl Tool for BridgedTool {
 
     fn description(&self) -> String {
         self.description.clone()
+    }
+
+    fn title(&self) -> Option<String> {
+        self.title.clone()
+    }
+
+    fn annotations(&self) -> Option<ToolAnnotations> {
+        self.annotations.clone()
+    }
+
+    fn icons(&self) -> Option<Vec<Icon>> {
+        self.icons.clone()
+    }
+
+    fn meta(&self) -> Option<MetaObject> {
+        self.meta.clone()
     }
 
     fn input_schema(&self) -> Value {
@@ -93,38 +136,29 @@ impl Tool for BridgedTool {
     }
 
     async fn call(&self, args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
-        let mut params = CallToolRequestParams::new(self.original_name.clone());
-        if let Some(obj) = args.as_object()
-            && !obj.is_empty()
-        {
-            params = params.with_arguments(obj.clone());
-        }
+        self.run(args, None).await
+    }
 
-        forward_tool_call(
-            &self.peer,
-            params,
-            &self.server,
-            &self.original_name,
-            self.tool_timeout,
-        )
-        .await
+    async fn call_with_context(
+        &self,
+        args: Value,
+        _config: &AppConfig,
+        _session: &SessionState,
+        context: &ToolRequestContext,
+    ) -> ToolResult {
+        self.run(args, Some(&context.cancellation)).await
     }
 }
 
-async fn forward_tool_call(
+pub(crate) async fn forward_tool_call(
     peer: &Peer<RoleClient>,
     params: CallToolRequestParams,
     server: &str,
     tool: &str,
     tool_timeout: Option<Duration>,
+    cancellation: Option<&CancellationToken>,
 ) -> ToolResult {
-    let result = if let Some(limit) = tool_timeout {
-        call_tool_with_timeout(peer, params, limit).await
-    } else {
-        peer.call_tool(params)
-            .await
-            .map_err(|error| error.to_string())
-    };
+    let result = call_upstream_tool(peer, params, tool_timeout, cancellation).await;
 
     match result {
         Ok(result) => map_call_result(result),
@@ -134,19 +168,53 @@ async fn forward_tool_call(
     }
 }
 
-async fn call_tool_with_timeout(
+async fn call_upstream_tool(
     peer: &Peer<RoleClient>,
     params: CallToolRequestParams,
-    timeout: Duration,
+    timeout: Option<Duration>,
+    cancellation: Option<&CancellationToken>,
 ) -> Result<CallToolResult, String> {
     let request = ClientRequest::CallToolRequest(CallToolRequest::new(params));
+    let options = timeout
+        .map(PeerRequestOptions::with_timeout)
+        .unwrap_or_else(PeerRequestOptions::no_options);
     let handle = peer
-        .send_cancellable_request(request, PeerRequestOptions::with_timeout(timeout))
+        .send_cancellable_request(request, options)
         .await
         .map_err(|error| error.to_string())?;
-    let response = match handle.await_response().await {
+
+    if cancellation.is_some_and(CancellationToken::is_cancelled) {
+        let _ = handle
+            .cancel(Some("downstream request cancelled".to_string()))
+            .await;
+        return Err("cancelled by downstream client".to_string());
+    }
+
+    let response = if let Some(cancellation) = cancellation {
+        let request_id = handle.id.clone();
+        let cancel_peer = peer.clone();
+        let response = handle.await_response();
+        tokio::pin!(response);
+        tokio::select! {
+            response = &mut response => response,
+            _ = cancellation.cancelled() => {
+                let notification = CancelledNotification::new(CancelledNotificationParam::new(
+                    Some(request_id),
+                    Some("downstream request cancelled".to_string()),
+                ));
+                if let Err(error) = cancel_peer.send_notification(notification.into()).await {
+                    tracing::debug!("could not forward upstream MCP cancellation: {error}");
+                }
+                return Err("cancelled by downstream client".to_string());
+            }
+        }
+    } else {
+        handle.await_response().await
+    };
+
+    let response = match response {
         Ok(response) => response,
-        Err(ServiceError::Timeout { .. }) => {
+        Err(ServiceError::Timeout { timeout }) => {
             return Err(format!("timed out after {}s", timeout.as_secs_f64()));
         }
         Err(error) => return Err(error.to_string()),
@@ -164,9 +232,9 @@ async fn call_tool_with_timeout(
 }
 
 /// Translate an upstream `CallToolResult` into this server's [`ToolResult`],
-/// preserving text, images, error flag and structured content. Content blocks
-/// this server has no native representation for are rendered as JSON text so
-/// nothing is silently dropped.
+/// preserving text, images, error state, structured content, and result metadata.
+/// Content blocks this server has no native representation for are rendered as
+/// JSON text so nothing is silently dropped.
 fn map_call_result(result: CallToolResult) -> ToolResult {
     let content: Vec<ToolContent> = result
         .content
@@ -187,6 +255,7 @@ fn map_call_result(result: CallToolResult) -> ToolResult {
         content,
         is_error: result.is_error.unwrap_or(false),
         structured_content: result.structured_content,
+        meta: result.meta,
         audit: Default::default(),
     }
 }
@@ -237,12 +306,13 @@ fn unique_name(base: String, used: &std::collections::HashSet<String>) -> String
 }
 
 /// Connect to every configured upstream MCP server, discover its tools, and
-/// build the bridged tool proxies. A server that fails to launch or answer is
-/// logged and skipped — it never blocks startup.
+/// materialize its effective exposure mode. A server that fails to launch or
+/// answer is logged and skipped — it never blocks startup.
 pub async fn connect_upstreams(config: &AppConfig) -> Bridge {
     let mut tools: Vec<Box<dyn Tool>> = Vec::new();
     let mut services: Vec<RunningService<RoleClient, ()>> = Vec::new();
     let mut report: Vec<String> = Vec::new();
+    let mut catalog_sources = Vec::new();
 
     // Deterministic order so logs and tool ordering are stable across runs.
     let mut names: Vec<&String> = config.mcp_servers.keys().collect();
@@ -255,73 +325,97 @@ pub async fn connect_upstreams(config: &AppConfig) -> Bridge {
             continue;
         }
         let sanitized = sanitize(server_name);
-
-        let is_gateway = spec.mode.as_deref() == Some("gateway");
+        let exposure = spec.exposure();
 
         match connect_one(server_name, spec, config).await {
             Ok((service, upstream_tools, tool_timeout)) => {
                 let peer = service.peer().clone();
                 let count = upstream_tools.len();
 
-                if is_gateway {
-                    // Collapse the whole server into one dispatcher tool + a
-                    // generated skill documenting every function.
-                    let functions: Vec<GatewayFunction> = upstream_tools
-                        .iter()
-                        .map(|t| GatewayFunction {
-                            name: t.name.to_string(),
-                            description: t
-                                .description
-                                .as_ref()
-                                .map(|c| c.to_string())
-                                .unwrap_or_default(),
-                            input_schema: Value::Object((*t.input_schema).clone()),
-                        })
-                        .collect();
+                match exposure {
+                    McpToolExposure::Gateway => {
+                        let functions: Vec<GatewayFunction> = upstream_tools
+                            .iter()
+                            .map(|t| GatewayFunction {
+                                name: t.name.to_string(),
+                                description: t
+                                    .description
+                                    .as_ref()
+                                    .map(|c| c.to_string())
+                                    .unwrap_or_default(),
+                                input_schema: Value::Object((*t.input_schema).clone()),
+                            })
+                            .collect();
 
-                    write_gateway_skill(config, server_name, &sanitized, &functions);
+                        write_gateway_skill(config, server_name, &sanitized, &functions);
 
-                    let leaked: &'static str = Box::leak(sanitized.clone().into_boxed_str());
-                    tools.push(Box::new(GatewayTool {
-                        name: leaked,
-                        server: server_name.clone(),
-                        description: gateway_description(server_name, &functions),
-                        function_names: functions.iter().map(|f| f.name.clone()).collect(),
-                        peer: peer.clone(),
-                        tool_timeout,
-                    }));
-                    report.push(format!(
-                        "{server_name} -> gateway ({count} functions via `{sanitized}`)"
-                    ));
-                    tracing::info!(
-                        "bridged MCP server '{server_name}' as gateway: {count} function(s)"
-                    );
-                } else {
-                    report.push(format!("{server_name} -> {count} tool(s)"));
-                    // Ensure distinct downstream names: sanitising or 64-byte
-                    // truncation can map two upstream tools to the same name.
-                    let mut used: std::collections::HashSet<String> =
-                        std::collections::HashSet::new();
-                    for tool in upstream_tools {
-                        let original_name = tool.name.to_string();
-                        let display = unique_name(bridged_name(&sanitized, &original_name), &used);
-                        used.insert(display.clone());
-                        let leaked: &'static str = Box::leak(display.into_boxed_str());
-                        tools.push(Box::new(BridgedTool {
+                        let leaked: &'static str = Box::leak(sanitized.clone().into_boxed_str());
+                        tools.push(Box::new(GatewayTool {
                             name: leaked,
-                            original_name,
                             server: server_name.clone(),
-                            description: tool
-                                .description
-                                .map(|c| c.to_string())
-                                .unwrap_or_default(),
-                            input_schema: Value::Object((*tool.input_schema).clone()),
-                            output_schema: tool.output_schema.map(|s| Value::Object((*s).clone())),
+                            description: gateway_description(server_name, &functions),
+                            function_names: functions.iter().map(|f| f.name.clone()).collect(),
                             peer: peer.clone(),
                             tool_timeout,
                         }));
+                        report.push(format!(
+                            "{server_name} -> gateway ({count} functions via `{sanitized}`)"
+                        ));
+                        tracing::info!(
+                            "bridged MCP server '{server_name}' as gateway: {count} function(s)"
+                        );
                     }
-                    tracing::info!("bridged MCP server '{server_name}': {count} tool(s)");
+                    McpToolExposure::Direct => {
+                        report.push(format!("{server_name} -> direct ({count} tool(s))"));
+                        let mut used: std::collections::HashSet<String> =
+                            std::collections::HashSet::new();
+                        for tool in upstream_tools {
+                            let original_name = tool.name.to_string();
+                            let display =
+                                unique_name(bridged_name(&sanitized, &original_name), &used);
+                            used.insert(display.clone());
+                            let leaked: &'static str = Box::leak(display.into_boxed_str());
+                            tools.push(Box::new(BridgedTool {
+                                name: leaked,
+                                original_name,
+                                server: server_name.clone(),
+                                title: tool.title,
+                                description: tool
+                                    .description
+                                    .map(|c| c.to_string())
+                                    .unwrap_or_default(),
+                                input_schema: Value::Object((*tool.input_schema).clone()),
+                                output_schema: tool
+                                    .output_schema
+                                    .map(|schema| Value::Object((*schema).clone())),
+                                annotations: tool.annotations,
+                                icons: tool.icons,
+                                meta: tool.meta,
+                                peer: peer.clone(),
+                                tool_timeout,
+                            }));
+                        }
+                        tracing::info!(
+                            "bridged MCP server '{server_name}' directly: {count} tool(s)"
+                        );
+                    }
+                    McpToolExposure::Catalog => {
+                        report.push(format!(
+                            "{server_name} -> catalog ({count} private tool(s))"
+                        ));
+                        catalog_sources.push(CatalogSourceInput {
+                            raw_name: server_name.clone(),
+                            provenance: spec.provenance,
+                            transport: transport_label(spec),
+                            peer_info: peer.peer_info(),
+                            tools: upstream_tools,
+                            peer: peer.clone(),
+                            tool_timeout,
+                        });
+                        tracing::info!(
+                            "indexed MCP server '{server_name}' privately: {count} tool(s)"
+                        );
+                    }
                 }
                 services.push(service);
             }
@@ -331,6 +425,10 @@ pub async fn connect_upstreams(config: &AppConfig) -> Bridge {
             }
         }
     }
+
+    let mut catalog_tools = build_catalog_tools(catalog_sources);
+    catalog_tools.append(&mut tools);
+    tools = catalog_tools;
 
     Bridge {
         tools,
@@ -437,6 +535,45 @@ struct GatewayTool {
     tool_timeout: Option<Duration>,
 }
 
+impl GatewayTool {
+    async fn run(&self, args: Value, cancellation: Option<&CancellationToken>) -> ToolResult {
+        let Some(function) = args.get("function").and_then(|v| v.as_str()) else {
+            return ToolResult::error("`function` is required (the name of the function to call)");
+        };
+        if !self.function_names.iter().any(|f| f == function) {
+            return ToolResult::error(format!(
+                "Unknown {} function '{function}'. Read the '{}' skill for the list.",
+                self.server, self.server
+            ));
+        }
+
+        let mut params = CallToolRequestParams::new(function.to_string());
+        match args.get("arguments") {
+            None | Some(Value::Null) => {}
+            Some(Value::Object(obj)) => {
+                if !obj.is_empty() {
+                    params = params.with_arguments(obj.clone());
+                }
+            }
+            Some(_) => {
+                return ToolResult::error(
+                    "`arguments` must be a JSON object (an object mapping the function's parameter names to values)",
+                );
+            }
+        }
+
+        forward_tool_call(
+            &self.peer,
+            params,
+            &self.server,
+            function,
+            self.tool_timeout,
+            cancellation,
+        )
+        .await
+    }
+}
+
 #[async_trait]
 impl Tool for GatewayTool {
     fn name(&self) -> &'static str {
@@ -475,42 +612,17 @@ impl Tool for GatewayTool {
     }
 
     async fn call(&self, args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
-        let Some(function) = args.get("function").and_then(|v| v.as_str()) else {
-            return ToolResult::error("`function` is required (the name of the function to call)");
-        };
-        if !self.function_names.iter().any(|f| f == function) {
-            return ToolResult::error(format!(
-                "Unknown {} function '{function}'. Read the '{}' skill for the list.",
-                self.server, self.server
-            ));
-        }
+        self.run(args, None).await
+    }
 
-        let mut params = CallToolRequestParams::new(function.to_string());
-        // `arguments` is optional, but a present-but-malformed value must be
-        // rejected rather than silently dropped (which would call the function
-        // with no arguments).
-        match args.get("arguments") {
-            None | Some(Value::Null) => {}
-            Some(Value::Object(obj)) => {
-                if !obj.is_empty() {
-                    params = params.with_arguments(obj.clone());
-                }
-            }
-            Some(_) => {
-                return ToolResult::error(
-                    "`arguments` must be a JSON object (an object mapping the function's parameter names to values)",
-                );
-            }
-        }
-
-        forward_tool_call(
-            &self.peer,
-            params,
-            &self.server,
-            function,
-            self.tool_timeout,
-        )
-        .await
+    async fn call_with_context(
+        &self,
+        args: Value,
+        _config: &AppConfig,
+        _session: &SessionState,
+        context: &ToolRequestContext,
+    ) -> ToolResult {
+        self.run(args, Some(&context.cancellation)).await
     }
 }
 
@@ -534,6 +646,14 @@ async fn connect_one(
 enum UpstreamTransport<'a> {
     Stdio(&'a str),
     StreamableHttp(&'a str),
+}
+
+fn transport_label(spec: &crate::types::McpServerSpec) -> String {
+    if spec.command.is_some() {
+        "stdio".to_string()
+    } else {
+        "streamable-http".to_string()
+    }
 }
 
 fn select_transport(spec: &crate::types::McpServerSpec) -> Result<UpstreamTransport<'_>, String> {
@@ -836,7 +956,8 @@ fn tool_is_enabled(spec: &crate::types::McpServerSpec, name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::McpServerSpec;
+    use crate::mcp_catalog::{MCP_CALL_TOOL, MCP_GET_TOOL, MCP_LIST_SOURCES, MCP_SEARCH_TOOLS};
+    use crate::types::{McpServerProvenance, McpServerSpec, McpToolExposure, ToolContent};
     use axum::{
         Router,
         extract::{Request, State},
@@ -846,15 +967,15 @@ mod tests {
     use rmcp::{
         ErrorData as McpError, ServerHandler,
         model::{
-            CallToolResponse, Implementation, InitializeResult, ListToolsResult,
-            PaginatedRequestParams, ServerCapabilities, ServerInfo,
+            CallToolResponse, Icon, Implementation, InitializeResult, ListToolsResult, MetaObject,
+            PaginatedRequestParams, ServerCapabilities, ServerInfo, ToolAnnotations,
         },
         service::{RequestContext, RoleServer},
         transport::streamable_http_server::{
             StreamableHttpServerConfig, StreamableHttpService, session::local::LocalSessionManager,
         },
     };
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     #[derive(Clone)]
     struct ExpectedHeaders {
@@ -956,6 +1077,231 @@ mod tests {
         (format!("http://{address}/mcp"), task)
     }
 
+    #[derive(Debug, Clone, PartialEq)]
+    struct RecordedCall {
+        name: String,
+        arguments: Option<serde_json::Map<String, Value>>,
+    }
+
+    #[derive(Clone)]
+    struct CatalogTestMcp {
+        calls: Arc<Mutex<Vec<RecordedCall>>>,
+    }
+
+    fn object_schema(value: Value) -> serde_json::Map<String, Value> {
+        value.as_object().cloned().unwrap()
+    }
+
+    fn catalog_test_tools() -> Vec<rmcp::model::Tool> {
+        let generic_schema = object_schema(json!({
+            "type": "object",
+            "properties": {
+                "value": {
+                    "type": "string",
+                    "description": "Value for this generic IDA operation"
+                }
+            },
+            "additionalProperties": false
+        }));
+        let mut tools = (0..66)
+            .map(|index| {
+                rmcp::model::Tool::new(
+                    format!("ida_operation_{index:02}"),
+                    format!("Generic IDA operation number {index}"),
+                    generic_schema.clone(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let decompile_input = object_schema(json!({
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "object",
+                    "description": "Target code location",
+                    "properties": {
+                        "virtual_address": {
+                            "type": "string",
+                            "description": "Function virtual address to decompile"
+                        }
+                    },
+                    "required": ["virtual_address"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["location"],
+            "additionalProperties": false
+        }));
+        let decompile_output = object_schema(json!({
+            "type": "object",
+            "properties": {
+                "rawTool": { "type": "string" },
+                "address": { "type": "string" }
+            },
+            "required": ["rawTool", "address"],
+            "additionalProperties": false
+        }));
+        let mut tool_meta = MetaObject::new();
+        tool_meta
+            .0
+            .insert("vendor".into(), Value::String("hex-rays".into()));
+        tools.push(
+            rmcp::model::Tool::new(
+                "decompile_function",
+                "Decompile a function and recover high-level pseudocode",
+                decompile_input,
+            )
+            .with_title("Decompile function")
+            .with_raw_output_schema(Arc::new(decompile_output))
+            .with_annotations(
+                ToolAnnotations::new()
+                    .read_only(true)
+                    .destructive(false)
+                    .idempotent(true)
+                    .open_world(false),
+            )
+            .with_icons(vec![Icon::new("https://example.invalid/decompiler.svg")])
+            .with_meta(tool_meta),
+        );
+        tools.push(rmcp::model::Tool::new(
+            "rename-function",
+            "Rename a function by address",
+            generic_schema.clone(),
+        ));
+        tools.push(rmcp::model::Tool::new(
+            "rename_function",
+            "Rename a function by symbol",
+            generic_schema.clone(),
+        ));
+        tools.push(rmcp::model::Tool::new(
+            "passthrough",
+            "Return mixed content, structured data, and result metadata",
+            generic_schema.clone(),
+        ));
+        tools.push(rmcp::model::Tool::new(
+            "error_result",
+            "Return a caller-visible tool error",
+            generic_schema,
+        ));
+        tools
+    }
+
+    impl ServerHandler for CatalogTestMcp {
+        fn get_info(&self) -> ServerInfo {
+            let mut implementation = Implementation::new("catalog-test-upstream", "9.8.7");
+            implementation.title = Some("IDA semantic analysis bridge".to_string());
+            implementation.description = Some("Metadata-rich many-tool MCP fixture".to_string());
+            InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+                .with_server_info(implementation)
+                .with_instructions(
+                    "Search for decompilation, renaming, and program-analysis operations.",
+                )
+        }
+
+        async fn list_tools(
+            &self,
+            _request: Option<PaginatedRequestParams>,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<ListToolsResult, McpError> {
+            Ok(ListToolsResult::with_all_items(catalog_test_tools()))
+        }
+
+        async fn call_tool(
+            &self,
+            request: CallToolRequestParams,
+            _context: RequestContext<RoleServer>,
+        ) -> Result<CallToolResponse, McpError> {
+            self.calls.lock().unwrap().push(RecordedCall {
+                name: request.name.to_string(),
+                arguments: request.arguments.clone(),
+            });
+
+            match request.name.as_ref() {
+                "decompile_function" => {
+                    let address = request
+                        .arguments
+                        .as_ref()
+                        .and_then(|arguments| arguments.get("location"))
+                        .and_then(Value::as_object)
+                        .and_then(|location| location.get("virtual_address"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default();
+                    Ok(CallToolResult::structured(json!({
+                        "rawTool": request.name,
+                        "address": address
+                    }))
+                    .into())
+                }
+                "passthrough" => {
+                    let mut result_meta = MetaObject::new();
+                    result_meta
+                        .0
+                        .insert("trace".into(), Value::String("fixture-result-meta".into()));
+                    let mut result = CallToolResult::success(vec![
+                        ContentBlock::text("mixed text"),
+                        ContentBlock::image("aGVsbG8=", "image/png"),
+                    ])
+                    .with_meta(Some(result_meta));
+                    result.structured_content = Some(json!({ "kind": "mixed", "ok": true }));
+                    Ok(result.into())
+                }
+                "error_result" => Ok(CallToolResult::error(vec![ContentBlock::text(
+                    "fixture tool error",
+                )])
+                .into()),
+                _ => Ok(CallToolResult::success(vec![ContentBlock::text(
+                    request.name.to_string(),
+                )])
+                .into()),
+            }
+        }
+    }
+
+    async fn spawn_catalog_upstream() -> (
+        String,
+        Arc<Mutex<Vec<RecordedCall>>>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .unwrap();
+        let address = listener.local_addr().unwrap();
+        let calls = Arc::new(Mutex::new(Vec::new()));
+        let factory_calls = calls.clone();
+        let mut config = StreamableHttpServerConfig::default();
+        config.json_response = true;
+        let service = StreamableHttpService::new(
+            move || {
+                Ok(CatalogTestMcp {
+                    calls: factory_calls.clone(),
+                })
+            },
+            Arc::new(LocalSessionManager::default()),
+            config,
+        );
+        let app = Router::new().nest_service("/mcp", service);
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (format!("http://{address}/mcp"), calls, task)
+    }
+
+    fn bridge_tool<'a>(bridge: &'a Bridge, name: &str) -> &'a dyn Tool {
+        bridge
+            .tools
+            .iter()
+            .find(|tool| tool.name() == name)
+            .map(|tool| tool.as_ref())
+            .unwrap_or_else(|| panic!("missing bridge tool {name}"))
+    }
+
+    async fn call_bridge_tool(bridge: &Bridge, name: &str, args: Value) -> ToolResult {
+        let config = crate::config::default_config(std::env::temp_dir());
+        bridge_tool(bridge, name)
+            .call(args, &config, &SessionState::new())
+            .await
+    }
+
     #[test]
     fn unique_name_dedups_with_suffix() {
         let mut used = std::collections::HashSet::new();
@@ -1020,6 +1366,551 @@ mod tests {
 
         let e = map_call_result(CallToolResult::error(vec![ContentBlock::text("boom")]));
         assert!(e.is_error);
+    }
+
+    #[tokio::test]
+    async fn catalog_mode_keeps_many_tools_private_and_supports_progressive_discovery() {
+        let (url, calls, server_task) = spawn_catalog_upstream().await;
+        let mut config = crate::config::default_config(std::env::temp_dir());
+        config.mcp_servers.insert(
+            "IDA MCP!".to_string(),
+            McpServerSpec {
+                url: Some(url),
+                provenance: McpServerProvenance::CodexConfig,
+                ..Default::default()
+            },
+        );
+
+        let bridge = connect_upstreams(&config).await;
+        let names = bridge
+            .tools
+            .iter()
+            .map(|tool| tool.name())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            [
+                MCP_LIST_SOURCES,
+                MCP_SEARCH_TOOLS,
+                MCP_GET_TOOL,
+                MCP_CALL_TOOL
+            ]
+        );
+        assert!(
+            bridge
+                .tools
+                .iter()
+                .all(|tool| !tool.requires_project_root())
+        );
+        assert!(bridge.tools.iter().all(|tool| tool.title().is_some()));
+        assert!(
+            bridge_tool(&bridge, MCP_LIST_SOURCES)
+                .output_schema()
+                .is_some()
+        );
+        assert!(
+            bridge_tool(&bridge, MCP_SEARCH_TOOLS)
+                .output_schema()
+                .is_some()
+        );
+        assert!(bridge_tool(&bridge, MCP_GET_TOOL).output_schema().is_some());
+        assert!(
+            bridge_tool(&bridge, MCP_CALL_TOOL)
+                .output_schema()
+                .is_none()
+        );
+        let discovery_annotations = bridge_tool(&bridge, MCP_SEARCH_TOOLS)
+            .annotations()
+            .unwrap();
+        assert_eq!(discovery_annotations.read_only_hint, Some(true));
+        assert_eq!(discovery_annotations.destructive_hint, Some(false));
+        assert_eq!(discovery_annotations.open_world_hint, Some(false));
+        let dispatcher_annotations = bridge_tool(&bridge, MCP_CALL_TOOL).annotations().unwrap();
+        assert_eq!(dispatcher_annotations.read_only_hint, Some(false));
+        assert_eq!(dispatcher_annotations.destructive_hint, Some(true));
+        assert_eq!(dispatcher_annotations.open_world_hint, Some(true));
+        let source_manifest = bridge_tool(&bridge, MCP_LIST_SOURCES).description();
+        assert!(source_manifest.contains("IDA_MCP_"));
+        assert!(source_manifest.contains("IDA MCP!"));
+        assert!(
+            bridge
+                .report
+                .iter()
+                .any(|line| line == "IDA MCP! -> catalog (71 private tool(s))")
+        );
+
+        let listed = call_bridge_tool(&bridge, MCP_LIST_SOURCES, json!({})).await;
+        assert!(!listed.is_error);
+        let listed = listed.structured_content.unwrap();
+        assert_eq!(listed["total"], 1);
+        assert_eq!(listed["sources"][0]["name"], "IDA MCP!");
+        assert_eq!(listed["sources"][0]["provenance"], "codex-config");
+        assert_eq!(listed["sources"][0]["transport"], "streamable-http");
+        assert_eq!(listed["sources"][0]["toolCount"], 71);
+        assert_eq!(
+            listed["sources"][0]["implementation"]["name"],
+            "catalog-test-upstream"
+        );
+        assert_eq!(
+            listed["sources"][0]["implementation"]["title"],
+            "IDA semantic analysis bridge"
+        );
+        assert!(
+            listed["sources"][0]["instructions"]
+                .as_str()
+                .unwrap()
+                .contains("program-analysis")
+        );
+        let source_id = listed["sources"][0]["id"].as_str().unwrap().to_string();
+        assert_eq!(source_id, "IDA_MCP_");
+
+        let filtered_sources = call_bridge_tool(
+            &bridge,
+            MCP_LIST_SOURCES,
+            json!({ "query": "semantic analysis" }),
+        )
+        .await
+        .structured_content
+        .unwrap();
+        assert_eq!(filtered_sources["total"], 1);
+        let missing_sources = call_bridge_tool(
+            &bridge,
+            MCP_LIST_SOURCES,
+            json!({ "query": "nonexistent system" }),
+        )
+        .await
+        .structured_content
+        .unwrap();
+        assert_eq!(missing_sources["total"], 0);
+
+        let searched = call_bridge_tool(
+            &bridge,
+            MCP_SEARCH_TOOLS,
+            json!({
+                "query": "decompile virtual address",
+                "source": source_id,
+                "limit": 5
+            }),
+        )
+        .await;
+        assert!(!searched.is_error);
+        let searched = searched.structured_content.unwrap();
+        assert_eq!(searched["matches"][0]["toolName"], "decompile_function");
+        let decompile_id = searched["matches"][0]["toolId"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let definition = call_bridge_tool(
+            &bridge,
+            MCP_GET_TOOL,
+            json!({ "source": source_id, "tool": decompile_id }),
+        )
+        .await;
+        assert!(!definition.is_error);
+        let definition = definition.structured_content.unwrap();
+        assert_eq!(definition["tool"]["id"], "decompile_function");
+        assert_eq!(definition["tool"]["name"], "decompile_function");
+        assert_eq!(definition["tool"]["title"], "Decompile function");
+        assert_eq!(
+            definition["tool"]["inputSchema"]["properties"]["location"]["properties"]["virtual_address"]
+                ["description"],
+            "Function virtual address to decompile"
+        );
+        assert_eq!(definition["tool"]["annotations"]["readOnlyHint"], true);
+        assert_eq!(
+            definition["tool"]["icons"][0]["src"],
+            "https://example.invalid/decompiler.svg"
+        );
+        assert_eq!(definition["tool"]["_meta"]["vendor"], "hex-rays");
+        assert_eq!(
+            definition["tool"]["outputSchema"]["properties"]["address"]["type"],
+            "string"
+        );
+
+        let decompiled = call_bridge_tool(
+            &bridge,
+            MCP_CALL_TOOL,
+            json!({
+                "source": source_id,
+                "tool": decompile_id,
+                "arguments": {
+                    "location": { "virtual_address": "0x81000000" }
+                }
+            }),
+        )
+        .await;
+        assert!(!decompiled.is_error);
+        assert_eq!(
+            decompiled.structured_content,
+            Some(json!({
+                "rawTool": "decompile_function",
+                "address": "0x81000000"
+            }))
+        );
+        assert_eq!(
+            calls.lock().unwrap().last().unwrap().name,
+            "decompile_function"
+        );
+
+        let call_count = calls.lock().unwrap().len();
+        let malformed = call_bridge_tool(
+            &bridge,
+            MCP_CALL_TOOL,
+            json!({
+                "source": source_id,
+                "tool": decompile_id,
+                "arguments": ["not", "an", "object"]
+            }),
+        )
+        .await;
+        assert!(malformed.is_error);
+        assert!(malformed.joined_text().contains("must be a JSON object"));
+        assert_eq!(calls.lock().unwrap().len(), call_count);
+
+        let renamed = call_bridge_tool(
+            &bridge,
+            MCP_SEARCH_TOOLS,
+            json!({ "query": "rename function", "source": source_id, "limit": 10 }),
+        )
+        .await
+        .structured_content
+        .unwrap();
+        let renamed = renamed["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|entry| {
+                entry["toolName"] == "rename-function" || entry["toolName"] == "rename_function"
+            })
+            .map(|entry| {
+                (
+                    entry["toolId"].as_str().unwrap().to_string(),
+                    entry["toolName"].as_str().unwrap().to_string(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(renamed.len(), 2);
+        assert_ne!(renamed[0].0, renamed[1].0);
+        for (tool_id, raw_name) in &renamed {
+            let result = call_bridge_tool(
+                &bridge,
+                MCP_CALL_TOOL,
+                json!({
+                    "source": source_id,
+                    "tool": tool_id,
+                    "arguments": { "value": "new_name" }
+                }),
+            )
+            .await;
+            assert!(!result.is_error);
+            assert_eq!(result.joined_text(), *raw_name);
+            assert_eq!(calls.lock().unwrap().last().unwrap().name, *raw_name);
+        }
+
+        let passthrough = call_bridge_tool(
+            &bridge,
+            MCP_SEARCH_TOOLS,
+            json!({ "query": "passthrough", "source": source_id, "limit": 1 }),
+        )
+        .await
+        .structured_content
+        .unwrap();
+        let passthrough_id = passthrough["matches"][0]["toolId"].as_str().unwrap();
+        let passthrough = call_bridge_tool(
+            &bridge,
+            MCP_CALL_TOOL,
+            json!({ "source": source_id, "tool": passthrough_id, "arguments": {} }),
+        )
+        .await;
+        assert!(!passthrough.is_error);
+        assert_eq!(passthrough.content.len(), 2);
+        assert!(matches!(
+            &passthrough.content[0],
+            ToolContent::Text(text) if text == "mixed text"
+        ));
+        assert!(matches!(
+            &passthrough.content[1],
+            ToolContent::Image { data, mime_type }
+                if data == "aGVsbG8=" && mime_type == "image/png"
+        ));
+        assert_eq!(
+            passthrough.structured_content,
+            Some(json!({ "kind": "mixed", "ok": true }))
+        );
+        assert_eq!(
+            passthrough
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.0.get("trace")),
+            Some(&Value::String("fixture-result-meta".to_string()))
+        );
+
+        let failed = call_bridge_tool(
+            &bridge,
+            MCP_SEARCH_TOOLS,
+            json!({ "query": "error_result", "source": source_id, "limit": 1 }),
+        )
+        .await
+        .structured_content
+        .unwrap();
+        let failed_id = failed["matches"][0]["toolId"].as_str().unwrap();
+        let failed = call_bridge_tool(
+            &bridge,
+            MCP_CALL_TOOL,
+            json!({ "source": source_id, "tool": failed_id }),
+        )
+        .await;
+        assert!(failed.is_error);
+        assert_eq!(failed.joined_text(), "fixture tool error");
+
+        drop(bridge);
+        server_task.abort();
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn catalog_mode_applies_allow_and_deny_filters_before_indexing() {
+        let (url, _calls, server_task) = spawn_catalog_upstream().await;
+        let mut config = crate::config::default_config(std::env::temp_dir());
+        config.mcp_servers.insert(
+            "filtered".to_string(),
+            McpServerSpec {
+                url: Some(url),
+                provenance: McpServerProvenance::CodexCli,
+                tools: Some(vec![
+                    "decompile_function".to_string(),
+                    "rename-function".to_string(),
+                    "error_result".to_string(),
+                ]),
+                disabled_tools: Some(vec!["error_result".to_string()]),
+                ..Default::default()
+            },
+        );
+
+        let bridge = connect_upstreams(&config).await;
+        assert_eq!(bridge.tools.len(), 4);
+        let listed = call_bridge_tool(&bridge, MCP_LIST_SOURCES, json!({}))
+            .await
+            .structured_content
+            .unwrap();
+        assert_eq!(listed["sources"][0]["toolCount"], 2);
+        assert_eq!(listed["sources"][0]["provenance"], "codex-cli");
+        let source_id = listed["sources"][0]["id"].as_str().unwrap();
+        let excluded = call_bridge_tool(
+            &bridge,
+            MCP_SEARCH_TOOLS,
+            json!({ "query": "error_result", "source": source_id }),
+        )
+        .await
+        .structured_content
+        .unwrap();
+        assert_eq!(excluded["total"], 0);
+        let included = call_bridge_tool(
+            &bridge,
+            MCP_SEARCH_TOOLS,
+            json!({ "query": "decompile", "source": source_id }),
+        )
+        .await
+        .structured_content
+        .unwrap();
+        assert_eq!(included["matches"][0]["toolName"], "decompile_function");
+
+        drop(bridge);
+        server_task.abort();
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn catalog_source_ids_disambiguate_sanitized_name_collisions() {
+        let (first_url, first_calls, first_server_task) = spawn_catalog_upstream().await;
+        let (second_url, second_calls, second_server_task) = spawn_catalog_upstream().await;
+        let mut config = crate::config::default_config(std::env::temp_dir());
+        config.mcp_servers.insert(
+            "ida-mcp".to_string(),
+            McpServerSpec {
+                url: Some(first_url),
+                mode: Some(McpToolExposure::Catalog),
+                ..Default::default()
+            },
+        );
+        config.mcp_servers.insert(
+            "ida_mcp".to_string(),
+            McpServerSpec {
+                url: Some(second_url),
+                mode: Some(McpToolExposure::Catalog),
+                ..Default::default()
+            },
+        );
+
+        let bridge = connect_upstreams(&config).await;
+        assert_eq!(bridge.tools.len(), 4);
+        let listed = call_bridge_tool(&bridge, MCP_LIST_SOURCES, json!({}))
+            .await
+            .structured_content
+            .unwrap();
+        assert_eq!(listed["total"], 2);
+        let sources = listed["sources"].as_array().unwrap();
+        let ids = sources
+            .iter()
+            .map(|source| source["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        let names = sources
+            .iter()
+            .map(|source| source["name"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, ["ida_mcp", "ida_mcp_2"]);
+        assert_eq!(names, ["ida-mcp", "ida_mcp"]);
+
+        let searched = call_bridge_tool(
+            &bridge,
+            MCP_SEARCH_TOOLS,
+            json!({ "query": "decompile", "source": "ida_mcp_2", "limit": 1 }),
+        )
+        .await
+        .structured_content
+        .unwrap();
+        let tool_id = searched["matches"][0]["toolId"].as_str().unwrap();
+        let called = call_bridge_tool(
+            &bridge,
+            MCP_CALL_TOOL,
+            json!({
+                "source": "ida_mcp_2",
+                "tool": tool_id,
+                "arguments": { "location": { "virtual_address": "0x82000000" } }
+            }),
+        )
+        .await;
+        assert!(!called.is_error);
+        assert!(first_calls.lock().unwrap().is_empty());
+        assert_eq!(
+            second_calls.lock().unwrap().last().unwrap().name,
+            "decompile_function"
+        );
+
+        drop(bridge);
+        first_server_task.abort();
+        second_server_task.abort();
+        let _ = first_server_task.await;
+        let _ = second_server_task.await;
+    }
+
+    #[tokio::test]
+    async fn explicit_direct_mode_retains_per_tool_exposure_and_metadata() {
+        let (url, calls, server_task) = spawn_catalog_upstream().await;
+        let mut config = crate::config::default_config(std::env::temp_dir());
+        config.mcp_servers.insert(
+            "IDA MCP!".to_string(),
+            McpServerSpec {
+                url: Some(url),
+                mode: Some(McpToolExposure::Direct),
+                ..Default::default()
+            },
+        );
+
+        let bridge = connect_upstreams(&config).await;
+        assert_eq!(bridge.tools.len(), 71);
+        assert!(bridge.tools.iter().all(|tool| !matches!(
+            tool.name(),
+            MCP_LIST_SOURCES | MCP_SEARCH_TOOLS | MCP_GET_TOOL | MCP_CALL_TOOL
+        )));
+        let names = bridge
+            .tools
+            .iter()
+            .map(|tool| tool.name())
+            .collect::<Vec<_>>();
+        assert!(names.contains(&"IDA_MCP___rename_function"));
+        assert!(names.contains(&"IDA_MCP___rename_function_2"));
+
+        let decompile = bridge
+            .tools
+            .iter()
+            .find(|tool| tool.name() == "IDA_MCP___decompile_function")
+            .unwrap();
+        assert_eq!(decompile.title().as_deref(), Some("Decompile function"));
+        assert_eq!(
+            decompile
+                .annotations()
+                .and_then(|annotations| annotations.read_only_hint),
+            Some(true)
+        );
+        assert_eq!(decompile.icons().unwrap().len(), 1);
+        assert_eq!(
+            decompile
+                .meta()
+                .as_ref()
+                .and_then(|meta| meta.0.get("vendor")),
+            Some(&Value::String("hex-rays".to_string()))
+        );
+        assert!(decompile.output_schema().is_some());
+
+        let result = call_bridge_tool(
+            &bridge,
+            "IDA_MCP___decompile_function",
+            json!({ "location": { "virtual_address": "0xDEADBEEF" } }),
+        )
+        .await;
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "rawTool": "decompile_function",
+                "address": "0xDEADBEEF"
+            }))
+        );
+        assert_eq!(
+            calls.lock().unwrap().last().unwrap().name,
+            "decompile_function"
+        );
+
+        drop(bridge);
+        server_task.abort();
+        let _ = server_task.await;
+    }
+
+    #[tokio::test]
+    async fn explicit_gateway_mode_remains_a_single_compatible_dispatcher() {
+        let (url, calls, server_task) = spawn_catalog_upstream().await;
+        let generated = tempfile::tempdir().unwrap();
+        let mut config = crate::config::default_config(std::env::temp_dir());
+        config.generated_skills_dir = Some(generated.path().to_path_buf());
+        config.mcp_servers.insert(
+            "IDA MCP!".to_string(),
+            McpServerSpec {
+                url: Some(url),
+                mode: Some(McpToolExposure::Gateway),
+                ..Default::default()
+            },
+        );
+
+        let bridge = connect_upstreams(&config).await;
+        assert_eq!(bridge.tools.len(), 1);
+        assert_eq!(bridge.tools[0].name(), "IDA_MCP_");
+        assert!(generated.path().join("IDA MCP!").join("SKILL.md").is_file());
+
+        let result = call_bridge_tool(
+            &bridge,
+            "IDA_MCP_",
+            json!({ "function": "rename-function", "arguments": { "value": "new_name" } }),
+        )
+        .await;
+        assert!(!result.is_error);
+        assert_eq!(result.joined_text(), "rename-function");
+        assert_eq!(
+            calls.lock().unwrap().last().unwrap().name,
+            "rename-function"
+        );
+
+        let malformed = call_bridge_tool(
+            &bridge,
+            "IDA_MCP_",
+            json!({ "function": "rename-function", "arguments": "wrong" }),
+        )
+        .await;
+        assert!(malformed.is_error);
+
+        drop(bridge);
+        server_task.abort();
+        let _ = server_task.await;
     }
 
     #[test]
@@ -1179,6 +2070,7 @@ mod tests {
             "remote",
             "echo",
             tool_timeout,
+            None,
         )
         .await;
         assert!(!echo.is_error);
@@ -1191,10 +2083,39 @@ mod tests {
             "remote",
             "slow",
             tool_timeout,
+            None,
         )
         .await;
         assert!(slow.is_error);
         assert!(slow.joined_text().contains("timed out after"));
+
+        let cancellation = CancellationToken::new();
+        let cancel_task = {
+            let cancellation = cancellation.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+                cancellation.cancel();
+            })
+        };
+        let started = std::time::Instant::now();
+        let cancelled = forward_tool_call(
+            service.peer(),
+            CallToolRequestParams::new("slow")
+                .with_arguments(json!({ "text": "cancelled" }).as_object().cloned().unwrap()),
+            "remote",
+            "slow",
+            Some(Duration::from_secs(5)),
+            Some(&cancellation),
+        )
+        .await;
+        cancel_task.await.unwrap();
+        assert!(cancelled.is_error);
+        assert!(
+            cancelled
+                .joined_text()
+                .contains("cancelled by downstream client")
+        );
+        assert!(started.elapsed() < Duration::from_millis(150));
 
         drop(service);
         server_task.abort();

--- a/src/codex_mcp.rs
+++ b/src/codex_mcp.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use crate::codex_config::load_codex_config;
 #[cfg(test)]
 use crate::codex_config::parse_codex_config;
-use crate::types::McpServerSpec;
+use crate::types::{McpServerProvenance, McpServerSpec};
 
 const CODEX_CLI_TIMEOUT: Duration = Duration::from_secs(30);
 const CODEX_CLI_MAX_OUTPUT_BYTES: usize = 4 * 1024 * 1024;
@@ -341,6 +341,7 @@ fn codex_cli_server_to_spec(
             tools: server.enabled_tools,
             disabled_tools: server.disabled_tools,
             mode: None,
+            provenance: McpServerProvenance::CodexCli,
         });
     }
     if matches!(kind.as_str(), "sse" | "websocket" | "ws") {
@@ -406,6 +407,7 @@ fn codex_cli_server_to_spec(
         tools: server.enabled_tools,
         disabled_tools: server.disabled_tools,
         mode: None,
+        provenance: McpServerProvenance::CodexCli,
     })
 }
 
@@ -604,6 +606,7 @@ fn parse_server(
                 tools,
                 disabled_tools,
                 mode: None,
+                provenance: McpServerProvenance::CodexConfig,
             }),
             ignored_fields,
         });
@@ -651,6 +654,7 @@ fn parse_server(
             tools,
             disabled_tools,
             mode: None,
+            provenance: McpServerProvenance::CodexConfig,
         }),
         ignored_fields,
     })
@@ -800,6 +804,8 @@ STATIC_SECRET = "do-not-log-this"
         })
         .unwrap();
         let server = outcome.servers.get("demo").unwrap();
+        assert_eq!(server.provenance, McpServerProvenance::CodexConfig);
+        assert_eq!(server.exposure(), crate::types::McpToolExposure::Catalog);
         assert_eq!(server.command.as_deref(), Some("npx"));
         assert_eq!(server.args, ["-y", "demo-server"]);
         assert_eq!(server.cwd.as_deref(), Some("/tmp/demo"));
@@ -1018,6 +1024,8 @@ command = "good-server"
         );
         assert!(!outcome.servers.contains_key("global"));
         let plugin = outcome.servers.get("plugin").unwrap();
+        assert_eq!(plugin.provenance, McpServerProvenance::CodexCli);
+        assert_eq!(plugin.exposure(), crate::types::McpToolExposure::Catalog);
         assert_eq!(plugin.command.as_deref(), Some("uv"));
         assert_eq!(plugin.args, ["run", "plugin-mcp"]);
         assert_eq!(plugin.cwd.as_deref(), Some("/plugins/example"));
@@ -1077,6 +1085,8 @@ command = "good-server"
         )
         .unwrap();
         let server = outcome.servers.get("plugin-web").unwrap();
+        assert_eq!(server.provenance, McpServerProvenance::CodexCli);
+        assert_eq!(server.exposure(), crate::types::McpToolExposure::Catalog);
         assert_eq!(server.transport.as_deref(), Some("streamable-http"));
         assert_eq!(server.url.as_deref(), Some("https://example.invalid/mcp"));
         assert_eq!(server.bearer_token_env_var.as_deref(), Some("WEB_TOKEN"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,10 +24,10 @@ use crate::openai_tunnel::validate_tunnel_id;
 use crate::project_catalog::{ProjectCatalog, discover_project_catalog_at};
 use crate::types::{
     AppConfig, ArtifactIngressConfig, AuditConfig, CodexProjectCatalogConfig, CommandConfig,
-    ConversationAuthToken, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, MemoryConfig,
-    OpenAiTunnelConfig, OutputConfig, ProjectCatalogConfig, ProjectCatalogEntryConfig,
-    ProjectDocConfig, ReviewConfig, SkillsConfig, TreeConfig, WorktreeConfig, WorktreeMode,
-    WorktreeUpstreamRefreshMode,
+    ConversationAuthToken, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, McpToolExposure,
+    MemoryConfig, OpenAiTunnelConfig, OutputConfig, ProjectCatalogConfig,
+    ProjectCatalogEntryConfig, ProjectDocConfig, ReviewConfig, SkillsConfig, TreeConfig,
+    WorktreeConfig, WorktreeMode, WorktreeUpstreamRefreshMode,
 };
 use crate::util::home_dir;
 
@@ -328,7 +328,7 @@ struct PartialMcpServerSpec {
     tool_timeout_sec: Option<f64>,
     tools: Option<Vec<String>>,
     disabled_tools: Option<Vec<String>>,
-    mode: Option<String>,
+    mode: Option<McpToolExposure>,
 }
 
 impl PartialMcpServerSpec {
@@ -1370,6 +1370,7 @@ mod tests {
             tools: Some(vec!["read".to_string()]),
             disabled_tools: Some(vec!["write".to_string()]),
             mode: None,
+            provenance: crate::types::McpServerProvenance::CodexConfig,
         }
     }
 
@@ -1690,7 +1691,7 @@ mod tests {
         let explicit = HashMap::from([(
             "demo".to_string(),
             PartialMcpServerSpec {
-                mode: Some("gateway".to_string()),
+                mode: Some(McpToolExposure::Gateway),
                 disabled: Some(false),
                 ..Default::default()
             },
@@ -1701,9 +1702,80 @@ mod tests {
         assert_eq!(server.command.as_deref(), Some("codex-server"));
         assert_eq!(server.args, ["--stdio"]);
         assert_eq!(server.env.get("TOKEN").map(String::as_str), Some("secret"));
-        assert_eq!(server.mode.as_deref(), Some("gateway"));
+        assert_eq!(server.mode, Some(McpToolExposure::Gateway));
+        assert_eq!(server.exposure(), McpToolExposure::Gateway);
+        assert_eq!(
+            server.provenance,
+            crate::types::McpServerProvenance::CodexConfig
+        );
         assert!(!server.disabled);
         assert_eq!(report.len(), 1);
+    }
+
+    #[test]
+    fn exposure_defaults_are_selected_by_server_provenance() {
+        let explicit = McpServerSpec::default();
+        assert_eq!(explicit.exposure(), McpToolExposure::Direct);
+
+        let imported_config = imported_server();
+        assert_eq!(imported_config.exposure(), McpToolExposure::Catalog);
+
+        let imported_cli = McpServerSpec {
+            provenance: crate::types::McpServerProvenance::CodexCli,
+            ..Default::default()
+        };
+        assert_eq!(imported_cli.exposure(), McpToolExposure::Catalog);
+    }
+
+    #[test]
+    fn explicit_overlays_preserve_imported_catalog_default_unless_mode_is_set() {
+        let imported = HashMap::from([("demo".to_string(), imported_server())]);
+        let explicit = HashMap::from([(
+            "demo".to_string(),
+            PartialMcpServerSpec {
+                disabled: Some(false),
+                ..Default::default()
+            },
+        )]);
+        let (merged, _) = merge_mcp_servers(imported, explicit);
+        let server = merged.get("demo").unwrap();
+        assert_eq!(server.exposure(), McpToolExposure::Catalog);
+        assert_eq!(
+            server.provenance,
+            crate::types::McpServerProvenance::CodexConfig
+        );
+
+        let imported = HashMap::from([("demo".to_string(), imported_server())]);
+        let explicit = HashMap::from([(
+            "demo".to_string(),
+            PartialMcpServerSpec {
+                mode: Some(McpToolExposure::Direct),
+                ..Default::default()
+            },
+        )]);
+        let (merged, _) = merge_mcp_servers(imported, explicit);
+        assert_eq!(
+            merged.get("demo").unwrap().exposure(),
+            McpToolExposure::Direct
+        );
+    }
+
+    #[test]
+    fn standalone_explicit_server_keeps_the_historical_direct_default() {
+        let explicit = HashMap::from([(
+            "local".to_string(),
+            PartialMcpServerSpec {
+                command: Some("local-server".to_string()),
+                ..Default::default()
+            },
+        )]);
+        let (merged, _) = merge_mcp_servers(HashMap::new(), explicit);
+        let server = merged.get("local").unwrap();
+        assert_eq!(
+            server.provenance,
+            crate::types::McpServerProvenance::Explicit
+        );
+        assert_eq!(server.exposure(), McpToolExposure::Direct);
     }
 
     #[test]
@@ -1833,7 +1905,7 @@ mod tests {
         );
         assert_eq!(demo.startup_timeout_sec, Some(12.5));
         assert_eq!(demo.tool_timeout_sec, Some(30.0));
-        assert_eq!(demo.mode.as_deref(), Some("gateway"));
+        assert_eq!(demo.mode, Some(McpToolExposure::Gateway));
         assert_eq!(
             demo.disabled_tools.as_deref(),
             Some(&["write".to_string()][..])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod exec_sessions;
 pub mod ignore_rules;
 pub mod instructions;
 pub mod logging;
+mod mcp_catalog;
 pub mod memory;
 pub mod openai_tunnel;
 pub mod output_budget;

--- a/src/mcp_catalog.rs
+++ b/src/mcp_catalog.rs
@@ -1,0 +1,1067 @@
+//! Progressive disclosure for transitively discovered MCP tools.
+
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use rmcp::RoleClient;
+use rmcp::model::{
+    CallToolRequestParams, Implementation, ServerPeerInfo, Tool as McpTool, ToolAnnotations,
+};
+use rmcp::service::Peer;
+use serde_json::{Map, Value, json};
+use tokio_util::sync::CancellationToken;
+
+use crate::bridge::forward_tool_call;
+use crate::exec_sessions::SessionState;
+use crate::tool::{Tool, ToolRequestContext};
+use crate::types::{AppConfig, McpServerProvenance, ToolResult};
+
+pub(crate) const MCP_LIST_SOURCES: &str = "mcp_list_sources";
+pub(crate) const MCP_SEARCH_TOOLS: &str = "mcp_search_tools";
+pub(crate) const MCP_GET_TOOL: &str = "mcp_get_tool";
+pub(crate) const MCP_CALL_TOOL: &str = "mcp_call_tool";
+
+const DEFAULT_SOURCE_LIMIT: usize = 50;
+const MAX_SOURCE_LIMIT: usize = 100;
+const DEFAULT_SEARCH_LIMIT: usize = 10;
+const MAX_SEARCH_LIMIT: usize = 50;
+const MAX_DESCRIPTION_CHARS: usize = 500;
+const BM25_K1: f64 = 1.2;
+const BM25_B: f64 = 0.75;
+
+pub(crate) struct CatalogSourceInput {
+    pub raw_name: String,
+    pub provenance: McpServerProvenance,
+    pub transport: String,
+    pub peer_info: Option<Arc<ServerPeerInfo>>,
+    pub tools: Vec<McpTool>,
+    pub peer: Peer<RoleClient>,
+    pub tool_timeout: Option<Duration>,
+}
+
+struct CatalogTool {
+    id: String,
+    raw: McpTool,
+}
+
+struct CatalogSource {
+    id: String,
+    raw_name: String,
+    provenance: McpServerProvenance,
+    transport: String,
+    implementation: Option<Implementation>,
+    instructions: Option<String>,
+    tools: Vec<CatalogTool>,
+    tool_by_id: HashMap<String, usize>,
+    peer: Peer<RoleClient>,
+    tool_timeout: Option<Duration>,
+}
+
+struct SearchDocument {
+    source_index: usize,
+    tool_index: usize,
+    term_frequency: HashMap<String, f64>,
+    length: f64,
+    normalized_name: String,
+    normalized_title: String,
+}
+
+struct SearchIndex {
+    documents: Vec<SearchDocument>,
+    document_frequency: HashMap<String, usize>,
+    average_length: f64,
+}
+
+struct Catalog {
+    sources: Vec<CatalogSource>,
+    source_by_id: HashMap<String, usize>,
+    index: SearchIndex,
+}
+
+impl Catalog {
+    fn new(mut inputs: Vec<CatalogSourceInput>) -> Self {
+        inputs.sort_by(|left, right| left.raw_name.cmp(&right.raw_name));
+        let mut used_sources = HashSet::new();
+        let mut sources = Vec::with_capacity(inputs.len());
+
+        for input in inputs {
+            let source_id = unique_identifier(
+                model_identifier(&input.raw_name, "source"),
+                &mut used_sources,
+            );
+            let mut used_tools = HashSet::new();
+            let mut raw_tools = input.tools;
+            raw_tools.sort_by(|left, right| {
+                left.name
+                    .cmp(&right.name)
+                    .then_with(|| left.title.cmp(&right.title))
+                    .then_with(|| left.description.cmp(&right.description))
+            });
+            let mut tools = Vec::with_capacity(raw_tools.len());
+            let mut tool_by_id = HashMap::new();
+
+            for raw in raw_tools {
+                let id =
+                    unique_identifier(model_identifier(raw.name.as_ref(), "tool"), &mut used_tools);
+                tool_by_id.insert(id.clone(), tools.len());
+                tools.push(CatalogTool { id, raw });
+            }
+
+            let (implementation, instructions) = input
+                .peer_info
+                .as_deref()
+                .map(|info| (info.server_info.clone(), info.instructions.clone()))
+                .unwrap_or((None, None));
+            sources.push(CatalogSource {
+                id: source_id,
+                raw_name: input.raw_name,
+                provenance: input.provenance,
+                transport: input.transport,
+                implementation,
+                instructions,
+                tools,
+                tool_by_id,
+                peer: input.peer,
+                tool_timeout: input.tool_timeout,
+            });
+        }
+
+        let source_by_id = sources
+            .iter()
+            .enumerate()
+            .map(|(index, source)| (source.id.clone(), index))
+            .collect();
+        let index = SearchIndex::build(&sources);
+        Self {
+            sources,
+            source_by_id,
+            index,
+        }
+    }
+
+    fn source(&self, id: &str) -> Result<&CatalogSource, String> {
+        self.source_by_id
+            .get(id)
+            .and_then(|index| self.sources.get(*index))
+            .ok_or_else(|| {
+                format!("Unknown MCP source id '{id}'. Call `{MCP_LIST_SOURCES}` first.")
+            })
+    }
+
+    fn tool<'a>(&'a self, source: &'a CatalogSource, id: &str) -> Result<&'a CatalogTool, String> {
+        source
+            .tool_by_id
+            .get(id)
+            .and_then(|index| source.tools.get(*index))
+            .ok_or_else(|| {
+                format!(
+                    "Unknown tool id '{id}' for MCP source '{}'. Search with `{MCP_SEARCH_TOOLS}` first.",
+                    source.id
+                )
+            })
+    }
+
+    fn manifest_description(&self) -> String {
+        let mut entries = self
+            .sources
+            .iter()
+            .take(20)
+            .map(|source| {
+                if source.id == source.raw_name {
+                    format!("`{}` ({} tools)", source.id, source.tools.len())
+                } else {
+                    format!(
+                        "`{}` / `{}` ({} tools)",
+                        source.id,
+                        source.raw_name,
+                        source.tools.len()
+                    )
+                }
+            })
+            .collect::<Vec<_>>();
+        if self.sources.len() > entries.len() {
+            entries.push(format!("{} more", self.sources.len() - entries.len()));
+        }
+        if entries.is_empty() {
+            "No catalog-mode sources are connected.".to_string()
+        } else {
+            format!("Connected private sources: {}.", entries.join(", "))
+        }
+    }
+
+    fn source_summary(source: &CatalogSource) -> Value {
+        let mut value = Map::new();
+        value.insert("id".into(), Value::String(source.id.clone()));
+        value.insert("name".into(), Value::String(source.raw_name.clone()));
+        value.insert(
+            "provenance".into(),
+            Value::String(source.provenance.as_str().to_string()),
+        );
+        value.insert("transport".into(), Value::String(source.transport.clone()));
+        value.insert("exposure".into(), Value::String("catalog".into()));
+        value.insert("toolCount".into(), json!(source.tools.len()));
+        if let Some(implementation) = &source.implementation
+            && let Ok(serialized) = serde_json::to_value(implementation)
+        {
+            value.insert("implementation".into(), serialized);
+        }
+        if let Some(instructions) = &source.instructions {
+            value.insert("instructions".into(), Value::String(instructions.clone()));
+        }
+        Value::Object(value)
+    }
+
+    fn tool_summary(source: &CatalogSource, tool: &CatalogTool, score: f64) -> Value {
+        let description = tool
+            .raw
+            .description
+            .as_deref()
+            .map(|description| truncate_chars(description, MAX_DESCRIPTION_CHARS));
+        json!({
+            "sourceId": source.id,
+            "sourceName": source.raw_name,
+            "toolId": tool.id,
+            "toolName": tool.raw.name,
+            "title": tool.raw.title,
+            "description": description,
+            "score": rounded_score(score),
+        })
+    }
+
+    fn tool_metadata(source: &CatalogSource, tool: &CatalogTool) -> Value {
+        let mut serialized = serde_json::to_value(&tool.raw)
+            .ok()
+            .and_then(|value| value.as_object().cloned())
+            .unwrap_or_default();
+        serialized.insert("id".into(), Value::String(tool.id.clone()));
+        json!({
+            "source": Self::source_summary(source),
+            "tool": serialized,
+        })
+    }
+
+    fn list_sources(&self, query: Option<&str>, limit: usize) -> Value {
+        let query_terms = query.map(tokenize).unwrap_or_default();
+        let mut sources = self
+            .sources
+            .iter()
+            .filter(|source| source_matches(source, &query_terms))
+            .map(Self::source_summary)
+            .collect::<Vec<_>>();
+        let total = sources.len();
+        sources.truncate(limit);
+        json!({
+            "sources": sources,
+            "total": total,
+        })
+    }
+
+    fn search(&self, query: &str, source_id: Option<&str>, limit: usize) -> Result<Value, String> {
+        let query_terms = tokenize(query);
+        if query_terms.is_empty() {
+            return Err("`query` must contain at least one letter or number".to_string());
+        }
+        let source_filter = source_id
+            .map(|id| {
+                self.source_by_id.get(id).copied().ok_or_else(|| {
+                    format!("Unknown MCP source id '{id}'. Call `{MCP_LIST_SOURCES}` first.")
+                })
+            })
+            .transpose()?;
+
+        let mut scored = self.index.search(&query_terms, query, source_filter);
+        let total = scored.len();
+        scored.truncate(limit);
+        let matches = scored
+            .into_iter()
+            .map(|(document_index, score)| {
+                let document = &self.index.documents[document_index];
+                let source = &self.sources[document.source_index];
+                let tool = &source.tools[document.tool_index];
+                Self::tool_summary(source, tool, score)
+            })
+            .collect::<Vec<_>>();
+        Ok(json!({
+            "query": query,
+            "source": source_id,
+            "matches": matches,
+            "total": total,
+        }))
+    }
+}
+
+impl SearchIndex {
+    fn build(sources: &[CatalogSource]) -> Self {
+        let mut documents = Vec::new();
+        let mut document_frequency = HashMap::new();
+        let mut total_length = 0.0;
+
+        for (source_index, source) in sources.iter().enumerate() {
+            for (tool_index, tool) in source.tools.iter().enumerate() {
+                let document = SearchDocument::new(source_index, tool_index, source, tool);
+                for term in document.term_frequency.keys() {
+                    *document_frequency.entry(term.clone()).or_insert(0) += 1;
+                }
+                total_length += document.length;
+                documents.push(document);
+            }
+        }
+
+        let average_length = if documents.is_empty() {
+            1.0
+        } else {
+            total_length / documents.len() as f64
+        };
+        Self {
+            documents,
+            document_frequency,
+            average_length,
+        }
+    }
+
+    fn search(
+        &self,
+        query_terms: &[String],
+        raw_query: &str,
+        source_filter: Option<usize>,
+    ) -> Vec<(usize, f64)> {
+        let mut query_frequency = HashMap::new();
+        for term in query_terms {
+            *query_frequency.entry(term.as_str()).or_insert(0_u32) += 1;
+        }
+        let normalized_query = tokenize(raw_query).join(" ");
+        let document_count = self.documents.len() as f64;
+        let mut scored = Vec::new();
+
+        for (document_index, document) in self.documents.iter().enumerate() {
+            if source_filter.is_some_and(|source| source != document.source_index) {
+                continue;
+            }
+            let mut score = 0.0;
+            for (term, query_count) in &query_frequency {
+                let Some(term_frequency) = document.term_frequency.get(*term) else {
+                    continue;
+                };
+                let document_frequency = *self.document_frequency.get(*term).unwrap_or(&0) as f64;
+                let inverse_document_frequency = (1.0
+                    + (document_count - document_frequency + 0.5) / (document_frequency + 0.5))
+                    .ln();
+                let length_normalization =
+                    BM25_K1 * (1.0 - BM25_B + BM25_B * document.length / self.average_length);
+                let term_score = inverse_document_frequency * (term_frequency * (BM25_K1 + 1.0))
+                    / (term_frequency + length_normalization);
+                score += term_score * (1.0 + (*query_count as f64).ln());
+            }
+
+            if document.normalized_name == normalized_query {
+                score += 12.0;
+            } else if !normalized_query.is_empty()
+                && document.normalized_name.contains(&normalized_query)
+            {
+                score += 4.0;
+            }
+            if !normalized_query.is_empty() && document.normalized_title == normalized_query {
+                score += 6.0;
+            }
+            if score > 0.0 {
+                scored.push((document_index, score));
+            }
+        }
+
+        scored.sort_by(|(left_index, left_score), (right_index, right_score)| {
+            right_score
+                .partial_cmp(left_score)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| left_index.cmp(right_index))
+        });
+        scored
+    }
+}
+
+impl SearchDocument {
+    fn new(
+        source_index: usize,
+        tool_index: usize,
+        source: &CatalogSource,
+        tool: &CatalogTool,
+    ) -> Self {
+        let mut term_frequency = HashMap::new();
+        add_text(&mut term_frequency, &source.id, 1.5);
+        add_text(&mut term_frequency, &source.raw_name, 1.5);
+        add_text(&mut term_frequency, source.provenance.as_str(), 0.5);
+        add_text(&mut term_frequency, &source.transport, 0.5);
+        if let Some(implementation) = &source.implementation {
+            add_text(&mut term_frequency, &implementation.name, 0.75);
+            add_optional_text(&mut term_frequency, implementation.title.as_deref(), 0.75);
+            add_optional_text(
+                &mut term_frequency,
+                implementation.description.as_deref(),
+                0.5,
+            );
+        }
+        add_optional_text(&mut term_frequency, source.instructions.as_deref(), 0.4);
+        add_text(&mut term_frequency, &tool.id, 5.0);
+        add_text(&mut term_frequency, tool.raw.name.as_ref(), 5.0);
+        add_optional_text(&mut term_frequency, tool.raw.title.as_deref(), 4.0);
+        add_optional_text(&mut term_frequency, tool.raw.description.as_deref(), 2.0);
+        collect_schema_terms(
+            &Value::Object((*tool.raw.input_schema).clone()),
+            &mut term_frequency,
+        );
+        if let Some(output_schema) = &tool.raw.output_schema {
+            collect_schema_terms(
+                &Value::Object((**output_schema).clone()),
+                &mut term_frequency,
+            );
+        }
+        let length = term_frequency.values().sum::<f64>().max(1.0);
+        Self {
+            source_index,
+            tool_index,
+            term_frequency,
+            length,
+            normalized_name: tokenize(tool.raw.name.as_ref()).join(" "),
+            normalized_title: tool
+                .raw
+                .title
+                .as_deref()
+                .map(tokenize)
+                .unwrap_or_default()
+                .join(" "),
+        }
+    }
+}
+
+fn add_text(terms: &mut HashMap<String, f64>, text: &str, weight: f64) {
+    for token in tokenize(text) {
+        *terms.entry(token).or_insert(0.0) += weight;
+    }
+}
+
+fn add_optional_text(terms: &mut HashMap<String, f64>, text: Option<&str>, weight: f64) {
+    if let Some(text) = text {
+        add_text(terms, text, weight);
+    }
+}
+
+fn collect_schema_terms(value: &Value, terms: &mut HashMap<String, f64>) {
+    match value {
+        Value::Object(object) => {
+            for (key, value) in object {
+                match key.as_str() {
+                    "properties" | "$defs" | "definitions" => {
+                        if let Value::Object(properties) = value {
+                            for (name, property) in properties {
+                                add_text(terms, name, 2.0);
+                                collect_schema_terms(property, terms);
+                            }
+                        }
+                    }
+                    "title" => add_optional_text(terms, value.as_str(), 1.5),
+                    "description" => add_optional_text(terms, value.as_str(), 1.0),
+                    "required" => {
+                        if let Value::Array(required) = value {
+                            for name in required.iter().filter_map(Value::as_str) {
+                                add_text(terms, name, 1.25);
+                            }
+                        }
+                    }
+                    "enum" => {
+                        if let Value::Array(values) = value {
+                            for item in values.iter().filter_map(Value::as_str) {
+                                add_text(terms, item, 0.4);
+                            }
+                        }
+                    }
+                    _ => collect_schema_terms(value, terms),
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_schema_terms(value, terms);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn tokenize(text: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let characters = text.chars().collect::<Vec<_>>();
+
+    for (index, character) in characters.iter().copied().enumerate() {
+        if character.is_alphanumeric() {
+            let previous = index
+                .checked_sub(1)
+                .and_then(|previous| characters.get(previous))
+                .copied();
+            let next = characters.get(index + 1).copied();
+            let starts_word = character.is_uppercase()
+                && !current.is_empty()
+                && (previous
+                    .is_some_and(|previous| previous.is_lowercase() || previous.is_ascii_digit())
+                    || (previous.is_some_and(char::is_uppercase)
+                        && next.is_some_and(char::is_lowercase)));
+            if starts_word {
+                tokens.push(current.to_lowercase());
+                current.clear();
+            }
+            current.extend(character.to_lowercase());
+        } else {
+            if !current.is_empty() {
+                tokens.push(std::mem::take(&mut current));
+            }
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+fn model_identifier(raw: &str, fallback: &str) -> String {
+    let mut identifier = raw
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '_' {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>();
+    if identifier.is_empty() || identifier.chars().all(|character| character == '_') {
+        identifier = fallback.to_string();
+    }
+    identifier.truncate(64);
+    identifier
+}
+
+fn unique_identifier(base: String, used: &mut HashSet<String>) -> String {
+    if used.insert(base.clone()) {
+        return base;
+    }
+    for suffix_number in 2..10_000 {
+        let suffix = format!("_{suffix_number}");
+        let mut candidate = base.clone();
+        candidate.truncate(64usize.saturating_sub(suffix.len()));
+        candidate.push_str(&suffix);
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+    }
+    unreachable!("identifier space exhausted")
+}
+
+fn source_matches(source: &CatalogSource, query_terms: &[String]) -> bool {
+    if query_terms.is_empty() {
+        return true;
+    }
+    let mut searchable = format!(
+        "{} {} {} {}",
+        source.id,
+        source.raw_name,
+        source.provenance.as_str(),
+        source.transport
+    );
+    if let Some(implementation) = &source.implementation {
+        searchable.push(' ');
+        searchable.push_str(&implementation.name);
+        if let Some(title) = &implementation.title {
+            searchable.push(' ');
+            searchable.push_str(title);
+        }
+        if let Some(description) = &implementation.description {
+            searchable.push(' ');
+            searchable.push_str(description);
+        }
+    }
+    if let Some(instructions) = &source.instructions {
+        searchable.push(' ');
+        searchable.push_str(instructions);
+    }
+    let tokens = tokenize(&searchable).into_iter().collect::<HashSet<_>>();
+    query_terms.iter().all(|term| tokens.contains(term))
+}
+
+fn truncate_chars(text: &str, limit: usize) -> String {
+    let mut characters = text.chars();
+    let truncated = characters.by_ref().take(limit).collect::<String>();
+    if characters.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
+}
+
+fn rounded_score(score: f64) -> f64 {
+    (score * 1_000.0).round() / 1_000.0
+}
+
+fn parse_limit(args: &Value, default: usize, maximum: usize) -> Result<usize, String> {
+    let Some(value) = args.get("limit") else {
+        return Ok(default);
+    };
+    let Some(value) = value.as_u64() else {
+        return Err("`limit` must be an integer".to_string());
+    };
+    let value = usize::try_from(value).map_err(|_| "`limit` is too large".to_string())?;
+    if value == 0 || value > maximum {
+        return Err(format!("`limit` must be between 1 and {maximum}"));
+    }
+    Ok(value)
+}
+
+fn required_string<'a>(args: &'a Value, key: &str) -> Result<&'a str, String> {
+    args.get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| format!("`{key}` must be a non-empty string"))
+}
+
+fn structured_json(value: Value) -> ToolResult {
+    let rendered = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+    ToolResult::text(rendered).with_structured(value)
+}
+
+fn read_only_annotations() -> ToolAnnotations {
+    ToolAnnotations::new()
+        .read_only(true)
+        .destructive(false)
+        .idempotent(true)
+        .open_world(false)
+}
+
+fn dispatcher_annotations() -> ToolAnnotations {
+    ToolAnnotations::new()
+        .read_only(false)
+        .destructive(true)
+        .idempotent(false)
+        .open_world(true)
+}
+
+struct McpListSourcesTool {
+    catalog: Arc<Catalog>,
+    description: String,
+}
+
+#[async_trait]
+impl Tool for McpListSourcesTool {
+    fn name(&self) -> &'static str {
+        MCP_LIST_SOURCES
+    }
+
+    fn title(&self) -> Option<String> {
+        Some("List transitive MCP sources".to_string())
+    }
+
+    fn description(&self) -> String {
+        self.description.clone()
+    }
+
+    fn annotations(&self) -> Option<ToolAnnotations> {
+        Some(read_only_annotations())
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Optional full-text filter over source id, raw name, implementation metadata, instructions, provenance, and transport."
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_SOURCE_LIMIT,
+                    "description": format!("Maximum sources to return. Defaults to {DEFAULT_SOURCE_LIMIT}.")
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "sources": { "type": "array", "items": { "type": "object" } },
+                "total": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["sources", "total"],
+            "additionalProperties": false
+        }))
+    }
+
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
+        let query = match args.get("query") {
+            None | Some(Value::Null) => None,
+            Some(Value::String(query)) => Some(query.as_str()),
+            Some(_) => return ToolResult::error("`query` must be a string"),
+        };
+        let limit = match parse_limit(&args, DEFAULT_SOURCE_LIMIT, MAX_SOURCE_LIMIT) {
+            Ok(limit) => limit,
+            Err(error) => return ToolResult::error(error),
+        };
+        structured_json(self.catalog.list_sources(query, limit))
+    }
+}
+
+struct McpSearchToolsTool {
+    catalog: Arc<Catalog>,
+    description: String,
+}
+
+#[async_trait]
+impl Tool for McpSearchToolsTool {
+    fn name(&self) -> &'static str {
+        MCP_SEARCH_TOOLS
+    }
+
+    fn title(&self) -> Option<String> {
+        Some("Search transitive MCP tools".to_string())
+    }
+
+    fn description(&self) -> String {
+        self.description.clone()
+    }
+
+    fn annotations(&self) -> Option<ToolAnnotations> {
+        Some(read_only_annotations())
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Ranked full-text query. The BM25 index covers source metadata, tool id/name/title/description, and recursively useful input/output schema property names and descriptions."
+                },
+                "source": {
+                    "type": "string",
+                    "description": format!("Optional model-visible source id returned by `{MCP_LIST_SOURCES}`.")
+                },
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": MAX_SEARCH_LIMIT,
+                    "description": format!("Maximum matches to return. Defaults to {DEFAULT_SEARCH_LIMIT}.")
+                }
+            },
+            "required": ["query"],
+            "additionalProperties": false
+        })
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "source": { "type": ["string", "null"] },
+                "matches": { "type": "array", "items": { "type": "object" } },
+                "total": { "type": "integer", "minimum": 0 }
+            },
+            "required": ["query", "source", "matches", "total"],
+            "additionalProperties": false
+        }))
+    }
+
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
+        let query = match required_string(&args, "query") {
+            Ok(query) => query,
+            Err(error) => return ToolResult::error(error),
+        };
+        let source = match args.get("source") {
+            None | Some(Value::Null) => None,
+            Some(Value::String(source)) if !source.trim().is_empty() => Some(source.as_str()),
+            Some(_) => return ToolResult::error("`source` must be a non-empty string"),
+        };
+        let limit = match parse_limit(&args, DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT) {
+            Ok(limit) => limit,
+            Err(error) => return ToolResult::error(error),
+        };
+        match self.catalog.search(query, source, limit) {
+            Ok(value) => structured_json(value),
+            Err(error) => ToolResult::error(error),
+        }
+    }
+}
+
+struct McpGetToolTool {
+    catalog: Arc<Catalog>,
+}
+
+#[async_trait]
+impl Tool for McpGetToolTool {
+    fn name(&self) -> &'static str {
+        MCP_GET_TOOL
+    }
+
+    fn title(&self) -> Option<String> {
+        Some("Get a transitive MCP tool definition".to_string())
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "Retrieve the exact upstream metadata and input/output schemas for one result from `{MCP_SEARCH_TOOLS}`. The response keeps model-visible `id` values separate from raw upstream `name` values and includes upstream title, annotations, icons, and `_meta` when supplied."
+        )
+    }
+
+    fn annotations(&self) -> Option<ToolAnnotations> {
+        Some(read_only_annotations())
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": format!("Model-visible source id returned by `{MCP_LIST_SOURCES}` or `{MCP_SEARCH_TOOLS}`.")
+                },
+                "tool": {
+                    "type": "string",
+                    "description": format!("Model-visible tool id returned by `{MCP_SEARCH_TOOLS}`.")
+                }
+            },
+            "required": ["source", "tool"],
+            "additionalProperties": false
+        })
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "source": { "type": "object" },
+                "tool": { "type": "object" }
+            },
+            "required": ["source", "tool"],
+            "additionalProperties": false
+        }))
+    }
+
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
+        let source_id = match required_string(&args, "source") {
+            Ok(source) => source,
+            Err(error) => return ToolResult::error(error),
+        };
+        let tool_id = match required_string(&args, "tool") {
+            Ok(tool) => tool,
+            Err(error) => return ToolResult::error(error),
+        };
+        let source = match self.catalog.source(source_id) {
+            Ok(source) => source,
+            Err(error) => return ToolResult::error(error),
+        };
+        let tool = match self.catalog.tool(source, tool_id) {
+            Ok(tool) => tool,
+            Err(error) => return ToolResult::error(error),
+        };
+        structured_json(Catalog::tool_metadata(source, tool))
+    }
+}
+
+struct McpCallToolTool {
+    catalog: Arc<Catalog>,
+}
+
+impl McpCallToolTool {
+    async fn run(&self, args: Value, cancellation: Option<&CancellationToken>) -> ToolResult {
+        let source_id = match required_string(&args, "source") {
+            Ok(source) => source,
+            Err(error) => return ToolResult::error(error),
+        };
+        let tool_id = match required_string(&args, "tool") {
+            Ok(tool) => tool,
+            Err(error) => return ToolResult::error(error),
+        };
+        let source = match self.catalog.source(source_id) {
+            Ok(source) => source,
+            Err(error) => return ToolResult::error(error),
+        };
+        let tool = match self.catalog.tool(source, tool_id) {
+            Ok(tool) => tool,
+            Err(error) => return ToolResult::error(error),
+        };
+
+        let mut params = CallToolRequestParams::new(tool.raw.name.to_string());
+        match args.get("arguments") {
+            None | Some(Value::Null) => {}
+            Some(Value::Object(arguments)) => {
+                if !arguments.is_empty() {
+                    params = params.with_arguments(arguments.clone());
+                }
+            }
+            Some(_) => {
+                return ToolResult::error(
+                    "`arguments` must be a JSON object mapping the selected tool's parameter names to values",
+                );
+            }
+        }
+
+        forward_tool_call(
+            &source.peer,
+            params,
+            &source.raw_name,
+            tool.raw.name.as_ref(),
+            source.tool_timeout,
+            cancellation,
+        )
+        .await
+    }
+}
+
+#[async_trait]
+impl Tool for McpCallToolTool {
+    fn name(&self) -> &'static str {
+        MCP_CALL_TOOL
+    }
+
+    fn title(&self) -> Option<String> {
+        Some("Call a transitive MCP tool".to_string())
+    }
+
+    fn description(&self) -> String {
+        format!(
+            "Invoke a catalog-mode upstream MCP tool selected by the model-visible source/tool ids returned by `{MCP_SEARCH_TOOLS}`. Call `{MCP_GET_TOOL}` first when exact arguments or upstream annotations matter. Results preserve upstream text, images, structured content, result metadata, and `isError`; configured timeouts and downstream cancellation are forwarded. Because this generic dispatcher can select tools with different side effects, its host-facing annotations are necessarily conservative and cannot reproduce per-tool approval semantics."
+        )
+    }
+
+    fn annotations(&self) -> Option<ToolAnnotations> {
+        Some(dispatcher_annotations())
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "description": format!("Model-visible source id returned by `{MCP_LIST_SOURCES}` or `{MCP_SEARCH_TOOLS}`.")
+                },
+                "tool": {
+                    "type": "string",
+                    "description": format!("Model-visible tool id returned by `{MCP_SEARCH_TOOLS}`.")
+                },
+                "arguments": {
+                    "type": "object",
+                    "description": format!("Arguments matching the selected tool's input schema from `{MCP_GET_TOOL}`.")
+                }
+            },
+            "required": ["source", "tool"],
+            "additionalProperties": false
+        })
+    }
+
+    fn fills_structured_content(&self) -> bool {
+        false
+    }
+
+    fn requires_project_root(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
+        self.run(args, None).await
+    }
+
+    async fn call_with_context(
+        &self,
+        args: Value,
+        _config: &AppConfig,
+        _session: &SessionState,
+        context: &ToolRequestContext,
+    ) -> ToolResult {
+        self.run(args, Some(&context.cancellation)).await
+    }
+}
+
+pub(crate) fn build_catalog_tools(inputs: Vec<CatalogSourceInput>) -> Vec<Box<dyn Tool>> {
+    if inputs.is_empty() {
+        return Vec::new();
+    }
+    let catalog = Arc::new(Catalog::new(inputs));
+    let manifest = catalog.manifest_description();
+    vec![
+        Box::new(McpListSourcesTool {
+            catalog: catalog.clone(),
+            description: format!(
+                "List or filter upstream MCP systems whose full tool catalog is kept private from downstream `tools/list`. {manifest} Use the returned model-visible source ids with `{MCP_SEARCH_TOOLS}`; raw configured names and implementation metadata remain available in the result."
+            ),
+        }),
+        Box::new(McpSearchToolsTool {
+            catalog: catalog.clone(),
+            description: format!(
+                "Search private transitive MCP tools with a local BM25 index instead of loading every upstream schema into the connector manifest. {manifest} Results contain stable model-visible source/tool ids plus raw upstream names; retrieve an exact definition with `{MCP_GET_TOOL}` before calling `{MCP_CALL_TOOL}` when needed."
+            ),
+        }),
+        Box::new(McpGetToolTool {
+            catalog: catalog.clone(),
+        }),
+        Box::new(McpCallToolTool { catalog }),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tokenizer_splits_names_for_ranked_search() {
+        assert_eq!(
+            tokenize("renameFunction_by-address"),
+            ["rename", "function", "by", "address"]
+        );
+        assert_eq!(tokenize("readIDBMetadata"), ["read", "idb", "metadata"]);
+    }
+
+    #[test]
+    fn identifiers_keep_raw_name_collisions_distinct() {
+        let mut used = HashSet::new();
+        let first = unique_identifier(model_identifier("a-b", "tool"), &mut used);
+        let second = unique_identifier(model_identifier("a b", "tool"), &mut used);
+        assert_eq!(first, "a_b");
+        assert_eq!(second, "a_b_2");
+    }
+
+    #[test]
+    fn schema_terms_include_recursive_property_names_and_descriptions() {
+        let mut terms = HashMap::new();
+        collect_schema_terms(
+            &json!({
+                "type": "object",
+                "properties": {
+                    "function_address": {
+                        "type": "string",
+                        "description": "Virtual address to decompile"
+                    }
+                }
+            }),
+            &mut terms,
+        );
+        assert!(terms.contains_key("function"));
+        assert!(terms.contains_key("address"));
+        assert!(terms.contains_key("decompile"));
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -149,6 +149,7 @@ fn to_call_tool_result(result: ToolResult) -> CallToolResult {
         CallToolResult::success(blocks)
     };
     ctr.structured_content = result.structured_content;
+    ctr.meta = result.meta;
     ctr
 }
 
@@ -160,6 +161,9 @@ fn advertised_tool(tool: &dyn Tool, config: &AppConfig) -> rmcp::model::Tool {
     }
     if let Some(annotations) = tool.annotations() {
         advertised = advertised.with_annotations(annotations);
+    }
+    if let Some(icons) = tool.icons() {
+        advertised = advertised.with_icons(icons);
     }
     if let Some(meta) = tool.meta() {
         advertised = advertised.with_meta(meta);
@@ -608,7 +612,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
         println!("Work directory: {}", config.work_dir.display());
     }
     println!(
-        "Tools loaded ({tool_count}): {} native + {bridged_count} bridged from upstream MCP servers",
+        "Tools loaded ({tool_count}): {} native + {bridged_count} upstream-facing MCP tools",
         tool_count - bridged_count
     );
     if !bridge_report.is_empty() {
@@ -1043,6 +1047,28 @@ mod tests {
         assert_eq!(annotations.destructive_hint, Some(false));
         assert_eq!(annotations.idempotent_hint, Some(false));
         assert_eq!(annotations.open_world_hint, Some(true));
+    }
+
+    #[test]
+    fn call_result_preserves_upstream_result_metadata() {
+        let mut meta = rmcp::model::MetaObject::new();
+        meta.0.insert("trace".to_string(), json!("upstream"));
+        let converted = to_call_tool_result(ToolResult {
+            content: vec![ToolContent::Text("ok".to_string())],
+            is_error: false,
+            structured_content: Some(json!({ "value": 1 })),
+            meta: Some(meta),
+            audit: Default::default(),
+        });
+
+        assert_eq!(converted.structured_content, Some(json!({ "value": 1 })));
+        assert_eq!(
+            converted
+                .meta
+                .as_ref()
+                .and_then(|metadata| metadata.0.get("trace")),
+            Some(&json!("upstream"))
+        );
     }
 
     #[tokio::test]

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use rmcp::model::{MetaObject, ToolAnnotations};
+use rmcp::model::{Icon, MetaObject, ToolAnnotations};
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 
@@ -49,6 +49,11 @@ pub trait Tool: Send + Sync {
 
     /// Optional MCP tool annotations (read-only / destructive hints).
     fn annotations(&self) -> Option<ToolAnnotations> {
+        None
+    }
+
+    /// Optional icons advertised by the tool.
+    fn icons(&self) -> Option<Vec<Icon>> {
         None
     }
 

--- a/src/tools/exec_command.rs
+++ b/src/tools/exec_command.rs
@@ -200,6 +200,7 @@ impl Tool for ExecCommand {
             ))],
             is_error,
             structured_content: Some(structured),
+            meta: None,
             audit: ToolAuditMetadata {
                 truncated: Some(buffer_truncated || truncated),
                 original_output_tokens: truncated.then_some(original_token_count),

--- a/src/tools/run_command.rs
+++ b/src/tools/run_command.rs
@@ -124,6 +124,7 @@ impl Tool for RunCommand {
             content: vec![crate::types::ToolContent::Text(out)],
             is_error: exit_code != 0,
             structured_content: None,
+            meta: None,
             audit: Default::default(),
         }
     }

--- a/src/tools/write_stdin.rs
+++ b/src/tools/write_stdin.rs
@@ -135,6 +135,7 @@ impl Tool for WriteStdin {
             content: vec![ToolContent::Text(render_unified_exec_output(&result))],
             is_error,
             structured_content: Some(structured),
+            meta: None,
             audit: ToolAuditMetadata {
                 truncated: Some(buffer_truncated || truncated),
                 original_output_tokens: truncated.then_some(original_token_count),

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,6 +7,7 @@
 use std::fmt;
 use std::ops::Deref;
 
+use rmcp::model::MetaObject;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use zeroize::Zeroize;
@@ -39,6 +40,7 @@ pub struct ToolResult {
     pub content: Vec<ToolContent>,
     pub is_error: bool,
     pub structured_content: Option<Value>,
+    pub meta: Option<MetaObject>,
     pub audit: ToolAuditMetadata,
 }
 
@@ -49,6 +51,7 @@ impl ToolResult {
             content: vec![ToolContent::Text(text.into())],
             is_error: false,
             structured_content: None,
+            meta: None,
             audit: ToolAuditMetadata::default(),
         }
     }
@@ -59,6 +62,7 @@ impl ToolResult {
             content: vec![ToolContent::Text(text.into())],
             is_error: true,
             structured_content: None,
+            meta: None,
             audit: ToolAuditMetadata::default(),
         }
     }
@@ -72,6 +76,7 @@ impl ToolResult {
             }],
             is_error: false,
             structured_content: None,
+            meta: None,
             audit: ToolAuditMetadata::default(),
         }
     }
@@ -399,10 +404,53 @@ pub struct CommandConfig {
     pub max_timeout: u64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum McpToolExposure {
+    Direct,
+    Gateway,
+    Catalog,
+}
+
+impl McpToolExposure {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Direct => "direct",
+            Self::Gateway => "gateway",
+            Self::Catalog => "catalog",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum McpServerProvenance {
+    #[default]
+    Explicit,
+    CodexConfig,
+    CodexCli,
+}
+
+impl McpServerProvenance {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Explicit => "explicit",
+            Self::CodexConfig => "codex-config",
+            Self::CodexCli => "codex-cli",
+        }
+    }
+
+    pub fn default_exposure(self) -> McpToolExposure {
+        match self {
+            Self::Explicit => McpToolExposure::Direct,
+            Self::CodexConfig | Self::CodexCli => McpToolExposure::Catalog,
+        }
+    }
+}
+
 /// One upstream MCP server to bridge, in the standard `mcpServers` shape. Its
-/// tools are discovered at startup and re-exposed under a `<server>__<tool>`
-/// name. A `command` selects stdio; a `url` selects Codex-compatible Streamable
-/// HTTP. Legacy SSE and WebSocket transports are rejected explicitly.
+/// tools are discovered at startup and materialized according to the effective
+/// exposure mode. A `command` selects stdio; a `url` selects Codex-compatible
+/// Streamable HTTP. Legacy SSE and WebSocket transports are rejected explicitly.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct McpServerSpec {
@@ -455,13 +503,28 @@ pub struct McpServerSpec {
     #[serde(default)]
     pub disabled_tools: Option<Vec<String>>,
     /// How the upstream's tools are exposed:
-    /// - `"direct"` (default): each upstream tool becomes its own `<server>__<tool>`.
+    /// - `"direct"`: each upstream tool becomes its own `<server>__<tool>`.
     /// - `"gateway"`: the whole server collapses into ONE dispatcher tool named
     ///   `<server>` taking `{function, arguments}`, plus an auto-generated skill
-    ///   documenting every function. Use it when a server has many tools and the
-    ///   client drops them.
+    ///   documenting every function.
+    /// - `"catalog"`: tools remain private and are reached through the fixed MCP
+    ///   source/search/schema/call surface.
+    ///
+    /// When absent, explicit `mcpServers` entries retain the historical direct
+    /// behavior, while automatically imported Codex/config/plugin entries use
+    /// catalog mode.
     #[serde(default)]
-    pub mode: Option<String>,
+    pub mode: Option<McpToolExposure>,
+    /// Internal origin used only to select the backward-compatible default mode.
+    #[serde(skip)]
+    pub provenance: McpServerProvenance,
+}
+
+impl McpServerSpec {
+    pub fn exposure(&self) -> McpToolExposure {
+        self.mode
+            .unwrap_or_else(|| self.provenance.default_exposure())
+    }
 }
 
 /// Configuration for OpenAI's outbound Secure MCP Tunnel runtime.
@@ -615,8 +678,8 @@ pub struct AppConfig {
     /// OpenAI's outbound tunnel, when enabled. The HTTP listener is restricted
     /// to loopback and its permissive browser CORS layer is disabled in this mode.
     pub openai_tunnel: Option<OpenAiTunnelConfig>,
-    /// Upstream MCP servers to bridge, keyed by name. Their tools are discovered
-    /// at startup and re-exposed as `<server>__<tool>`.
+    /// Upstream MCP servers, keyed by their raw configured names. Their tools are
+    /// discovered at startup and exposed according to each server's effective mode.
     pub mcp_servers: std::collections::HashMap<String, McpServerSpec>,
     /// Directory where gateway-mode servers write their auto-generated SKILL.md,
     /// added to skill discovery. Set at startup, not from the config file.

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -256,6 +256,7 @@ impl Tool for FakeTool {
             content: vec![],
             is_error: false,
             structured_content: None,
+            meta: None,
             audit: Default::default(),
         }
     }
@@ -279,6 +280,7 @@ fn derives_content_from_text_blocks() {
         content: vec![ToolContent::Text("hello".into())],
         is_error: false,
         structured_content: None,
+        meta: None,
         audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
@@ -302,6 +304,7 @@ fn joins_multiple_text_blocks_and_skips_non_text() {
         ],
         is_error: false,
         structured_content: None,
+        meta: None,
         audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
@@ -318,6 +321,7 @@ fn leaves_tools_own_structured_content_alone() {
         content: vec![ToolContent::Text("{}".into())],
         is_error: false,
         structured_content: Some(json!({ "current_time": "2026-01-01 00:00:00 UTC" })),
+        meta: None,
         audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
@@ -334,6 +338,7 @@ fn adds_nothing_when_tool_declares_no_output_schema() {
         content: vec![ToolContent::Text("hello".into())],
         is_error: false,
         structured_content: None,
+        meta: None,
         audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
@@ -347,6 +352,7 @@ fn adds_nothing_to_an_error_result() {
         content: vec![ToolContent::Text("boom".into())],
         is_error: true,
         structured_content: None,
+        meta: None,
         audit: Default::default(),
     };
     let filled = apply_default_structured(&tool, &result);
@@ -360,6 +366,7 @@ fn does_not_mutate_the_result_it_was_given() {
         content: vec![ToolContent::Text("hello".into())],
         is_error: false,
         structured_content: None,
+        meta: None,
         audit: Default::default(),
     };
     let _ = apply_default_structured(&tool, &result);


### PR DESCRIPTION
## Problem

`codex-free` currently discovers every upstream MCP tool at startup and, in direct bridge mode, registers every transitive definition in its downstream `tools/list`. Automatically imported Codex and plugin MCPs can therefore add dozens of connector capabilities even when the model needs only one or two of them. Gateway mode reduces the count, but it relies on a generated monolithic skill and an unranked dispatcher rather than progressive discovery.

This PR separates the complete internal upstream catalogue from the tool definitions exposed to ChatGPT. It implements the closest analogue to Codex's deferred MCP tool exposure that can be provided entirely by an MCP server, without control over the host's Responses API request.

## Architecture

### Private transitive catalogue

Catalog-mode servers still complete initialization and paginated `tools/list` discovery at startup, but their filtered tool definitions remain private inside `codex-free`. Each source retains:

- its raw configured server name, provenance, transport, implementation metadata, initialization instructions, peer, and timeout;
- every selected raw upstream tool definition, including title, description, input/output schemas, annotations, icons, and `_meta`;
- separate, deterministic model-facing source/tool identifiers with collision disambiguation.

Dispatch never reconstructs upstream names from sanitized identifiers. It resolves the stored source/tool IDs to the original raw server and tool names.

### Fixed progressive-disclosure surface

All catalog-mode sources share four project-independent downstream tools, regardless of the number of transitive definitions:

- `mcp_list_sources` lists or filters available systems and exposes source metadata and tool counts;
- `mcp_search_tools` performs ranked full-text search over private tool definitions;
- `mcp_get_tool` returns the exact metadata and schemas for a selected match;
- `mcp_call_tool` invokes the selected source/tool through a generic dispatcher.

The search implementation is a local weighted BM25 index. Documents include source identifiers and names, provenance, transport, implementation metadata and instructions, tool identifiers/names/titles/descriptions, and recursively useful input/output-schema property names, descriptions, required fields, and enum values. Exact normalized name/title matches receive deterministic boosts. CamelCase, snake/kebab case, and acronym-heavy identifiers are tokenized separately.

### Call fidelity

Direct proxies, gateway dispatch, and catalog dispatch share the same cancellable forwarding path. Forwarded results preserve text blocks, images, structured content, `isError`, and result `_meta`; unsupported content variants retain the existing JSON-text fallback. Configured call deadlines use RMCP cancellable requests, and downstream request cancellation is forwarded upstream.

Direct mode now also preserves upstream titles, annotations, icons, tool `_meta`, and output schemas in downstream `tools/list`.

## Exposure defaults and compatibility

Exposure is selected by explicit provenance rather than a tool-count heuristic:

| Server provenance | Default exposure |
| --- | --- |
| Automatically imported from Codex `config.toml` | `catalog` |
| Discovered through `codex mcp list/get`, including plugin-only MCPs | `catalog` |
| Standalone `codex.config.json.mcpServers` entry | `direct` |

An explicit same-name entry overlays an imported server without discarding imported provenance. Setting `mode` to `direct`, `gateway`, or `catalog` overrides the default deliberately.

This preserves the historical behavior for standalone explicit servers while preventing automatically imported Codex/plugin catalogues from flooding the ChatGPT connector capability list. Setting `"mode": "direct"` restores flattened exposure for an imported server. Existing gateway mode remains available as the same one-dispatcher-plus-generated-skill compatibility mode.

The existing `tools` allow-list and `disabledTools` deny-list continue to operate on raw upstream names before any exposure mode is materialized. Disabled and failed upstreams retain the existing non-fatal startup/reporting behavior.

## Host approval and dynamic-catalogue trade-offs

A generic dispatcher cannot reproduce the selected upstream tool's individual ChatGPT approval boundary because the downstream host sees one tool definition before runtime `source` and `tool` selection. `mcp_call_tool` therefore advertises conservative potentially-destructive/open-world annotations. `mcp_get_tool` exposes the selected upstream annotations to the model, but direct mode remains the option when host-level per-tool annotations and approvals are required.

The private catalogue is a startup snapshot. Upstream `tools/list_changed` notifications are not projected into the fixed downstream surface; restarting `codex-free` rematerializes a changed catalogue.

## Tests

The bridge tests include a stateful 71-tool Streamable HTTP MCP fixture and cover:

- a many-tool imported MCP producing only the four fixed downstream tools;
- source discovery, filtering, metadata visibility, and project independence;
- BM25 ranking over descriptions and recursive schema fields;
- exact input/output schema, annotations, icons, and `_meta` retrieval;
- raw-name dispatch and sanitized source/tool identifier collisions;
- `tools`/`disabledTools` filtering;
- malformed dispatcher arguments and unknown selections;
- text, image, structured-content, result-metadata, and tool-error passthrough;
- timeout and downstream-cancellation forwarding;
- explicit direct behavior and metadata preservation;
- gateway behavior and generated-skill compatibility;
- Codex config/CLI/plugin provenance defaults and explicit overlay overrides.

Validation completed successfully:

- `cargo fmt --all`
- `git diff --check`
- `cargo check --all-targets`
- `cargo test --all-targets` (586 tests)
- `cargo clippy --all-targets -- -D warnings`
