### PR TITLE
release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-26
+
 ### Added
 
 - Progressive disclosure for transitive MCP tools. Catalog-mode upstreams keep
@@ -384,7 +386,8 @@ filename sort uses byte/Unicode ordering rather than `localeCompare`;
 `write_file` reports UTF-8 byte counts; `exec_command` uses plain pipes, not a
 PTY. See the README's "Notes on the port" for the full list.
 
-[Unreleased]: https://github.com/hypnguyen1209/codex-free/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/hypnguyen1209/codex-free/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.3.0...v1.4.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codex-free"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-free"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 description = "Codex Free MCP bridge, ported to Rust: a local Streamable-HTTP MCP server exposing Codex-style agent tools over a chosen work directory."
 license = "MIT"

--- a/src/server.rs
+++ b/src/server.rs
@@ -192,7 +192,7 @@ impl ServerHandler for CodexHandler {
         );
         capabilities.extensions = Some(extensions);
         InitializeResult::new(capabilities)
-            .with_server_info(Implementation::new("codex-free", "1.6.0"))
+            .with_server_info(Implementation::new("codex-free", "1.7.0"))
             .with_instructions(build_initial_instructions(&self.config))
     }
 


### PR DESCRIPTION
Release v1.7.0.

Bumps `Cargo.toml`, `Cargo.lock`, and the MCP `Implementation` version to `1.7.0`, and promotes the `[Unreleased]` CHANGELOG section to `[1.7.0] - 2026-08-26`.

### Highlights
- **Progressive disclosure for transitive MCP tools** (catalog exposure mode) — Codex-imported servers default to a private index reached through four fixed discovery tools (#29).
- **User-level config discovery** — `~/.codex-free/codex.config.json` and `CODEX_FREE_CONFIG`, with the working-directory config kept as a warned fallback (#28).
- Direct MCP proxies retain upstream titles/annotations/icons/`_meta`/output schemas; direct/gateway/catalog calls share cancellable forwarding.
- `quickstart` writes the user-level config by default.