### PR TITLE
feat(review): keep widget diffs out of model context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `show_changes` now keeps its review metadata and bounded patch in
+  component-only result `_meta` instead of model-visible `structuredContent`.
+  Its concise text result still reports aggregate counts and automatic checkpoint
+  advancement, while the MCP App remains independently interactive. The default
+  patch budget is now 4 MiB and is regression-tested with 10,000 changed code
+  lines. Review-card expansion, per-file disclosure, and the larger-file-list
+  control persist across ChatGPT widget remounts through private widget state.
+  The UI resource moved to a versioned URI to avoid stale host caches, while the
+  prior URI remains readable for historical cards.
 - The `show_changes` MCP app now uses a compact, single-line file list with
   initially collapsed per-file diffs, a short reveal control for larger change
   sets, and smaller explicitly sized monospace patch text across web and native

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ flowchart LR
     Worktree[("Managed Git worktree\nper-conversation checkout,\nswept on startup")]
     ExecSessions[("Conversation exec sessions\n(in memory, idle-reaped)")]
     ReviewRefs[("Git refs/codex-free/review\nproject-open + last-review")]
-    ReviewUI["MCP App review card\nui://codex-free/review/mcp-app.html"]
+    ReviewUI["MCP App review card\nui://codex-free/review/v2/mcp-app.html"]
     SkillDirs[(".agents/skills\n.codex/skills\n.claude/skills")]
     CodexCfg[("$CODEX_HOME\nconfig.toml")]
     CodexCli["optional Codex CLI\nmcp list/get --json"]
@@ -306,7 +306,7 @@ Structured primitives — cheaper and safer than shelling out for the same job, 
 | `import_host_file` | Stream one ChatGPT attachment or generated file into a new project-relative path, with bounded size, SHA-256 verification and atomic no-overwrite publication |
 | `run_command` | Execute a command in the work directory (allowlist-restricted) |
 | `git_status` | Show git status, parsed into changed files with status codes |
-| `show_changes` | Compare the scoped working tree with the project-open or last-review checkpoint, optionally advancing the incremental baseline; compatible hosts render an interactive review card |
+| `show_changes` | Compare the scoped working tree with the project-open or last-review checkpoint, optionally advancing the incremental baseline; compatible hosts receive the bounded diff in an interactive component-only review card |
 | `git_push` | Push commits to a remote |
 | `git_commit` | Create a commit, optionally staging all tracked changes |
 | `git_log` | Show recent commit history |
@@ -374,7 +374,7 @@ sessions.
 
 `clock_sleep` also caps at 5 minutes rather than Codex's 12 hours — a longer wait would outlive the HTTP request through the tunnel.
 
-Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `show_changes` returns its review summary, file records, warnings and bounded patch, `import_host_file` returns its destination, byte count and SHA-256 receipt, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it.
+Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `import_host_file` returns its destination, byte count and SHA-256 receipt, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it. `show_changes` deliberately advertises no output schema: its model-visible result is concise text, while its complete review payload is attached as component-only result `_meta` for the MCP App.
 
 All project-scoped paths are resolved relative to the active project root: `--work-dir` in single-project mode, or the root selected for the current ChatGPT conversation in multi-project mode. Non-ChatGPT clients use the root selected for their current MCP transport session.
 
@@ -451,7 +451,7 @@ an existing config keeps working.
     "maxTreeNodes": 1000
   },
   "review": {
-    "maxPatchBytes": 524288
+    "maxPatchBytes": 4194304
   },
   "audit": {
     "logFile": null,
@@ -634,7 +634,7 @@ The `review` block bounds presentation without changing checkpoint semantics:
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `maxPatchBytes` | `524288` | Largest complete binary-capable patch returned by `show_changes`; a larger patch is omitted rather than cut mid-hunk, while file metadata and aggregate statistics remain available. `0` disables patch bodies |
+| `maxPatchBytes` | `4194304` | Largest complete binary-capable patch attached to the review widget's component-only result metadata. The 4 MiB default is regression-tested with 10,000 changed code lines of roughly 300 bytes each; unusually long lines and large binary patches can still exceed it. A larger patch is omitted rather than cut mid-hunk, while file metadata and aggregate statistics remain available. `0` disables patch bodies |
 
 The `artifactIngress` block governs [native host-file ingress](#native-host-file-ingress):
 
@@ -789,9 +789,9 @@ Review state is initialized immediately before the first project-scoped tool cal
 - **project open** is immutable and shows the complete task diff;
 - **last review** advances only when `show_changes` is called with `advance=true` (the default), so the next review is incremental.
 
-`show_changes` accepts `since: "last_review" | "project_open"`, `advance`, and `include_patch`. Use `advance=false` for a read-only inspection. The result contains a concise text summary plus structured aggregate counts, bounded file records, rename sources, binary markers, warnings, and a complete unified binary patch when it fits `review.maxPatchBytes`. Oversized patches are omitted explicitly rather than returned as invalid partial hunks.
+`show_changes` accepts `since: "last_review" | "project_open"`, `advance`, and `include_patch`. Use `advance=false` for a read-only inspection. The ordinary model-visible result is a concise aggregate summary with checkpoint status and warnings; it deliberately has no `structuredContent`. Compatible MCP Apps receive bounded file records, rename sources, binary markers, warnings, and the complete unified binary patch through namespaced result `_meta`, which ChatGPT forwards to the component without adding it to model context. Oversized patches are omitted explicitly rather than returned as invalid partial hunks.
 
-Snapshots use Git objects, but they do **not** touch the real index or working tree. Codex Free builds a private temporary index containing only the logical project root, then carries the same literal pathspec through every comparison. If the selected project is `packages/app` inside a monorepo, sibling changes under `packages/other` cannot enter its checkpoint or diff. Paths returned to the model and UI are relative to the selected project, not the repository root.
+Snapshots use Git objects, but they do **not** touch the real index or working tree. Codex Free builds a private temporary index containing only the logical project root, then carries the same literal pathspec through every comparison. If the selected project is `packages/app` inside a monorepo, sibling changes under `packages/other` cannot enter its checkpoint or diff. Paths in the component-only review payload are relative to the selected project, not the repository root.
 
 With ChatGPT's stable `_meta["openai/session"]`, each conversation/project scope stores exactly two namespaced refs under:
 
@@ -802,7 +802,7 @@ refs/codex-free/review/<project-hash>/<conversation-hash>/last-review
 
 The raw conversation identifier is never written. The refs survive MCP reconnects and Codex Free restarts. Generic MCP clients receive transport-local in-memory checkpoints instead. Each conversation/project pair retains only its current two referenced snapshots; superseded synthetic commits are ordinary Git-GC candidates. To inspect or remove old conversation refs manually, use `git for-each-ref refs/codex-free/review/` and `git update-ref -d <ref>`. Removing both refs resets that owner to the current scoped state on its next project call.
 
-Codex Free also advertises the standard MCP Apps extension and serves a self-contained resource at `ui://codex-free/review/mcp-app.html`. Compatible ChatGPT developer connectors render `show_changes` as a file, statistic and patch card. No separate web service or public app publication is needed; clients that ignore MCP Apps metadata still receive the same ordinary MCP result. The card updates at the `show_changes` tool-call boundary—it is not a continuous filesystem watcher.
+Codex Free also advertises the standard MCP Apps extension and serves a self-contained resource at `ui://codex-free/review/v2/mcp-app.html`. Compatible ChatGPT developer connectors render `show_changes` as a file, statistic and patch card from component-only result metadata. No separate web service or public app publication is needed; clients that ignore MCP Apps metadata receive only the concise ordinary text result. Checkpoint advancement completes before that result is returned and does not wait for user interaction. The card remains independently interactive while the model continues, and its overall disclosure, expanded file diffs, and larger-file-list state are persisted as private ChatGPT widget state so an iframe remount restores them. The prior unversioned resource URI remains readable, and the v2 widget has a structured-content fallback solely so historical cards created before this change can still remount; current `show_changes` results never populate that model-visible field. The card updates at the `show_changes` tool-call boundary—it is not a continuous filesystem watcher.
 
 ## Context and memory
 

--- a/codex.config.json
+++ b/codex.config.json
@@ -33,7 +33,7 @@
     "entries": []
   },
   "review": {
-    "maxPatchBytes": 524288
+    "maxPatchBytes": 4194304
   },
   "audit": {
     "logFile": null,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -72,7 +72,7 @@ ChatGPT / MCP client
    active project root     upstream MCP servers (idasql, remote-docs, …)
 ```
 
-Five surfaces reach the model:
+Five integration surfaces are exposed to the client:
 
 - **Tools** — `tools/list` + `tools/call` (native, fixed catalog discovery/call,
   direct compatibility proxies, and gateway compatibility dispatchers).
@@ -84,7 +84,8 @@ Five surfaces reach the model:
   durable grant is keyed by ChatGPT's stable conversation metadata rather than
   by the replaceable MCP transport.
 - **MCP App** — the self-contained review resource linked from `show_changes`;
-  unsupported clients ignore the UI metadata and keep the ordinary tool result.
+  its complete diff arrives through component-only result metadata, while
+  unsupported clients retain only the concise ordinary text result.
 
 ---
 
@@ -467,8 +468,8 @@ the original order and rejects duplicate names.
 | `worktrees.rs` | Per-conversation managed Git worktree lifecycle: create a detached checkout under `worktrees.root` via `git worktree add`, optionally at an exact fetched commit, dual source/worktree root tracking, startup sweep bounded by `keepCount`, Windows `\\?\`-prefix handling, and the opt-in `allowSetupScript` gate for per-worktree environment setup. |
 | `project_catalog.rs` | Live, read-only project discovery from native Codex plus explicit metadata; canonical access-root filtering, deduplication, deterministic query ranking, sanitized MCP warnings, and local diagnostics. |
 | `exec_sessions.rs` | Generic-client transport fallback plus conversation-owned unified-exec sessions and transport-local review state: shell resolution, PowerShell exit-code wrapping, background stdout/stderr drain tasks, process-group kill, idle cleanup, and output truncation (UTF-16 units to match the TS). |
-| `review.rs` | Project-scoped Git snapshots, persistent conversation refs, transport-local fallbacks, incremental compare-and-swap checkpoints, diff parsing and result budgets. |
-| `review_ui.rs` | Embedded MCP Apps resource and compatibility metadata for the interactive `show_changes` review card. |
+| `review.rs` | Project-scoped Git snapshots, persistent conversation refs, transport-local fallbacks, incremental compare-and-swap checkpoints, diff parsing and component-payload budgets. |
+| `review_ui.rs` | Embedded MCP Apps resource, component-only review-result metadata, and persisted private interaction state for the interactive `show_changes` card. |
 | `apply_patch.rs` | The Codex patch format: parse then apply, atomically, with fuzzy context matching and CRLF preservation. |
 | `memory.rs` | Working memory outside the repo, keyed by a hash of the normalized active root, with `O_EXCL` locking and atomic writes. In multi-project mode, a configured `memory.dir` is a base containing one hashed child per project. |
 | `quickstart.rs` | Interactive first-install wizard for project scope, native tunnel credentials, JSON config merging, preservation of preconfigured advanced conversation authorization, and the ChatGPT developer-mode connector handoff. |
@@ -698,7 +699,7 @@ the legacy fallback. All fields are optional.
               "defaultShell": "…" },
   "ignore": { "useGitignore": true, "useDefaultPatterns": true, "customPatterns": [] },
   "output": { "maxFileLines": 1000, "maxFileBytes": 131072, "maxEntries": 500, "maxTreeNodes": 1000 },
-  "review": { "maxPatchBytes": 524288 },
+  "review": { "maxPatchBytes": 4194304 },
   "audit": { "logFile": null, "includeCommandPreview": false,
              "commandPreviewMaxBytes": 512, "redactEnv": [] },
   "artifactIngress": { "enabled": true, "maxFileBytes": 104857600,

--- a/docs/superpowers/specs/2026-08-24-review-checkpoints-ui-design.md
+++ b/docs/superpowers/specs/2026-08-24-review-checkpoints-ui-design.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Add an explicit review workflow to Codex Free without coupling correctness to a particular MCP host UI. The server must be able to report changes since project opening or since the last acknowledged review, advance the incremental baseline atomically, and optionally render the same structured result as an MCP App.
+Add an explicit review workflow to Codex Free without coupling checkpoint correctness to a particular MCP host UI. The server must be able to report changes since project opening or since the last emitted review, advance the incremental baseline atomically, and optionally render the complete review as an MCP App without placing the diff in model-visible context.
 
 ## Non-goals
 
@@ -19,7 +19,8 @@ Add an explicit review workflow to Codex Free without coupling correctness to a 
 4. The last-review checkpoint advances with compare-and-swap semantics so concurrent reviews cannot silently overwrite one another.
 5. ChatGPT conversation checkpoints survive MCP transport replacement and server restart. Generic MCP-client checkpoints remain transport-local.
 6. Raw ChatGPT conversation identifiers are never stored; the existing hashed conversation identity is used in ref names.
-7. Plain MCP clients receive the complete ordinary MCP tool result, including structured review data. UI support is optional presentation metadata over that same result.
+7. The ordinary MCP content is concise and model-visible. Complete review data is carried only in namespaced result `_meta`, which MCP Apps receive but the model does not.
+8. Checkpoint advancement is completed before `show_changes` returns and never waits for the user to expand, collapse, or otherwise interact with the widget.
 
 ## Ownership model
 
@@ -66,11 +67,11 @@ Checkpoint initialisation is best-effort for unrelated tools: a non-Git project 
 - `advance: boolean`, default `true`;
 - `include_patch: boolean`, default `true`.
 
-It creates one current snapshot, compares it with the requested baseline, and optionally advances `last-review` to that snapshot. Persistent advancement uses `git update-ref <ref> <new> <expected-old>`. A compare-and-swap conflict preserves the returned diff but reports that the baseline was not advanced.
+It creates one current snapshot, compares it with the requested baseline, and optionally advances `last-review` to that snapshot before returning. Persistent advancement uses `git update-ref <ref> <new> <expected-old>`. A compare-and-swap conflict preserves the returned diff but reports that the baseline was not advanced. Advancement records that the diff was emitted, not that the model or user inspected every hunk.
 
 ## Result contract
 
-The text result is concise and usable by the model. `structuredContent` is the authoritative UI payload:
+The tool deliberately advertises no `outputSchema` and returns no `structuredContent`. Its text result is concise and usable by the model. Namespaced result `_meta` is the authoritative component-only UI payload:
 
 - requested and effective baseline;
 - whether the last-review checkpoint advanced;
@@ -81,20 +82,20 @@ The text result is concise and usable by the model. `structuredContent` is the a
 - explicit omission metadata when the patch or file list is bounded;
 - warnings such as compare-and-swap conflicts.
 
-A patch larger than `review.maxPatchBytes` is omitted rather than cut mid-hunk. File metadata and aggregate statistics remain available. `0` disables patch bodies.
+A patch larger than `review.maxPatchBytes` is omitted rather than cut mid-hunk. File metadata and aggregate statistics remain available. The default is 4 MiB, regression-tested with 10,000 changed code lines whose source lines are roughly 300 bytes long. Byte bounding remains necessary because line length and binary-patch expansion are unbounded. `0` disables patch bodies.
 
 ## MCP Apps integration
 
 The server advertises the standard `io.modelcontextprotocol/ui` extension and a single resource:
 
 ```text
-ui://codex-free/review/mcp-app.html
+ui://codex-free/review/v2/mcp-app.html
 text/html;profile=mcp-app
 ```
 
-The `show_changes` tool descriptor links that resource through both the current nested `_meta.ui.resourceUri` shape and the compatibility `_meta["ui/resourceUri"]` key. Unsupported clients ignore the metadata and continue to receive the normal result.
+The `show_changes` tool descriptor links that resource through both the current nested `_meta.ui.resourceUri` shape and the compatibility `_meta["ui/resourceUri"]` key. The tool result stores the complete `ReviewResult` under `_meta["io.github.hypnguyen1209/review"]`. Unsupported clients ignore the component metadata and continue to receive the concise text result. The prior unversioned resource URI remains readable with the v2 HTML, which falls back to historical structured review results only when component metadata is absent; current tool results never produce that model-visible payload.
 
-The resource is a self-contained HTML/CSS/JavaScript document embedded in the Rust binary. It has no external script, font, style, network, or storage dependency. It performs the MCP Apps handshake, validates `postMessage` source identity, consumes `ui/notifications/tool-result`, renders only with DOM `textContent`, and reports size changes. The view never performs checkpoint mutations itself.
+The resource is a self-contained HTML/CSS/JavaScript document embedded in the Rust binary. It has no external script, font, style, network, or direct browser-storage dependency. It performs the MCP Apps handshake, validates `postMessage` source identity, consumes component-only result metadata from `ui/notifications/tool-result` and ChatGPT's canonical `toolResponseMetadata` envelope, renders only with DOM `textContent`, and reports size changes. The view never performs checkpoint mutations itself. Its overall disclosure state, per-file expansions, and larger-file-list disclosure are saved through `window.openai.setWidgetState` under `privateContent` and restored from `window.openai.widgetState` after iframe remounts; none of that state is exposed to the model. Hosts without the ChatGPT state API retain normal interaction for the current iframe lifetime.
 
 ## Concurrency and failure handling
 

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use anyhow::{Context, bail};
 use chrono::{SecondsFormat, Utc};
 use regex::Regex;
+use serde::Serialize;
 use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
@@ -288,6 +289,7 @@ pub(crate) fn summarize_output(result: &ToolResult) -> Value {
         .structured_content
         .as_ref()
         .map_or(0, serialized_json_bytes);
+    let meta_bytes = result.meta.as_ref().map_or(0, serialized_json_bytes);
     json!({
         "content_bytes": text_bytes.saturating_add(image_base64_bytes),
         "text_bytes": text_bytes,
@@ -295,6 +297,7 @@ pub(crate) fn summarize_output(result: &ToolResult) -> Value {
         "image_count": image_count,
         "image_base64_bytes": image_base64_bytes,
         "structured_bytes": structured_bytes,
+        "meta_bytes": meta_bytes,
         "truncated": result.audit.truncated,
         "original_output_tokens": result.audit.original_output_tokens,
         "exec_session_id": result.audit.exec_session_id,
@@ -317,7 +320,7 @@ impl Write for CountingWriter {
     }
 }
 
-fn serialized_json_bytes(value: &Value) -> u64 {
+fn serialized_json_bytes<T: Serialize>(value: &T) -> u64 {
     let mut writer = CountingWriter::default();
     if serde_json::to_writer(&mut writer, value).is_ok() {
         writer.0
@@ -668,6 +671,7 @@ fn open_private_append(path: &Path) -> anyhow::Result<File> {
 mod tests {
     use super::*;
     use crate::config::default_config;
+    use rmcp::model::MetaObject;
 
     #[test]
     fn argument_summary_exposes_shape_but_not_values() {
@@ -844,6 +848,22 @@ mod tests {
         assert_eq!(events[2]["duration_ms"], 17);
         assert_eq!(events[2]["output"]["truncated"], true);
         assert_eq!(events[2]["output"]["text_bytes"], 25);
+    }
+
+    #[test]
+    fn output_summary_counts_component_metadata_without_retaining_it() {
+        let mut result = ToolResult::text("ok");
+        let mut meta = MetaObject::new();
+        meta.0.insert(
+            "io.github.example/review".to_string(),
+            json!({ "patch": "sensitive patch" }),
+        );
+        result.meta = Some(meta);
+
+        let summary = summarize_output(&result);
+        assert_eq!(summary["structured_bytes"], 0);
+        assert!(summary["meta_bytes"].as_u64().unwrap() > 0);
+        assert!(!summary.to_string().contains("sensitive patch"));
     }
 
     #[test]

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -33,7 +33,7 @@ pub const AGENT_BRIEF: &str = concat!(
     "- Do not amend a commit unless explicitly asked.\n",
     "- If changes appear that you did not make, STOP and ask the user how to proceed.\n",
     "- NEVER run destructive commands such as `git reset --hard` or `git checkout --` unless the user specifically asked for or approved them.\n",
-    "- After the final related file change, call show_changes once to review the project-scoped aggregate diff. Do not advance the checkpoint after every file unless the user asks for incremental reviews.\n",
+    "- After the final related file change, call show_changes once to present the project-scoped aggregate diff. Do not advance the checkpoint after every file unless the user asks for incremental reviews.\n",
     "\n## Running commands\n\n",
     "- Match the shell named under Environment. The same command string does not mean the same thing under POSIX sh, PowerShell and cmd.\n",
     "- exec_command returns a session_id instead of a result when a command outlives its yield window. Drive it from there with write_stdin rather than starting the command again.\n",

--- a/src/review.rs
+++ b/src/review.rs
@@ -118,25 +118,9 @@ impl ReviewResult {
         }
         lines.push(format!("Repository scope: {}", self.scope));
 
-        for file in &self.files {
-            let path = match &file.previous_path {
-                Some(previous) => format!("{previous} -> {}", file.path),
-                None => file.path.clone(),
-            };
-            let stats = if file.binary {
-                "binary".to_string()
-            } else {
-                format!(
-                    "+{} -{}",
-                    file.additions.unwrap_or(0),
-                    file.deletions.unwrap_or(0)
-                )
-            };
-            lines.push(format!("- {} {path} ({stats})", file.status));
-        }
         if self.files_omitted > 0 {
             lines.push(format!(
-                "... {} additional file{} omitted from the result.",
+                "{} file record{} omitted from the widget payload.",
                 self.files_omitted,
                 if self.files_omitted == 1 { "" } else { "s" }
             ));
@@ -157,7 +141,7 @@ impl ReviewResult {
 
         if self.patch_included && !self.patch.is_empty() {
             lines.push(format!(
-                "Patch included in structuredContent ({} bytes).",
+                "Complete patch attached to component-only widget metadata ({} bytes).",
                 self.patch_bytes.unwrap_or(self.patch.len())
             ));
         } else if let Some(reason) = &self.patch_omitted_reason {

--- a/src/review_ui.rs
+++ b/src/review_ui.rs
@@ -1,9 +1,13 @@
 use rmcp::model::{MetaObject, Resource, ResourceContents};
 use serde_json::json;
 
-pub const REVIEW_UI_URI: &str = "ui://codex-free/review/mcp-app.html";
+use crate::review::ReviewResult;
+
+pub const REVIEW_UI_URI: &str = "ui://codex-free/review/v2/mcp-app.html";
+pub const LEGACY_REVIEW_UI_URI: &str = "ui://codex-free/review/mcp-app.html";
 pub const REVIEW_UI_MIME_TYPE: &str = "text/html;profile=mcp-app";
 pub const MCP_APPS_EXTENSION_ID: &str = "io.modelcontextprotocol/ui";
+pub const REVIEW_RESULT_META_KEY: &str = "io.github.hypnguyen1209/review";
 
 pub fn tool_meta() -> MetaObject {
     serde_json::from_value(json!({
@@ -20,6 +24,15 @@ pub fn resource_meta() -> MetaObject {
     .expect("static review resource metadata must be an object")
 }
 
+pub fn result_meta(result: &ReviewResult) -> MetaObject {
+    let mut meta = MetaObject::new();
+    meta.0.insert(
+        REVIEW_RESULT_META_KEY.to_string(),
+        serde_json::to_value(result).expect("review result must serialize"),
+    );
+    meta
+}
+
 pub fn resource() -> Resource {
     Resource::new(REVIEW_UI_URI, "codex-free-review")
         .with_title("Code review")
@@ -30,9 +43,18 @@ pub fn resource() -> Resource {
 }
 
 pub fn contents() -> ResourceContents {
-    ResourceContents::text(REVIEW_UI_HTML, REVIEW_UI_URI)
-        .with_mime_type(REVIEW_UI_MIME_TYPE)
-        .with_meta(resource_meta())
+    contents_for_uri(REVIEW_UI_URI).expect("current review UI URI must be supported")
+}
+
+pub fn contents_for_uri(uri: &str) -> Option<ResourceContents> {
+    if uri != REVIEW_UI_URI && uri != LEGACY_REVIEW_UI_URI {
+        return None;
+    }
+    Some(
+        ResourceContents::text(REVIEW_UI_HTML, uri)
+            .with_mime_type(REVIEW_UI_MIME_TYPE)
+            .with_meta(resource_meta()),
+    )
 }
 
 pub const REVIEW_UI_HTML: &str = r##"<!doctype html>
@@ -124,9 +146,13 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
   "use strict";
   const root = document.getElementById("root");
   const INITIAL_VISIBLE_FILES = 3;
+  const REVIEW_META_KEY = "io.github.hypnguyen1209/review";
+  const WIDGET_STATE_VERSION = 1;
   let nextId = 1;
   const pending = new Map();
   let resizeObserver;
+  let currentData;
+  let uiState = normalizeWidgetState(window.openai && window.openai.widgetState);
 
   function post(message) {
     window.parent.postMessage(message, "*");
@@ -147,6 +173,68 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
     if (className) node.className = className;
     if (text !== undefined) node.textContent = String(text);
     return node;
+  }
+
+  function normalizeWidgetState(value) {
+    const source = value && typeof value === "object" && value.privateContent && typeof value.privateContent === "object"
+      ? value.privateContent
+      : value;
+    const expandedFiles = source && Array.isArray(source.expandedFiles)
+      ? source.expandedFiles.filter(item => typeof item === "string")
+      : [];
+    return {
+      reviewOpen: !(source && source.reviewOpen === false),
+      showAllFiles: Boolean(source && source.showAllFiles),
+      expandedFiles: new Set(expandedFiles)
+    };
+  }
+
+  function widgetStatesEqual(left, right) {
+    if (left.reviewOpen !== right.reviewOpen || left.showAllFiles !== right.showAllFiles) return false;
+    if (left.expandedFiles.size !== right.expandedFiles.size) return false;
+    for (const key of left.expandedFiles) {
+      if (!right.expandedFiles.has(key)) return false;
+    }
+    return true;
+  }
+
+  function persistWidgetState() {
+    const api = window.openai;
+    if (!api || typeof api.setWidgetState !== "function") return;
+    try {
+      api.setWidgetState({
+        privateContent: {
+          version: WIDGET_STATE_VERSION,
+          reviewOpen: uiState.reviewOpen,
+          showAllFiles: uiState.showAllFiles,
+          expandedFiles: Array.from(uiState.expandedFiles)
+        }
+      });
+    } catch (_) {}
+  }
+
+  function reviewPayloadFromMetadata(value) {
+    const queue = [value];
+    const seen = new Set();
+    const nestedKeys = ["_meta", "meta", "call_tool_result", "callToolResult", "mcp_tool_result", "mcpToolResult", "result"];
+    while (queue.length) {
+      const candidate = queue.shift();
+      if (!candidate || typeof candidate !== "object" || seen.has(candidate)) continue;
+      seen.add(candidate);
+      const payload = candidate[REVIEW_META_KEY];
+      if (payload && typeof payload === "object") return payload;
+      for (const key of nestedKeys) {
+        if (candidate[key] && typeof candidate[key] === "object") queue.push(candidate[key]);
+      }
+    }
+    return null;
+  }
+
+  function legacyStructuredPayload(value) {
+    if (!value || typeof value !== "object") return null;
+    const payload = value.structuredContent || value.structured_content;
+    if (payload && typeof payload === "object") return payload;
+    return value.summary && Array.isArray(value.files) ? value : null;
   }
 
   function splitPatch(patch) {
@@ -170,6 +258,12 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
   function displayPath(file, chunk) {
     if (file && file.path) return file.previousPath ? `${file.previousPath} → ${file.path}` : file.path;
     return chunk && chunk.heading ? chunk.heading : "Patch";
+  }
+
+  function entryStateKey(file, chunk, index) {
+    const previous = file && file.previousPath ? file.previousPath : "";
+    const path = file && file.path ? file.path : (chunk && chunk.heading ? chunk.heading : "Patch");
+    return `${index}:${previous}→${path}`;
   }
 
   function pathNode(file, chunk) {
@@ -227,22 +321,34 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
     else reportSize();
   }
 
-  function diffDetails(file, chunk, unavailableReason) {
+  function diffDetails(file, chunk, unavailableReason, stateKey) {
     const details = el("details", "file-entry");
-    details.open = false;
     const summary = el("summary", "file-summary");
     summary.append(statusNode(file), pathNode(file, chunk), fileStats(file));
     details.append(summary);
 
     let rendered = false;
+    const ensureRendered = () => {
+      if (rendered) return;
+      rendered = true;
+      const body = el("div", "diff-body");
+      if (chunk) renderDiffLines(chunk.lines, body);
+      else body.append(el("div", "empty", unavailableReason || "No textual diff is available for this file."));
+      details.append(body);
+    };
+    details.open = uiState.expandedFiles.has(stateKey);
+    if (details.open) ensureRendered();
     details.addEventListener("toggle", () => {
-      if (details.open && !rendered) {
-        rendered = true;
-        const body = el("div", "diff-body");
-        if (chunk) renderDiffLines(chunk.lines, body);
-        else body.append(el("div", "empty", unavailableReason || "No textual diff is available for this file."));
-        details.append(body);
+      const persistedOpen = uiState.expandedFiles.has(stateKey);
+      if (details.open === persistedOpen) {
+        scheduleSizeReport();
+        return;
       }
+      if (details.open) {
+        ensureRendered();
+        uiState.expandedFiles.add(stateKey);
+      } else uiState.expandedFiles.delete(stateKey);
+      persistWidgetState();
       scheduleSizeReport();
     });
     return details;
@@ -258,7 +364,7 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
     for (const entry of entries) container.append(entry);
     if (entries.length <= INITIAL_VISIBLE_FILES) return;
 
-    let expanded = false;
+    let expanded = uiState.showAllFiles;
     const button = el("button", "show-more");
     button.type = "button";
     const sync = () => {
@@ -273,6 +379,8 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
     };
     button.addEventListener("click", () => {
       expanded = !expanded;
+      uiState.showAllFiles = expanded;
+      persistWidgetState();
       sync();
     });
     container.append(button);
@@ -288,7 +396,7 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
 
     for (let index = 0; index < count; index += 1) {
       entries.push(patchAvailable
-        ? diffDetails(files[index], chunks[index], data.patchOmittedReason)
+        ? diffDetails(files[index], chunks[index], data.patchOmittedReason, entryStateKey(files[index], chunks[index], index))
         : fileRow(files[index]));
     }
     appendEntries(entries, container);
@@ -300,12 +408,13 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
         : "The scoped working tree matches the selected checkpoint."));
     }
     if (data.filesOmitted) {
-      container.append(el("div", "empty omitted", `${data.filesOmitted} additional file${data.filesOmitted === 1 ? "" : "s"} omitted from structured metadata.`));
+      container.append(el("div", "empty omitted", `${data.filesOmitted} additional file${data.filesOmitted === 1 ? "" : "s"} omitted from widget file metadata.`));
     }
   }
 
   function render(data) {
     if (!data || typeof data !== "object") return;
+    currentData = data;
     root.replaceChildren();
     const summary = data.summary || {};
     const header = el("header");
@@ -321,8 +430,16 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
     root.append(header);
 
     const review = el("details", "review");
-    review.open = true;
-    review.addEventListener("toggle", scheduleSizeReport);
+    review.open = uiState.reviewOpen;
+    review.addEventListener("toggle", () => {
+      if (uiState.reviewOpen === review.open) {
+        scheduleSizeReport();
+        return;
+      }
+      uiState.reviewOpen = review.open;
+      persistWidgetState();
+      scheduleSizeReport();
+    });
     const reviewSummary = el("summary", "review-summary");
     const count = summary.files || 0;
     const summaryStats = el("span", "summary-stats");
@@ -352,7 +469,7 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
   }
 
   function toolResultPayload(params) {
-    return params && (params.structuredContent || params.structured_content);
+    return reviewPayloadFromMetadata(params) || legacyStructuredPayload(params);
   }
 
   window.addEventListener("message", event => {
@@ -369,7 +486,8 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
       return;
     }
     if (message.method === "ui/notifications/tool-result") {
-      render(toolResultPayload(message.params));
+      const output = toolResultPayload(message.params);
+      if (output) render(output);
     } else if (message.method === "ui/notifications/host-context-changed") {
       applyHostContext(message.params);
     } else if (message.method === "ui/resource-teardown" && message.id !== undefined) {
@@ -396,23 +514,39 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
     reportSize();
   }
 
-  const legacy = window.openai && window.openai.toolOutput;
+  const legacy = window.openai && (
+    reviewPayloadFromMetadata(window.openai.toolResponseMetadata)
+    || legacyStructuredPayload(window.openai.toolOutput)
+  );
   if (legacy) render(legacy);
   window.addEventListener("openai:set_globals", event => {
-    const output = event.detail && event.detail.globals && event.detail.globals.toolOutput;
-    if (output) render(output);
+    const globals = event.detail && event.detail.globals;
+    if (!globals) return;
+    let shouldRender = false;
+    if (Object.prototype.hasOwnProperty.call(globals, "widgetState")) {
+      const nextState = normalizeWidgetState(globals.widgetState);
+      shouldRender = Boolean(currentData) && !widgetStatesEqual(uiState, nextState);
+      uiState = nextState;
+    }
+    const output = reviewPayloadFromMetadata(globals.toolResponseMetadata)
+      || (!currentData ? legacyStructuredPayload(globals.toolOutput) : null);
+    if (output && !currentData) {
+      currentData = output;
+      shouldRender = true;
+    }
+    if (shouldRender) render(currentData);
   });
 
   request("ui/initialize", {
     protocolVersion: "2026-01-26",
-    appInfo: { name: "codex-free-review", version: "1.0.0" },
+    appInfo: { name: "codex-free-review", version: "2.0.0" },
     appCapabilities: {}
   }).then(result => {
     applyHostContext(result && result.hostContext);
     notify("ui/notifications/initialized", {});
     startSizeReporting();
   }).catch(error => {
-    if (!legacy) root.replaceChildren(el("div", "notice", `Review UI could not initialize: ${error && error.message ? error.message : String(error)}`));
+    if (!currentData) root.replaceChildren(el("div", "notice", `Review UI could not initialize: ${error && error.message ? error.message : String(error)}`));
   });
 })();
 </script>
@@ -423,6 +557,7 @@ pre { width: 100%; min-width: 0; max-width: 100%; margin: 0; overflow-x: auto; o
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::review::{ReviewBaseline, ReviewFile, ReviewSummary};
 
     #[test]
     fn tool_metadata_carries_current_and_compatibility_resource_keys() {
@@ -449,6 +584,44 @@ mod tests {
         let value = serde_json::to_value(contents).unwrap();
         assert_eq!(value["uri"], REVIEW_UI_URI);
         assert_eq!(value["mimeType"], REVIEW_UI_MIME_TYPE);
+        let legacy = serde_json::to_value(contents_for_uri(LEGACY_REVIEW_UI_URI).unwrap()).unwrap();
+        assert_eq!(legacy["uri"], LEGACY_REVIEW_UI_URI);
+        assert!(contents_for_uri("ui://codex-free/review/unknown.html").is_none());
+    }
+
+    #[test]
+    fn result_metadata_contains_the_complete_widget_payload() {
+        let result = ReviewResult {
+            since: ReviewBaseline::LastReview,
+            advance_requested: true,
+            checkpoint_advanced: true,
+            scope: ".".to_string(),
+            summary: ReviewSummary {
+                files: 1,
+                additions: 1,
+                deletions: 0,
+                binary_files: 0,
+            },
+            files: vec![ReviewFile {
+                path: "src/lib.rs".to_string(),
+                previous_path: None,
+                status: "modified".to_string(),
+                additions: Some(1),
+                deletions: Some(0),
+                binary: false,
+            }],
+            files_omitted: 0,
+            patch: "diff --git a/src/lib.rs b/src/lib.rs\n+new\n".to_string(),
+            patch_included: true,
+            patch_bytes: Some(45),
+            patch_omitted_reason: None,
+            warnings: Vec::new(),
+        };
+        let meta = result_meta(&result);
+        let payload = meta.get(REVIEW_RESULT_META_KEY).unwrap();
+        assert_eq!(payload["patch"], result.patch);
+        assert_eq!(payload["checkpointAdvanced"], true);
+        assert_eq!(payload["files"][0]["path"], "src/lib.rs");
     }
 
     #[test]
@@ -459,6 +632,15 @@ mod tests {
         assert!(REVIEW_UI_HTML.contains("ui/notifications/size-changed"));
         assert!(REVIEW_UI_HTML.contains("event.source !== window.parent"));
         assert!(REVIEW_UI_HTML.contains("hasOwnProperty.call(message, \"result\")"));
+        assert!(REVIEW_UI_HTML.contains("window.openai.toolResponseMetadata"));
+        assert!(REVIEW_UI_HTML.contains(REVIEW_RESULT_META_KEY));
+        assert!(
+            REVIEW_UI_HTML
+                .contains("reviewPayloadFromMetadata(params) || legacyStructuredPayload(params)")
+        );
+        assert!(
+            REVIEW_UI_HTML.contains("value.summary && Array.isArray(value.files) ? value : null")
+        );
         assert!(REVIEW_UI_HTML.contains("textContent"));
         assert!(!REVIEW_UI_HTML.contains("<script src="));
         let initialized = REVIEW_UI_HTML
@@ -475,11 +657,23 @@ mod tests {
         assert!(REVIEW_UI_HTML.contains("text-size-adjust: 100%"));
         assert!(REVIEW_UI_HTML.contains("const INITIAL_VISIBLE_FILES = 3"));
         assert!(REVIEW_UI_HTML.contains("el(\"details\", \"file-entry\")"));
-        assert!(REVIEW_UI_HTML.contains("details.open = false"));
+        assert!(REVIEW_UI_HTML.contains("details.open = uiState.expandedFiles.has(stateKey)"));
         assert!(REVIEW_UI_HTML.contains("details.addEventListener(\"toggle\""));
         assert!(REVIEW_UI_HTML.contains("renderDiffLines(chunk.lines, body)"));
         assert!(REVIEW_UI_HTML.contains("document.documentElement.clientWidth"));
         assert!(!REVIEW_UI_HTML.contains("document.documentElement.scrollWidth"));
         assert!(!REVIEW_UI_HTML.contains("font: 11px/1.55"));
+    }
+
+    #[test]
+    fn embedded_view_persists_private_interaction_state() {
+        assert!(REVIEW_UI_HTML.contains("window.openai.widgetState"));
+        assert!(REVIEW_UI_HTML.contains("api.setWidgetState"));
+        assert!(REVIEW_UI_HTML.contains("privateContent"));
+        assert!(REVIEW_UI_HTML.contains("uiState.reviewOpen = review.open"));
+        assert!(REVIEW_UI_HTML.contains("uiState.showAllFiles = expanded"));
+        assert!(REVIEW_UI_HTML.contains("uiState.expandedFiles.add(stateKey)"));
+        assert!(REVIEW_UI_HTML.contains("hasOwnProperty.call(globals, \"widgetState\")"));
+        assert!(REVIEW_UI_HTML.contains("output && !currentData"));
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -226,13 +226,13 @@ impl ServerHandler for CodexHandler {
         request: ReadResourceRequestParams,
         _context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, McpError> {
-        if request.uri != review_ui::REVIEW_UI_URI {
+        let Some(contents) = review_ui::contents_for_uri(&request.uri) else {
             return Err(McpError::resource_not_found(
                 format!("Unknown resource: {}", request.uri),
                 None,
             ));
-        }
-        Ok(ReadResourceResult::new(vec![review_ui::contents()]).into())
+        };
+        Ok(ReadResourceResult::new(vec![contents]).into())
     }
 
     async fn call_tool(

--- a/src/tools/show_changes.rs
+++ b/src/tools/show_changes.rs
@@ -3,7 +3,9 @@ use rmcp::model::MetaObject;
 use serde_json::{Value, json};
 
 use crate::exec_sessions::SessionState;
-use crate::review::{ReviewBaseline, ReviewCheckpointManager, ReviewOwner, ReviewRequest};
+use crate::review::{
+    ReviewBaseline, ReviewCheckpointManager, ReviewOwner, ReviewRequest, ReviewResult,
+};
 use crate::review_ui;
 use crate::tool::{Tool, ToolRequestContext};
 use crate::types::{AppConfig, ToolResult};
@@ -20,6 +22,12 @@ fn bool_argument(args: &Value, key: &str, default: bool) -> Result<bool, String>
 
 impl ShowChanges {
     pub const NAME: &'static str = "show_changes";
+
+    fn tool_result(result: ReviewResult) -> ToolResult {
+        let mut output = ToolResult::text(result.render_text());
+        output.meta = Some(review_ui::result_meta(&result));
+        output
+    }
 
     fn request(args: &Value) -> Result<ReviewRequest, String> {
         let since = match args.get("since") {
@@ -50,10 +58,7 @@ impl ShowChanges {
             None => ReviewOwner::transport(session.review_state()),
         };
         match manager.show_changes(config, owner, request).await {
-            Ok(result) => {
-                let structured = serde_json::to_value(&result).unwrap_or(Value::Null);
-                ToolResult::text(result.render_text()).with_structured(structured)
-            }
+            Ok(result) => Self::tool_result(result),
             Err(error) => ToolResult::error(error),
         }
     }
@@ -74,7 +79,7 @@ impl Tool for ShowChanges {
     }
 
     fn description(&self) -> String {
-        "Review project-scoped working-tree changes against the immutable project-open checkpoint or the incremental last-review checkpoint. The snapshot includes tracked, untracked, deleted, renamed, executable, symlink, and binary changes without modifying the real Git index. By default the returned review advances the last-review checkpoint, so call once after a related batch of edits rather than after every file. Set advance=false for a read-only comparison."
+        "Present project-scoped working-tree changes against the immutable project-open checkpoint or the incremental last-review checkpoint. The interactive widget receives tracked, untracked, deleted, renamed, executable, symlink, and binary changes through component-only result metadata without adding the patch to model-visible structured content. By default the returned review advances the last-review checkpoint, so call once after a related batch of edits rather than after every file. Set advance=false for a read-only comparison."
             .to_string()
     }
 
@@ -93,62 +98,11 @@ impl Tool for ShowChanges {
                 },
                 "include_patch": {
                     "type": "boolean",
-                    "description": "Include the unified binary-capable patch when it fits review.maxPatchBytes. Default: true."
+                    "description": "Attach the unified binary-capable patch to component-only widget metadata when it fits review.maxPatchBytes. Default: true."
                 }
             },
             "additionalProperties": false
         })
-    }
-
-    fn output_schema(&self) -> Option<Value> {
-        Some(json!({
-            "type": "object",
-            "properties": {
-                "since": { "type": "string", "enum": ["last_review", "project_open"] },
-                "advanceRequested": { "type": "boolean" },
-                "checkpointAdvanced": { "type": "boolean" },
-                "scope": { "type": "string" },
-                "summary": {
-                    "type": "object",
-                    "properties": {
-                        "files": { "type": "integer" },
-                        "additions": { "type": "integer" },
-                        "deletions": { "type": "integer" },
-                        "binaryFiles": { "type": "integer" }
-                    },
-                    "required": ["files", "additions", "deletions", "binaryFiles"]
-                },
-                "files": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "path": { "type": "string" },
-                            "previousPath": { "type": "string" },
-                            "status": { "type": "string" },
-                            "additions": { "type": "integer" },
-                            "deletions": { "type": "integer" },
-                            "binary": { "type": "boolean" }
-                        },
-                        "required": ["path", "status", "binary"]
-                    }
-                },
-                "filesOmitted": { "type": "integer" },
-                "patch": { "type": "string" },
-                "patchIncluded": { "type": "boolean" },
-                "patchBytes": { "type": "integer" },
-                "patchOmittedReason": { "type": "string" },
-                "warnings": { "type": "array", "items": { "type": "string" } }
-            },
-            "required": [
-                "since", "advanceRequested", "checkpointAdvanced", "scope", "summary",
-                "files", "filesOmitted", "patch", "patchIncluded", "warnings"
-            ]
-        }))
-    }
-
-    fn fills_structured_content(&self) -> bool {
-        false
     }
 
     async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult {
@@ -177,6 +131,7 @@ impl Tool for ShowChanges {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::review::ReviewSummary;
 
     #[test]
     fn request_defaults_to_incremental_advancing_patch_review() {
@@ -191,5 +146,41 @@ mod tests {
         assert!(ShowChanges::request(&json!({ "since": 1 })).is_err());
         assert!(ShowChanges::request(&json!({ "advance": "yes" })).is_err());
         assert!(ShowChanges::request(&json!({ "include_patch": 1 })).is_err());
+    }
+
+    #[test]
+    fn result_keeps_the_patch_out_of_model_visible_structured_content() {
+        let result = ReviewResult {
+            since: ReviewBaseline::LastReview,
+            advance_requested: true,
+            checkpoint_advanced: true,
+            scope: ".".to_string(),
+            summary: ReviewSummary {
+                files: 1,
+                additions: 1,
+                deletions: 0,
+                binary_files: 0,
+            },
+            files: Vec::new(),
+            files_omitted: 0,
+            patch: "diff --git a/file b/file\n+secret patch line\n".to_string(),
+            patch_included: true,
+            patch_bytes: Some(48),
+            patch_omitted_reason: None,
+            warnings: Vec::new(),
+        };
+
+        let output = ShowChanges::tool_result(result);
+        assert!(output.structured_content.is_none());
+        assert!(!output.joined_text().contains("secret patch line"));
+        assert_eq!(
+            output
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get(review_ui::REVIEW_RESULT_META_KEY))
+                .and_then(|payload| payload.get("patch"))
+                .and_then(Value::as_str),
+            Some("diff --git a/file b/file\n+secret patch line\n")
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -240,9 +240,9 @@ pub struct MemoryConfig {
     pub max_bytes: Option<usize>,
 }
 
-pub const DEFAULT_REVIEW_MAX_PATCH_BYTES: usize = 512 * 1024;
+pub const DEFAULT_REVIEW_MAX_PATCH_BYTES: usize = 4 * 1024 * 1024;
 
-/// Bounds review results without changing checkpoint semantics.
+/// Bounds the component-only patch payload without changing checkpoint semantics.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ReviewConfig {

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -208,6 +208,7 @@ fn show_changes_links_the_review_mcp_app() {
             .and_then(Value::as_str),
         Some(codex_free::review_ui::REVIEW_UI_URI)
     );
+    assert!(tool.output_schema().is_none());
 }
 
 #[test]
@@ -425,7 +426,6 @@ fn tools_that_need_their_own_structured_content() {
             "get_environment".to_string(),
             "get_project_doc".to_string(),
             "import_host_file".to_string(),
-            "show_changes".to_string(),
             "skills_list".to_string(),
             "write_stdin".to_string(),
         ]

--- a/tests/review_checkpoints.rs
+++ b/tests/review_checkpoints.rs
@@ -440,6 +440,40 @@ async fn omits_instead_of_truncating_an_oversized_patch() {
 }
 
 #[tokio::test]
+async fn default_widget_budget_includes_ten_thousand_changed_code_lines() {
+    fn source(prefix: char) -> String {
+        let padding = "x".repeat(270);
+        (0..5_000)
+            .map(|index| format!("const VALUE_{index:04}: &str = \"{prefix}{padding}\";\n"))
+            .collect()
+    }
+
+    let repo = init_repo();
+    let file = repo.path().join("large.rs");
+    std::fs::write(&file, source('a')).unwrap();
+    commit_all(repo.path(), "seed");
+    let config = default_config(repo.path().to_path_buf());
+    assert_eq!(config.review.max_patch_bytes, 4 * 1024 * 1024);
+    let manager = ReviewCheckpointManager::new();
+    let owner = conversation("ten-thousand-lines");
+    manager
+        .ensure_initialized(&config, owner.clone())
+        .await
+        .unwrap();
+
+    std::fs::write(&file, source('b')).unwrap();
+    let result = manager
+        .show_changes(&config, owner, request(ReviewBaseline::ProjectOpen, false))
+        .await
+        .unwrap();
+
+    assert_eq!(result.summary.additions + result.summary.deletions, 10_000);
+    assert!(result.patch_included);
+    assert!(result.patch_bytes.unwrap() < config.review.max_patch_bytes);
+    assert!(result.patch.contains("const VALUE_4999"));
+}
+
+#[tokio::test]
 async fn non_git_project_reports_a_clear_error() {
     let root = TempDir::new().unwrap();
     let config = default_config(PathBuf::from(root.path()));


### PR DESCRIPTION
## Overview

Keep the complete `show_changes` diff available to the interactive review widget without placing it in model-visible tool output.

The tool now returns only a concise text summary to the model. Its complete `ReviewResult`—file metadata, statistics, warnings, and the bounded unified binary patch—is attached under namespaced tool-result `_meta`, which compatible MCP Apps can consume without `structuredContent` entering the conversation context.

## Behavior

- Remove `show_changes`'s `outputSchema` and stop returning `structuredContent`.
- Attach the complete review payload under `_meta["io.github.hypnguyen1209/review"]`.
- Keep automatic `last-review` advancement unchanged: snapshot comparison and compare-and-swap advancement finish before the tool result is returned and do not wait for user interaction.
- Keep the review card independently interactive after the model continues.
- Persist the overall card disclosure, each expanded file diff, and the larger-file-list disclosure through ChatGPT private widget state.
- Restore that state after iframe remounts without re-render loops or scroll resets.
- Read the canonical `toolResponseMetadata` envelope and standard MCP Apps tool-result notifications.
- Version the resource URI as `ui://codex-free/review/v2/mcp-app.html` to avoid stale cached UI code.
- Continue serving the prior resource URI and accept historical structured review payloads so existing conversation cards can remount.

## Diff capacity

Raise the default patch budget from 512 KiB to 4 MiB. The regression suite constructs a real Git patch with exactly 5,000 deleted and 5,000 added Rust lines, approximately 300 bytes per source line, and verifies that the complete patch is retained.

The byte bound remains configurable because source-line length and Git binary-patch expansion are not intrinsically bounded. Oversized patches continue to be omitted as a whole instead of being cut mid-hunk.

Audit summaries now report the serialized result-metadata byte count without retaining or logging the metadata contents.

## Validation

- `cargo fmt --all -- --check`
- extracted embedded JavaScript + `node --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`
- focused review UI, hidden-result, historical-compatibility, oversized-patch, and 10,000-line patch-budget tests
