### PR TITLE
feat: add downloadable project file exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Native project-file egress through `export_host_file`. The tool snapshots one
+  project-relative regular file and returns a standard MCP `resource_link`; the
+  connector host retrieves the immutable bytes through `resources/read` instead
+  of receiving a machine-local path or model-visible base64 payload.
+- `artifactEgress` configuration, enabled by default, for the per-file byte limit,
+  process-wide cached-byte and live-reference bounds, and opaque resource lifetime.
+
 ### Changed
 
 - The `show_changes` MCP app now uses a compact, single-line file list with
@@ -13,6 +22,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   sets, and smaller explicitly sized monospace patch text across web and native
   mobile/desktop hosts. Patch panes remain horizontally scrollable without
   expanding the host card, and generated Git diffs use the histogram algorithm.
+
+### Security
+
+- Exported files are opened through a capability-confined active-project root,
+  with traversal, absolute paths, symlink escapes, non-regular files, and growth
+  past the configured limit rejected. Each result is an owned immutable snapshot
+  behind a random 256-bit short-lived capability; cache eviction and restart
+  invalidate references, and audit records never include their URIs or filenames.
 
 ## [1.7.0] - 2026-08-26
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A local MCP bridge server that lets ChatGPT Web Pro call tools on your machine: 
 
 In native-tunnel mode, Codex Free listens only on `127.0.0.1`, protects the MCP endpoint with a random per-process bearer token, starts OpenAI's official runtime-only tunnel client, and supervises it for the lifetime of the server. The tunnel client makes outbound HTTPS requests to OpenAI and forwards tunnel traffic to the authenticated loopback MCP endpoint. A conventional externally managed tunnel remains available as an alternative.
 
-The tool set covers the ones [Codex](https://github.com/openai/codex) gives its own agent — `apply_patch`, `exec_command`/`write_stdin`, `view_image`, `update_plan`, `clock_curr_time`/`clock_sleep` — so ChatGPT Web can work the way Codex does: patch files in place instead of rewriting them, drive interactive and long-running processes, and keep a plan across a task. It also bridges ChatGPT-native attachments and generated files into the active local project without base64 reconstruction. It carries the project's `AGENTS.md` and Codex's own agent brief, so the client is told how to behave and not just what it can call. It bounds what a tool call can return, keeps a plan and notes on disk across conversations, and records project-scoped review checkpoints so ChatGPT can inspect either the full task diff or only changes since the last review. And it loads Codex's skills: a `SKILL.md` in the repo or your home directory teaches the client how *you* do a recurring task, and only the ones that apply are ever read. Schemas and prompt are ported from the Codex source, not reimplemented from guesswork.
+The tool set covers the ones [Codex](https://github.com/openai/codex) gives its own agent — `apply_patch`, `exec_command`/`write_stdin`, `view_image`, `update_plan`, `clock_curr_time`/`clock_sleep` — so ChatGPT Web can work the way Codex does: patch files in place instead of rewriting them, drive interactive and long-running processes, and keep a plan across a task. It also bridges ChatGPT-native attachments and generated files into the active local project, and returns project files to ChatGPT as downloadable MCP resources, without reconstructing binary data in model-visible text or pretending a machine-local path is usable by the host. It carries the project's `AGENTS.md` and Codex's own agent brief, so the client is told how to behave and not just what it can call. It bounds what a tool call can return, keeps a plan and notes on disk across conversations, and records project-scoped review checkpoints so ChatGPT can inspect either the full task diff or only changes since the last review. And it loads Codex's skills: a `SKILL.md` in the repo or your home directory teaches the client how *you* do a recurring task, and only the ones that apply are ever read. Schemas and prompt are ported from the Codex source, not reimplemented from guesswork.
 
 Beyond the port, Codex Free can **aggregate other MCP servers**. It connects to local stdio servers or remote Streamable HTTP endpoints, keeps automatically imported Codex/plugin tool catalogues private by default, and gives the ChatGPT-side agent a fixed ranked discovery/schema/call surface. Explicit direct flattening and the older one-tool gateway remain available as compatibility modes.
 
@@ -24,6 +24,7 @@ flowchart LR
 
     FS["read_file\nwrite_file\nlist_directory\ntree"]
     Ingress["import_host_file"]
+    Egress["export_host_file"]
     Search["glob\ngrep"]
     Shell["run_command"]
     Git["git_status\nshow_changes\ngit_push\ngit_commit\ngit_log"]
@@ -38,6 +39,7 @@ flowchart LR
     Bridge["MCP aggregator\n(bridge.rs)"]
     WorkDir[("Project root\nper-conversation in\nmulti-project mode")]
     HostFiles[("ChatGPT attachments\nand generated files")]
+    ArtifactCache[("Bounded immutable\nfile snapshots")]
     State[("~/.codex-free\nmemory (per project)")]
     Bindings[("~/.codex-free\nconversation-projects")]
     Worktree[("Managed Git worktree\nper-conversation checkout,\nswept on startup")]
@@ -56,6 +58,7 @@ flowchart LR
 
     Tools --> FS
     Tools --> Ingress
+    Tools --> Egress
     Tools --> Search
     Tools --> Shell
     Tools --> Git
@@ -72,6 +75,9 @@ flowchart LR
     FS --> WorkDir
     HostFiles --> Ingress
     Ingress --> WorkDir
+    WorkDir --> Egress
+    Egress --> ArtifactCache
+    Server <-->|"resource_link / resources/read"| ArtifactCache
     Search --> WorkDir
     Shell --> WorkDir
     Edit --> WorkDir
@@ -304,6 +310,7 @@ Structured primitives — cheaper and safer than shelling out for the same job, 
 | `read_file` | Read a file's contents, a bounded window at a time, with optional line offset/limit |
 | `write_file` | Write content to a file, creating parent directories if needed |
 | `import_host_file` | Stream one ChatGPT attachment or generated file into a new project-relative path, with bounded size, SHA-256 verification and atomic no-overwrite publication |
+| `export_host_file` | Snapshot one project-relative file and return a short-lived, opaque MCP resource that ChatGPT can download without receiving a local path or base64 text |
 | `run_command` | Execute a command in the work directory (allowlist-restricted) |
 | `git_status` | Show git status, parsed into changed files with status codes |
 | `show_changes` | Compare the scoped working tree with the project-open or last-review checkpoint, optionally advancing the incremental baseline; compatible hosts render an interactive review card |
@@ -357,7 +364,7 @@ Multi-project mode adds two project-control tools:
 
 Codex needs the first three for none of these reasons: it puts its agent brief in the system prompt, the OS and shell in an `<environment_context>` message, and `AGENTS.md` straight into the prompt, all before the first turn. An MCP server has none of those channels — it can only expose tools — so the same facts are tool calls here as well as part of the server's `instructions`. It needs `remember` and `recall` for the opposite reason: its context is large and its session state lives in the CLI process, whereas the client here is a chat window that loses the conversation. See [Context and memory](#context-and-memory), [Acting as a Codex agent](#acting-as-a-codex-agent), [Shells and the host](#shells-and-the-host), [AGENTS.md](#agentsmd) and [Skills](#skills).
 
-That is 27 native tools in the default single-project mode and 29 in multi-project mode. Enabling conversation authorization adds the ChatGPT-facing `setup` tool, producing 28 or 30 respectively. Setting `artifactIngress.enabled` to `false` removes `import_host_file`, reducing the applicable count by one. One or more [catalog-mode MCP upstreams](#catalog-mode-default-for-automatic-imports) add one shared four-tool discovery/call surface regardless of how many transitive tools they contain. Direct mode adds one downstream tool per selected upstream tool; gateway mode adds one downstream dispatcher per upstream server.
+That is 28 native tools in the default single-project mode and 30 in multi-project mode. Enabling conversation authorization adds the ChatGPT-facing `setup` tool, producing 29 or 31 respectively. Setting `artifactIngress.enabled` to `false` removes `import_host_file`; setting `artifactEgress.enabled` to `false` independently removes `export_host_file`. Each disabled direction reduces the applicable count by one. One or more [catalog-mode MCP upstreams](#catalog-mode-default-for-automatic-imports) add one shared four-tool discovery/call surface regardless of how many transitive tools they contain. Direct mode adds one downstream tool per selected upstream tool; gateway mode adds one downstream dispatcher per upstream server.
 
 Two deliberate differences from Codex:
 
@@ -374,7 +381,7 @@ sessions.
 
 `clock_sleep` also caps at 5 minutes rather than Codex's 12 hours — a longer wait would outlive the HTTP request through the tunnel.
 
-Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `show_changes` returns its review summary, file records, warnings and bounded patch, `import_host_file` returns its destination, byte count and SHA-256 receipt, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it.
+Every tool that advertises an `outputSchema` also returns `structuredContent` matching it, as the MCP spec asks. `exec_command` and `write_stdin` return Codex's unified-exec object, `show_changes` returns its review summary, file records, warnings and bounded patch, `import_host_file` returns its destination, byte count and SHA-256 receipt, `export_host_file` returns its immutable-snapshot receipt and a standard MCP `resource_link`, `clock_curr_time` returns `{ current_time }`, `get_environment` returns the environment object, `get_project_doc` returns `{ files, content }` and `skills_list` returns `{ skills, content }`; the rest return `{ content: <text> }`, which the server derives from the text blocks so handlers don't repeat it.
 
 All project-scoped paths are resolved relative to the active project root: `--work-dir` in single-project mode, or the root selected for the current ChatGPT conversation in multi-project mode. Non-ChatGPT clients use the root selected for their current MCP transport session.
 
@@ -467,6 +474,13 @@ an existing config keeps working.
     "maxRedirects": 3,
     "maxConcurrentDownloads": 2,
     "allowedHosts": ["*"]
+  },
+  "artifactEgress": {
+    "enabled": true,
+    "maxFileBytes": 104857600,
+    "maxCachedBytes": 268435456,
+    "maxReferences": 64,
+    "referenceTtlMs": 300000
   },
   "memory": {
     "enabled": true,
@@ -648,6 +662,16 @@ The `artifactIngress` block governs [native host-file ingress](#native-host-file
 | `maxConcurrentDownloads` | `2` | Process-wide concurrent import cap, between `1` and `16` |
 | `allowedHosts` | `["*"]` | Host patterns a download URL and every redirect hop must match. `"*"` accepts any public HTTPS host while rejecting internal/reserved addresses (loopback, private, link-local, unique-local, CGNAT, `localhost`, cloud metadata). A bare host (`files.example.com`) matches exactly; a leading dot (`.example.com`) matches that host and its subdomains; an explicitly named host is trusted as given, including an internal one |
 
+The `artifactEgress` block governs [native host-file egress](#native-host-file-egress):
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `true` | Expose `export_host_file`; `false` removes the tool from `tools/list` |
+| `maxFileBytes` | `104857600` | Maximum bytes in one exported snapshot (100 MiB, approximately 104.9 MB), checked before and during the read |
+| `maxCachedBytes` | `268435456` | Process-wide payload-byte ceiling for live immutable snapshots (256 MiB, approximately 268.4 MB); the oldest references are evicted when necessary |
+| `maxReferences` | `64` | Maximum number of live exported-file references, between `1` and `1024`; the oldest are evicted when the bound is reached |
+| `referenceTtlMs` | `300000` | Lifetime of an opaque resource capability after the tool call (5 minutes). Expired references return `resource_not_found`; call `export_host_file` again to create a fresh one |
+
 The `memory` block governs `remember`, `recall` and the plan `update_plan` saves:
 
 | Key | Default | Description |
@@ -743,6 +767,28 @@ Source and destination authority are deliberately narrow:
 - archive extraction, execution, arbitrary URL fetching and arbitrary local-source paths are outside this tool's contract.
 
 After publication, the result is an ordinary project file. Git, `glob`, `tree`, review tools and normal deletion provide its catalogue and lifecycle; Codex Free does not maintain a second artifact database or TTL.
+
+## Native host-file egress
+
+Machine-local paths are not downloadable by ChatGPT, and returning a large binary file as base64 text would put the encoded payload into the tool result and model context. `export_host_file` instead uses MCP's resource flow:
+
+```text
+the agent creates or selects a project file
+        ↓
+the agent calls export_host_file(path)
+        ↓
+Codex Free opens the file through the active-project capability and snapshots its exact bytes
+        ↓
+the tool returns a standard MCP resource_link with an opaque codex-free://artifact/... URI
+        ↓
+the connector host resolves that URI through resources/read and receives a base64 blob resource
+```
+
+The returned resource describes the original filename, MIME type and byte count. The structured receipt includes the project-relative source path, SHA-256 digest and remaining lifetime, but deliberately does not duplicate the bearer-capability URI into ordinary structured data. It never exposes an absolute filesystem path or asks the model to copy the file contents through text.
+
+The resource is an immutable snapshot, not a delayed path read. Replacing, truncating, deleting or retargeting the source after `export_host_file` returns cannot change the bytes served for that reference. Source access is capability-confined to an existing regular file inside the active project; traversal, absolute paths and symlink escapes fail closed. The read is bounded before allocation and again while streaming so a growing file cannot cross `artifactEgress.maxFileBytes` unnoticed.
+
+Each URI contains a 256-bit random bearer capability. Issued resources are not added to `resources/list`, are shared only through the tool result, and remain in a process-wide in-memory cache so ChatGPT can replace the MCP transport between the tool call and `resources/read`. The cache is bounded by both total bytes and reference count; oldest entries are evicted as needed, every reference expires after `artifactEgress.referenceTtlMs`, and all references disappear when Codex Free restarts. Calling `export_host_file` again creates a fresh snapshot and capability.
 
 ## Multi-project mode
 
@@ -1112,7 +1158,7 @@ Codex CLI MCP discovery: codex
   idalib -> imported from Codex CLI (not present in config.toml)
 Codex MCP overrides:
   remote-exec -> imported fields overlaid by codex.config.json
-Tools loaded (31): 27 native + 4 upstream-facing MCP tools
+Tools loaded (32): 28 native + 4 upstream-facing MCP tools
 Upstream MCP servers:
   idalib      -> catalog (66 private tool(s))
   idasql      -> catalog (12 private tool(s))
@@ -1175,7 +1221,7 @@ When `remote-exec` was imported from Codex, that overlay is sufficient; include 
 - `type` is inferred: `command` means `"stdio"`, while `url` means Streamable HTTP. Explicit HTTP aliases `"http"`, `"streamable-http"`, and `"streamable_http"` are accepted.
 - Legacy SSE and WebSocket transports are rejected explicitly because current Codex supports stdio and Streamable HTTP, not those legacy protocols.
 
-OAuth authorization-code login and credential persistence are not implemented by this bridge. An OAuth-protected upstream must therefore be supplied a usable bearer token through `bearerTokenEnvVar` or an environment-backed `Authorization` header. MCP resources, resource templates, and prompts remain separate capability work. Catalog mode reports upstream initialization instructions as source metadata, but does not inject them into Codex Free's own initialization instructions.
+OAuth authorization-code login and credential persistence are not implemented by this bridge. An OAuth-protected upstream must therefore be supplied a usable bearer token through `bearerTokenEnvVar` or an environment-backed `Authorization` header. Upstream MCP resources, resource templates, and prompts remain separate capability work: Codex Free's native exported-file resources are resolved locally, but resource links returned by a bridged server are not proxied through that server. Catalog mode reports upstream initialization instructions as source metadata, but does not inject them into Codex Free's own initialization instructions.
 
 If your server doesn't show up, **check the banner first** — the most common cause is a wrong `command` path.
 
@@ -1213,6 +1259,7 @@ Native tunnel mode ignores `allowedHosts` and forces the accepted authorities to
 - **Stable server-config authority**: the implicit config is user-scoped at `~/.codex-free/codex.config.json`, so changing the launch directory does not normally change command, MCP-server, network, tunnel, or worktree policy. `--config` and `CODEX_FREE_CONFIG` remain explicit overrides. The old `./codex.config.json` behavior is retained only as a warned compatibility fallback when no user config exists.
 - **Bounded GitHub cloning and target fetching**: URL-based project selection accepts only normalized HTTPS/SSH repository roots plus HTTPS branch and PR URLs on `github.com`. It separates owner/repository identity from the exact checkout target, rejects embedded credentials, unsupported subpages, and non-GitHub/insecure transports, and disables interactive Git credential prompts. The configured clone directory is canonicalized inside the access root at startup and revalidated at use time. Resolution uses per-repository cross-process locks, bounded subprocess timeouts, private temporary clone destinations, remote verification, exact branch/PR refspecs, and collision refusal. Existing source checkouts are fetched without moving `HEAD`; a conversation already bound to another selection is rejected before the network/disk side effect.
 - **Host-authorized native-file ingress**: `import_host_file` accepts only ChatGPT's declared native-file object, rejects local source paths, constrains the download URL and every redirect hop to the configurable `artifactIngress.allowedHosts` allowlist (default `"*"`, which admits any public HTTPS host but never a loopback, private, link-local, unique-local, CGNAT, `localhost`, or metadata address), ignores ambient proxy credentials, and enforces whole-request, idle, size and concurrency limits. Its signed URL and file ID are never logged or returned: RMCP debug/trace payload logging is unconditionally suppressed even when `RUST_LOG` requests it. Destination publication uses a capability-confined directory handle, canonical-path and file-identity revalidation, a private partial file, SHA-256, and atomic no-overwrite linking so traversal, moved roots, symlink escapes, partial visibility and replacement races fail closed.
+- **Bounded native-file egress**: `export_host_file` accepts only a relative regular-file path inside the active project, opens it through a capability-confined directory handle, rejects traversal and symlink escapes, enforces `artifactEgress.maxFileBytes` before and during the read, and returns a SHA-256 receipt plus a standard MCP resource link. The link carries a random 256-bit opaque capability rather than a local path. Its immutable bytes live only in a process-wide memory cache bounded by `maxCachedBytes`, `maxReferences` and `referenceTtlMs`; expired and evicted references fail closed, and audit output records only the number of resource links, never their URIs or filenames.
 - **One bounded exception in single-project mode**: [AGENTS.md](#agentsmd) discovery may read above `--work-dir`, up to the nearest `.git`. It is read-only, opens only `AGENTS.override.md`, `AGENTS.md` and any `projectDoc.fallbackFilenames`, and `get_project_doc` reports the absolute path of every file it used. Set `projectDoc.maxBytes` to `0` to switch it off, or `projectDoc.rootMarkers` to `[]` to keep the search inside the work directory. Multi-project mode does not perform this upward walk; its selected directory is the exact project root.
 - **Namespaced review state inside Git**: ChatGPT review checkpoints are exactly two refs per conversation/project pair under `refs/codex-free/review/`. Synthetic snapshots contain only the selected project path, are built through a temporary index, and never modify the real index or working tree. Generic MCP-client checkpoints are in memory only. The namespace grows with the number of distinct persistent conversation/project pairs; the review section documents inspection and manual removal.
 - **Bounded state writes outside the work directory**: `remember` and `update_plan` write `memory.json` under `~/.codex-free/projects/`. Multi-project mode also writes one small project-binding record under `~/.codex-free/conversation-projects/` for each ChatGPT conversation and access root. Per-conversation authorization writes a small marker under `~/.codex-free/conversation-authorizations/`. Binding and authorization filenames are derived from a hash of `openai/session`; the raw identifier is not stored. Authorization namespaces include a one-way digest of the canonical work directory and configured token, while marker contents store only the grant. Set `memory.enabled` to `false` to disable plans and notes; delete the corresponding state directory to forget bindings or authorizations. See [Context and memory](#context-and-memory).

--- a/codex.config.json
+++ b/codex.config.json
@@ -49,5 +49,12 @@
     "maxRedirects": 3,
     "maxConcurrentDownloads": 2,
     "allowedHosts": ["*"]
+  },
+  "artifactEgress": {
+    "enabled": true,
+    "maxFileBytes": 104857600,
+    "maxCachedBytes": 268435456,
+    "maxReferences": 64,
+    "referenceTtlMs": 300000
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,8 +4,9 @@ A Rust port of the `codex-free` MCP bridge. codex-free is a local [Model Context
 Protocol](https://modelcontextprotocol.io) server that exposes Codex-style agent
 tools over **Streamable HTTP**, scoped either to one configured working directory
 or to a project root selected independently by each ChatGPT conversation, and can
-additionally **aggregate local or remote MCP servers**, **surface local skills**, and
-materialize ChatGPT-native files inside the active project.
+additionally **aggregate local or remote MCP servers**, **surface local skills**,
+materialize ChatGPT-native files inside the active project, and return project files
+to ChatGPT as downloadable MCP resources.
 Clients without ChatGPT conversation metadata use an MCP-transport-session fallback.
 
 This document explains how it is put together and why. For usage, see
@@ -35,7 +36,7 @@ ChatGPT / MCP client
 │        │                                      │
 │        ▼                                      │
 │  registry: Vec<Box<dyn Tool>>                 │
-│    • 27 native tools                          │
+│    • 28 native tools                          │
 │    • + setup authorization wire tool          │
 │    • + list_projects + set_project_root       │
 │      in multi-project mode                    │
@@ -58,6 +59,10 @@ ChatGPT / MCP client
 │  shared ReviewCheckpointManager               │
 │    • project-open + last-review snapshots     │
 │    • scoped Git refs + MCP Apps resource      │
+│                                               │
+│  shared ArtifactEgressStore                   │
+│    • opaque short-lived resource capabilities │
+│    • bounded immutable in-memory snapshots    │
 │                                               │
 │  optional shared AuditLogger                  │
 │    • redacted JSONL tool lifecycle records    │
@@ -83,8 +88,11 @@ Five surfaces reach the model:
 - **Conversation authorization** — an optional authentication-token gate whose
   durable grant is keyed by ChatGPT's stable conversation metadata rather than
   by the replaceable MCP transport.
-- **MCP App** — the self-contained review resource linked from `show_changes`;
-  unsupported clients ignore the UI metadata and keep the ordinary tool result.
+- **Resources / MCP App** — the self-contained review resource linked from
+  `show_changes`, plus opaque exported-file resources linked from
+  `export_host_file` and resolved through `resources/read`. Unsupported clients
+  ignore review UI metadata and keep the ordinary result; a client must support
+  resource links to retrieve exported file bytes.
 
 ---
 
@@ -105,8 +113,10 @@ Five surfaces reach the model:
    rmcp `Tool` definitions, including optional titles, behavioral annotations,
    icons, input/output schemas, OpenAI file-parameter metadata, and MCP Apps
    resource metadata. Transitive definitions held by the private MCP catalog are
-   deliberately absent from this registry.
-   `resources/list` / `resources/read` expose the embedded review HTML.
+   deliberately absent from this registry. `resources/list` exposes only the
+   embedded review HTML. `resources/read` serves that static resource and also
+   resolves opaque exported-file capabilities returned by `export_host_file`;
+   those dynamic references are intentionally not enumerable.
 4. `tools/call` → `CodexHandler::call_tool` reads `openai/session` from rmcp's
    `RequestContext::meta`. rmcp moves wire-level request `_meta` into that context
    before dispatch, so the typed tool parameters are not the authoritative source.
@@ -317,8 +327,8 @@ in that order. It parses camelCase fields for backward compatibility, imports
 user-level Codex MCP definitions through `codex_mcp.rs`, opportunistically adds
 plugin-provided entries from the Codex CLI's effective catalogue, then applies
 explicit `mcpServers` entries as field overlays. Optional sub-configs (`projectDoc`,
-`projectCatalog`, `output`, `review`, `artifactIngress`, `worktrees`, `memory`,
-`skills`, `ignore`, `audit`) fall back to per-module defaults, as does `codexMcp`
+`projectCatalog`, `output`, `review`, `artifactIngress`, `artifactEgress`, `worktrees`,
+`memory`, `skills`, `ignore`, `audit`) fall back to per-module defaults, as does `codexMcp`
 (Codex MCP import and CLI enrichment). In multi-project mode, dispatch clones this
 config per call and substitutes the conversation's selected root—or the transport
 fallback—for `work_dir`; the static server policy, catalogue overlay, and bridge
@@ -373,15 +383,18 @@ one-line instruction needed by an individual chat or ChatGPT Project.
   `ProjectBindingStore` resolves its project, the persistent
   `ConversationAuthorizationStore` resolves the optional token grant, and the in-memory
   `ConversationExecSessionStore` resolves resident commands across replacement
-  transports. Upstream MCP connections, all three stores, and the tool registry are
-  shared (`Arc`) across transports.
+  transports, and `ArtifactEgressStore` preserves short-lived exported-file
+  snapshots across the same replacement. Upstream MCP connections, all four stores,
+  and the tool registry are shared (`Arc`) across transports.
 - **`get_info`** advertises server name `codex-free` (wire-compatible identity),
   version, tools/resources capabilities, the `io.modelcontextprotocol/ui` extension,
   and the `instructions`. The review resource is embedded in the binary and has no
   external network or asset dependency.
-- **Tool descriptors** preserve generic titles, MCP annotations and `_meta`
-  extensions. `import_host_file` uses this path for
-  `_meta["openai/fileParams"]`; the server has no tool-name special case.
+- **Tool descriptors and results** preserve generic titles, MCP annotations and
+  `_meta` extensions. `import_host_file` uses the descriptor path for
+  `_meta["openai/fileParams"]`; `export_host_file` returns a standard
+  `resource_link`, and `resources/read` resolves only locally issued opaque
+  artifact capabilities. The conversion layer has no tool-name special case.
 - **Errors**: a tool that fails returns `Ok(CallToolResult::error(...))`
   (`isError: true`) so the caller sees the message; only an unknown tool name is
   an error *result* as well. Protocol errors are avoided.
@@ -422,11 +435,11 @@ a private per-run temporary directory and are removed after shutdown.
 
 ---
 
-## 5. Native tools (27 default, 29 multi-project)
+## 5. Native tools (28 default, 30 multi-project)
 
 | Group | Tools |
 |-------|-------|
-| File / code | `read_file`, `write_file`, `import_host_file`, `apply_patch`, `glob`, `grep`, `list_directory`, `tree`, `view_image` |
+| File / code | `read_file`, `write_file`, `import_host_file`, `export_host_file`, `apply_patch`, `glob`, `grep`, `list_directory`, `tree`, `view_image` |
 | Commands | `run_command` (allowlisted argv), `exec_command` / `write_stdin` (resident shell sessions) |
 | Git / review | `git_status`, `show_changes`, `git_push`, `git_commit`, `git_log` |
 | Environment / project | `get_environment`, `get_project_doc`, `get_agent_brief` |
@@ -437,10 +450,11 @@ a private per-run temporary directory and are removed after shutdown.
 
 Conversation authorization prepends the ChatGPT-facing `setup` wire tool; multi-project mode then
 prepends `list_projects` and `set_project_root`. The optional tools are omitted
-from the ordinary single-project registry, preserving the 27-tool default surface
+from the ordinary single-project registry, preserving the 28-tool default surface
 and behaviour. Enabling the gate raises the applicable count by one.
-`artifactIngress.enabled = false` independently removes
-`import_host_file`, reducing either count by one. Project-catalogue discovery and
+`artifactIngress.enabled = false` independently removes `import_host_file`, while
+`artifactEgress.enabled = false` independently removes `export_host_file`; each
+reduces the applicable count by one. Project-catalogue discovery and
 selection, clocks, the four transitive-MCP catalog tools, and direct/gateway
 compatibility tools are project-independent; every other native tool is blocked
 until a conversation binding or transport fallback is available.
@@ -454,8 +468,9 @@ the original order and rejects duplicate names.
 
 | Module | Responsibility |
 |--------|----------------|
-| `safe_path.rs` | Lexical path-traversal guard (no `canonicalize`; component-wise containment). The security boundary for every filesystem tool. |
+| `safe_path.rs` | Lexical path-traversal guard (no `canonicalize`; component-wise containment) used by the ordinary filesystem tools. Native file ingress and egress use their own capability-confined boundaries below. |
 | `artifact_ingress/` | OpenAI native-file validation and streaming plus capability-confined, atomic no-overwrite workspace publication. It never accepts a local source path, and constrains the download URL and every redirect hop to the configurable `artifactIngress.allowedHosts` allowlist (default `"*"`, which still rejects loopback, private, link-local, unique-local, CGNAT, `localhost`, and metadata addresses). |
+| `artifact_egress.rs` | Capability-confined regular-file snapshotting plus a process-wide bounded store of immutable bytes. It returns random opaque `codex-free://artifact/...` resource capabilities, enforces per-file/total-byte/reference/TTL limits, and serves blobs only through `resources/read`; absolute paths, traversal, symlink escapes, and delayed path rereads are excluded. |
 | `logging.rs` | Tracing initialization with default filters for normal, `-v`, and `-vv` operation (an explicit `RUST_LOG` remains authoritative), plus a non-overridable filter that suppresses RMCP framework events, preventing native-file bearer URLs from appearing in logs before tool dispatch or malformed-session errors. |
 | `output_budget.rs` | Line/byte windowing and list caps, each cut announced with the continuation argument. |
 | `audit.rs` | Private append-only JSONL tool lifecycle records, stable hashed identities, redacted argument summaries, output accounting, and opt-in bounded command previews. |
@@ -705,6 +720,9 @@ the legacy fallback. All fields are optional.
                        "requestTimeoutMs": 120000, "idleTimeoutMs": 30000,
                        "maxRedirects": 3, "maxConcurrentDownloads": 2,
                        "allowedHosts": ["*"] },
+  "artifactEgress": { "enabled": true, "maxFileBytes": 104857600,
+                      "maxCachedBytes": 268435456, "maxReferences": 64,
+                      "referenceTtlMs": 300000 },
   "worktrees": { "mode": "auto",        // auto | always | never; or --worktree-mode
                  "root": "…",            // default: $CODEX_HOME/worktrees; or --worktree-root
                  "upstreamRefreshMode": "never",   // never | best-effort
@@ -751,7 +769,7 @@ The banner is designed so failures are never silent:
 
 ```
 Config: C:\Users\alice\.codex-free\codex.config.json (user config)
-Tools loaded (34): 30 native + 4 upstream-facing MCP tools
+Tools loaded (35): 31 native + 4 upstream-facing MCP tools
 Upstream MCP servers:
   idalib      -> catalog (66 private tool(s))
   remote-exec -> catalog (84 private tool(s))
@@ -772,7 +790,7 @@ Audit command previews: disabled
   internal bearer are never printed.
 - Multi-project startup also prints `Project access root:`, `Project mode:
   persistent ChatGPT conversation binding`, and the conversation-binding state
-  directory; its native count is 29 because the selectors are present.
+  directory; its native count is 30 because the selectors are present.
 - Conversation authorization adds one native tool and prints only whether the
   gate is enabled; neither the token nor its derived namespace is printed.
 - `-v` and `-vv` increase Codex Free diagnostics without dumping raw tool payloads;
@@ -817,6 +835,10 @@ units to match the TS `text.length` / `text.slice`.
   temporary directories to cover provider-host validation, redirects, declared
   and streamed size limits, idle and caller cancellation, exact hashes, partial
   cleanup, symlink escapes, no-overwrite publication, and concurrent writers.
+- `artifact_egress` unit tests cover opaque resource generation, exact immutable
+  byte snapshots after source replacement, MIME and SHA-256 receipts, traversal,
+  symlink escape and oversize rejection, caller cancellation boundaries, cache-byte
+  and reference eviction, and reference expiry.
 - `tests/review_fixes.rs` locks the behavioral-fidelity fixes found by the
   adversarial review of the port. The bridge/gateway/skills code was reviewed the
   same way; the confirmed low-severity findings (name-collision dedup, YAML-safe
@@ -847,3 +869,5 @@ Run: `cargo test`. Build a standalone binary: `cargo build --release`.
 | Native tunnel key is rejected before startup | `apiKeyRef` must be `env:NAME` or `file:/path`. The referenced value must exist; on Unix, key files must not grant group/other access. |
 | `import_host_file` is missing | `artifactIngress.enabled` is false, or the connector cached an older manifest. Enable it and remove/re-add the connector so ChatGPT refreshes `tools/list`. |
 | Native file import reports an untrusted URL | The supplied value was not a ChatGPT-native file parameter or its temporary provider URL no longer matches the supported OpenAI file-service boundary. Reattach or regenerate the file instead of passing a URL manually. |
+| `export_host_file` is missing | `artifactEgress.enabled` is false, or the connector cached an older manifest. Enable it and remove/re-add the connector so ChatGPT refreshes `tools/list`. |
+| An exported-file resource is unknown or expired | Its opaque capability exceeded `artifactEgress.referenceTtlMs`, was evicted by the byte/reference bounds, or Codex Free restarted. Call `export_host_file` again to create a fresh immutable snapshot. |

--- a/src/artifact_egress.rs
+++ b/src/artifact_egress.rs
@@ -1,0 +1,794 @@
+use std::collections::{HashMap, VecDeque};
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use base64::{Engine, engine::general_purpose::STANDARD, engine::general_purpose::URL_SAFE_NO_PAD};
+use cap_std::{ambient_authority, fs::Dir};
+use getrandom::getrandom;
+use rmcp::model::{Resource, ResourceContents};
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncReadExt;
+use tokio_util::sync::CancellationToken;
+
+use crate::types::ArtifactEgressConfig;
+
+pub const ARTIFACT_RESOURCE_URI_PREFIX: &str = "codex-free://artifact/";
+const TOKEN_BYTES: usize = 32;
+const TOKEN_LENGTH: usize = 43;
+const TOKEN_ATTEMPTS: usize = 8;
+const MAX_SOURCE_PATH_BYTES: usize = 4096;
+
+#[derive(Debug)]
+pub struct ArtifactEgressError {
+    code: &'static str,
+    message: String,
+}
+
+impl ArtifactEgressError {
+    fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn code(&self) -> &'static str {
+        self.code
+    }
+}
+
+impl fmt::Display for ArtifactEgressError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ArtifactEgressError {}
+
+#[derive(Debug)]
+pub struct ArtifactSnapshot {
+    name: String,
+    mime_type: String,
+    bytes: Arc<[u8]>,
+    sha256: String,
+}
+
+impl ArtifactSnapshot {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn mime_type(&self) -> &str {
+        &self.mime_type
+    }
+
+    pub fn byte_count(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    pub fn sha256(&self) -> &str {
+        &self.sha256
+    }
+}
+
+#[derive(Debug)]
+pub struct RegisteredArtifact {
+    pub resource: Resource,
+    pub sha256: String,
+    pub byte_count: u64,
+    pub mime_type: String,
+    pub name: String,
+    pub expires_in_ms: u64,
+}
+
+#[derive(Debug)]
+struct StoredArtifact {
+    snapshot: Arc<ArtifactSnapshot>,
+    expires_at: Instant,
+}
+
+#[derive(Debug, Default)]
+struct StoreState {
+    entries: HashMap<String, StoredArtifact>,
+    order: VecDeque<String>,
+    cached_bytes: u64,
+}
+
+impl StoreState {
+    fn remove(&mut self, token: &str) {
+        if let Some(entry) = self.entries.remove(token) {
+            self.cached_bytes = self
+                .cached_bytes
+                .saturating_sub(entry.snapshot.byte_count());
+        }
+    }
+
+    fn prune_expired(&mut self, now: Instant) {
+        while let Some(token) = self.order.front().cloned() {
+            match self.entries.get(&token) {
+                Some(entry) if entry.expires_at > now => break,
+                Some(_) => {
+                    self.order.pop_front();
+                    self.remove(&token);
+                }
+                None => {
+                    self.order.pop_front();
+                }
+            }
+        }
+    }
+
+    fn evict_oldest(&mut self) -> bool {
+        while let Some(token) = self.order.pop_front() {
+            if self.entries.contains_key(&token) {
+                self.remove(&token);
+                return true;
+            }
+        }
+        false
+    }
+}
+
+#[derive(Debug)]
+pub struct ArtifactEgressStore {
+    config: ArtifactEgressConfig,
+    state: Mutex<StoreState>,
+}
+
+impl ArtifactEgressStore {
+    pub fn new(config: ArtifactEgressConfig) -> Self {
+        Self {
+            config,
+            state: Mutex::new(StoreState::default()),
+        }
+    }
+
+    pub fn register(
+        &self,
+        snapshot: ArtifactSnapshot,
+    ) -> Result<RegisteredArtifact, ArtifactEgressError> {
+        let byte_count = snapshot.byte_count();
+        if byte_count > self.config.max_file_bytes || byte_count > self.config.max_cached_bytes {
+            return Err(ArtifactEgressError::new(
+                "artifact_too_large",
+                "The exported file exceeds the configured artifact-egress limit.",
+            ));
+        }
+
+        let now = Instant::now();
+        let expires_at = now
+            .checked_add(Duration::from_millis(self.config.reference_ttl_ms))
+            .ok_or_else(|| {
+                ArtifactEgressError::new(
+                    "artifact_egress_invalid",
+                    "artifactEgress.referenceTtlMs is too large for this platform.",
+                )
+            })?;
+        let snapshot = Arc::new(snapshot);
+        let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+        state.prune_expired(now);
+
+        let token = (0..TOKEN_ATTEMPTS)
+            .find_map(|_| {
+                let token = generate_token().ok()?;
+                (!state.entries.contains_key(&token)).then_some(token)
+            })
+            .ok_or_else(|| {
+                ArtifactEgressError::new(
+                    "artifact_reference_failed",
+                    "A unique artifact reference could not be generated.",
+                )
+            })?;
+
+        while state.entries.len() >= self.config.max_references
+            || state.cached_bytes.saturating_add(byte_count) > self.config.max_cached_bytes
+        {
+            if !state.evict_oldest() {
+                return Err(ArtifactEgressError::new(
+                    "artifact_cache_full",
+                    "The artifact-egress cache could not make room for this file.",
+                ));
+            }
+        }
+
+        let uri = format!("{ARTIFACT_RESOURCE_URI_PREFIX}{token}");
+
+        state.cached_bytes = state.cached_bytes.saturating_add(byte_count);
+        state.order.push_back(token.clone());
+        state.entries.insert(
+            token,
+            StoredArtifact {
+                snapshot: Arc::clone(&snapshot),
+                expires_at,
+            },
+        );
+
+        let resource = Resource::new(uri, snapshot.name.clone())
+            .with_title(snapshot.name.clone())
+            .with_description("Immutable file snapshot exported from the active Codex Free project")
+            .with_mime_type(snapshot.mime_type.clone())
+            .with_size(byte_count);
+
+        Ok(RegisteredArtifact {
+            resource,
+            sha256: snapshot.sha256.clone(),
+            byte_count,
+            mime_type: snapshot.mime_type.clone(),
+            name: snapshot.name.clone(),
+            expires_in_ms: self.config.reference_ttl_ms,
+        })
+    }
+
+    pub async fn read_resource(
+        &self,
+        uri: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<Option<ResourceContents>, ArtifactEgressError> {
+        let Some(token) = parse_token(uri) else {
+            return Ok(None);
+        };
+        let snapshot = {
+            let now = Instant::now();
+            let mut state = self.state.lock().unwrap_or_else(|error| error.into_inner());
+            state.prune_expired(now);
+            let Some(entry) = state.entries.get(token) else {
+                return Ok(None);
+            };
+            Arc::clone(&entry.snapshot)
+        };
+        let uri = uri.to_string();
+        let mut task = tokio::task::spawn_blocking(move || {
+            ResourceContents::blob(STANDARD.encode(snapshot.bytes.as_ref()), uri)
+                .with_mime_type(snapshot.mime_type.clone())
+        });
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => Err(ArtifactEgressError::new(
+                "resource_read_cancelled",
+                "Exported-file resource retrieval was cancelled by the MCP client.",
+            )),
+            result = &mut task => result
+                .map(Some)
+                .map_err(|_| ArtifactEgressError::new(
+                    "resource_read_failed",
+                    "The exported-file resource could not be encoded.",
+                )),
+        }
+    }
+}
+
+fn generate_token() -> Result<String, getrandom::Error> {
+    let mut bytes = [0_u8; TOKEN_BYTES];
+    getrandom(&mut bytes)?;
+    Ok(URL_SAFE_NO_PAD.encode(bytes))
+}
+
+fn parse_token(uri: &str) -> Option<&str> {
+    let token = uri.strip_prefix(ARTIFACT_RESOURCE_URI_PREFIX)?;
+    (token.len() == TOKEN_LENGTH
+        && token
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'))
+    .then_some(token)
+}
+
+#[derive(Debug)]
+struct SourcePath {
+    relative: PathBuf,
+    display: String,
+    name: String,
+}
+
+impl SourcePath {
+    fn parse(value: &str) -> Result<Self, ArtifactEgressError> {
+        if value.is_empty()
+            || value.len() > MAX_SOURCE_PATH_BYTES
+            || value.chars().any(char::is_control)
+            || value.ends_with('/')
+            || value.ends_with('\\')
+        {
+            return Err(invalid_source());
+        }
+
+        let mut relative = PathBuf::new();
+        for component in Path::new(value).components() {
+            match component {
+                Component::Normal(part) => {
+                    validate_platform_component(part)?;
+                    relative.push(part);
+                }
+                Component::CurDir => {}
+                Component::Prefix(_) | Component::RootDir | Component::ParentDir => {
+                    return Err(invalid_source());
+                }
+            }
+        }
+        let name = relative
+            .file_name()
+            .filter(|name| !name.is_empty())
+            .ok_or_else(invalid_source)?
+            .to_string_lossy()
+            .into_owned();
+        let display = relative
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
+        Ok(Self {
+            relative,
+            display,
+            name,
+        })
+    }
+}
+
+fn validate_platform_component(component: &std::ffi::OsStr) -> Result<(), ArtifactEgressError> {
+    #[cfg(windows)]
+    {
+        let value = component.to_string_lossy();
+        if value.ends_with(' ')
+            || value.ends_with('.')
+            || value
+                .chars()
+                .any(|character| character.is_control() || "<>:\"|?*".contains(character))
+        {
+            return Err(invalid_source());
+        }
+        let stem = value
+            .split('.')
+            .next()
+            .unwrap_or_default()
+            .to_ascii_uppercase();
+        let numbered_device = |prefix| {
+            stem.strip_prefix(prefix).is_some_and(|number| {
+                matches!(number, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+            })
+        };
+        if matches!(stem.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+            || numbered_device("COM")
+            || numbered_device("LPT")
+        {
+            return Err(invalid_source());
+        }
+    }
+
+    #[cfg(not(windows))]
+    let _ = component;
+
+    Ok(())
+}
+
+fn invalid_source() -> ArtifactEgressError {
+    ArtifactEgressError::new(
+        "source_invalid",
+        "The source must be a non-empty relative file path inside the active project.",
+    )
+}
+
+fn mime_type_for_path(path: &Path) -> &'static str {
+    let extension = path
+        .extension()
+        .and_then(std::ffi::OsStr::to_str)
+        .map(str::to_ascii_lowercase);
+    match extension.as_deref() {
+        Some(
+            "txt" | "md" | "markdown" | "rst" | "log" | "rs" | "c" | "h" | "cc" | "cpp" | "cxx"
+            | "hpp" | "hh" | "java" | "kt" | "kts" | "swift" | "go" | "py" | "rb" | "php" | "sh"
+            | "bash" | "zsh" | "fish" | "ps1" | "bat" | "cmd" | "toml" | "ini" | "cfg" | "conf"
+            | "diff" | "patch",
+        ) => "text/plain",
+        Some("csv") => "text/csv",
+        Some("tsv") => "text/tab-separated-values",
+        Some("html" | "htm") => "text/html",
+        Some("css") => "text/css",
+        Some("js" | "mjs" | "cjs") => "text/javascript",
+        Some("xml") => "application/xml",
+        Some("json" | "map") => "application/json",
+        Some("yaml" | "yml") => "application/yaml",
+        Some("pdf") => "application/pdf",
+        Some("zip") => "application/zip",
+        Some("gz" | "tgz") => "application/gzip",
+        Some("bz2" | "tbz" | "tbz2") => "application/x-bzip2",
+        Some("xz" | "txz") => "application/x-xz",
+        Some("tar") => "application/x-tar",
+        Some("7z") => "application/x-7z-compressed",
+        Some("rar") => "application/vnd.rar",
+        Some("wasm") => "application/wasm",
+        Some("doc") => "application/msword",
+        Some("docx") => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        Some("xls") => "application/vnd.ms-excel",
+        Some("xlsx") => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        Some("ppt") => "application/vnd.ms-powerpoint",
+        Some("pptx") => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        Some("odt") => "application/vnd.oasis.opendocument.text",
+        Some("ods") => "application/vnd.oasis.opendocument.spreadsheet",
+        Some("odp") => "application/vnd.oasis.opendocument.presentation",
+        Some("png") => "image/png",
+        Some("jpg" | "jpeg" | "jpe") => "image/jpeg",
+        Some("gif") => "image/gif",
+        Some("webp") => "image/webp",
+        Some("bmp") => "image/bmp",
+        Some("svg" | "svgz") => "image/svg+xml",
+        Some("ico") => "image/x-icon",
+        Some("tif" | "tiff") => "image/tiff",
+        Some("avif") => "image/avif",
+        Some("mp3") => "audio/mpeg",
+        Some("wav") => "audio/wav",
+        Some("flac") => "audio/flac",
+        Some("ogg" | "oga") => "audio/ogg",
+        Some("m4a") => "audio/mp4",
+        Some("mp4" | "m4v") => "video/mp4",
+        Some("webm") => "video/webm",
+        Some("mov") => "video/quicktime",
+        Some("avi") => "video/x-msvideo",
+        _ => "application/octet-stream",
+    }
+}
+
+fn cancelled() -> ArtifactEgressError {
+    ArtifactEgressError::new(
+        "file_export_cancelled",
+        "File export was cancelled by the MCP client.",
+    )
+}
+
+fn absolute_root(work_dir: &Path) -> Result<PathBuf, ArtifactEgressError> {
+    if work_dir.is_absolute() {
+        return Ok(work_dir.to_path_buf());
+    }
+    std::env::current_dir()
+        .map(|directory| directory.join(work_dir))
+        .map_err(|_| {
+            ArtifactEgressError::new(
+                "source_unsafe",
+                "The active project root could not be made absolute safely.",
+            )
+        })
+}
+
+fn open_project_file(
+    work_dir: &Path,
+    source: &SourcePath,
+    max_file_bytes: u64,
+) -> Result<(std::fs::File, u64), ArtifactEgressError> {
+    let root = absolute_root(work_dir)?;
+    let canonical_root = std::fs::canonicalize(root).map_err(|_| {
+        ArtifactEgressError::new(
+            "source_unsafe",
+            "The active project root could not be resolved safely.",
+        )
+    })?;
+    let directory = Dir::open_ambient_dir(canonical_root, ambient_authority()).map_err(|_| {
+        ArtifactEgressError::new(
+            "source_unsafe",
+            "The active project root could not be opened safely.",
+        )
+    })?;
+    let file = directory.open(&source.relative).map_err(|error| {
+        if error.kind() == std::io::ErrorKind::NotFound {
+            ArtifactEgressError::new(
+                "source_not_found",
+                format!("File not found: {}", source.display),
+            )
+        } else {
+            ArtifactEgressError::new(
+                "source_unsafe",
+                format!(
+                    "The source `{}` could not be opened safely.",
+                    source.display
+                ),
+            )
+        }
+    })?;
+    let metadata = file.metadata().map_err(|_| {
+        ArtifactEgressError::new(
+            "source_read_failed",
+            format!("The source `{}` could not be inspected.", source.display),
+        )
+    })?;
+    if !metadata.is_file() {
+        return Err(ArtifactEgressError::new(
+            "source_not_file",
+            format!("The source `{}` is not a regular file.", source.display),
+        ));
+    }
+    if metadata.len() > max_file_bytes {
+        return Err(ArtifactEgressError::new(
+            "artifact_too_large",
+            format!(
+                "The source `{}` is {} bytes; artifactEgress.maxFileBytes is {}.",
+                source.display,
+                metadata.len(),
+                max_file_bytes
+            ),
+        ));
+    }
+    Ok((file.into_std(), metadata.len()))
+}
+
+pub async fn snapshot_project_file(
+    work_dir: &Path,
+    input_path: &str,
+    config: &ArtifactEgressConfig,
+    cancellation: &CancellationToken,
+) -> Result<ArtifactSnapshot, ArtifactEgressError> {
+    if !config.enabled {
+        return Err(ArtifactEgressError::new(
+            "artifact_egress_disabled",
+            "File export is disabled by configuration.",
+        ));
+    }
+    let source = SourcePath::parse(input_path)?;
+    let source_for_open = SourcePath {
+        relative: source.relative.clone(),
+        display: source.display.clone(),
+        name: source.name.clone(),
+    };
+    let work_dir = work_dir.to_path_buf();
+    let max_file_bytes = config.max_file_bytes;
+    let mut open_task = tokio::task::spawn_blocking(move || {
+        open_project_file(&work_dir, &source_for_open, max_file_bytes)
+    });
+    let (file, declared_size) = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(cancelled()),
+        result = &mut open_task => result.map_err(|_| {
+            ArtifactEgressError::new(
+                "source_read_failed",
+                "The file-open operation terminated unexpectedly.",
+            )
+        })??,
+    };
+
+    let mut bytes = Vec::with_capacity(
+        usize::try_from(declared_size.min(config.max_file_bytes)).unwrap_or_default(),
+    );
+    let file = tokio::fs::File::from_std(file);
+    let mut limited = file.take(config.max_file_bytes.saturating_add(1));
+    let read_result = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(cancelled()),
+        result = limited.read_to_end(&mut bytes) => result,
+    };
+    read_result.map_err(|_| {
+        ArtifactEgressError::new(
+            "source_read_failed",
+            format!("The source `{}` could not be read.", source.display),
+        )
+    })?;
+    if bytes.len() as u64 > config.max_file_bytes {
+        return Err(ArtifactEgressError::new(
+            "artifact_too_large",
+            format!(
+                "The source `{}` grew beyond artifactEgress.maxFileBytes while it was read.",
+                source.display
+            ),
+        ));
+    }
+
+    let mut hash_task = tokio::task::spawn_blocking(move || {
+        let sha256 = format!("{:x}", Sha256::digest(&bytes));
+        (bytes, sha256)
+    });
+    let (bytes, sha256) = tokio::select! {
+        biased;
+        _ = cancellation.cancelled() => return Err(cancelled()),
+        result = &mut hash_task => result.map_err(|_| ArtifactEgressError::new(
+            "source_read_failed",
+            "The exported file could not be hashed.",
+        ))?,
+    };
+    let mime_type = mime_type_for_path(&source.relative).to_string();
+    Ok(ArtifactSnapshot {
+        name: source.name,
+        mime_type,
+        bytes: Arc::from(bytes),
+        sha256,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> ArtifactEgressConfig {
+        ArtifactEgressConfig {
+            max_file_bytes: 1024,
+            max_cached_bytes: 2048,
+            max_references: 2,
+            reference_ttl_ms: 60_000,
+            ..ArtifactEgressConfig::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshots_exact_bytes_and_serves_an_opaque_resource() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("payload.bin"), [0_u8, 1, 2, 255]).unwrap();
+        let snapshot = snapshot_project_file(
+            root.path(),
+            "payload.bin",
+            &config(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(snapshot.byte_count(), 4);
+        assert_eq!(snapshot.mime_type(), "application/octet-stream");
+
+        let store = ArtifactEgressStore::new(config());
+        let registered = store.register(snapshot).unwrap();
+        assert!(
+            registered
+                .resource
+                .uri
+                .starts_with(ARTIFACT_RESOURCE_URI_PREFIX)
+        );
+        assert!(!registered.resource.uri.contains("payload"));
+        assert_eq!(registered.resource.name, "payload.bin");
+        assert_eq!(registered.resource.size, Some(4));
+
+        std::fs::write(root.path().join("payload.bin"), b"replacement").unwrap();
+
+        let contents = store
+            .read_resource(&registered.resource.uri, &CancellationToken::new())
+            .await
+            .unwrap()
+            .unwrap();
+        match contents {
+            ResourceContents::BlobResourceContents {
+                blob, mime_type, ..
+            } => {
+                assert_eq!(STANDARD.decode(blob).unwrap(), [0_u8, 1, 2, 255]);
+                assert_eq!(mime_type.as_deref(), Some("application/octet-stream"));
+            }
+            _ => panic!("expected blob resource"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_traversal_and_files_over_the_limit() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("large.bin"), vec![0_u8; 1025]).unwrap();
+        let cancellation = CancellationToken::new();
+
+        let traversal = snapshot_project_file(root.path(), "../secret", &config(), &cancellation)
+            .await
+            .unwrap_err();
+        assert_eq!(traversal.code(), "source_invalid");
+
+        let too_large = snapshot_project_file(root.path(), "large.bin", &config(), &cancellation)
+            .await
+            .unwrap_err();
+        assert_eq!(too_large.code(), "artifact_too_large");
+
+        let control = snapshot_project_file(root.path(), "bad\nname", &config(), &cancellation)
+            .await
+            .unwrap_err();
+        assert_eq!(control.code(), "source_invalid");
+    }
+
+    #[tokio::test]
+    async fn evicts_oldest_snapshots_to_stay_within_both_bounds() {
+        let root = tempfile::tempdir().unwrap();
+        for name in ["one.bin", "two.bin", "three.bin"] {
+            std::fs::write(root.path().join(name), vec![name.as_bytes()[0]; 800]).unwrap();
+        }
+        let store = ArtifactEgressStore::new(config());
+        let mut uris = Vec::new();
+        for name in ["one.bin", "two.bin", "three.bin"] {
+            let snapshot =
+                snapshot_project_file(root.path(), name, &config(), &CancellationToken::new())
+                    .await
+                    .unwrap();
+            uris.push(store.register(snapshot).unwrap().resource.uri);
+        }
+        let cancellation = CancellationToken::new();
+        assert!(
+            store
+                .read_resource(&uris[0], &cancellation)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            store
+                .read_resource(&uris[1], &cancellation)
+                .await
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            store
+                .read_resource(&uris[2], &cancellation)
+                .await
+                .unwrap()
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn expires_resource_capabilities() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("short.txt"), b"short").unwrap();
+        let mut short_lived = config();
+        short_lived.reference_ttl_ms = 1;
+        let snapshot = snapshot_project_file(
+            root.path(),
+            "short.txt",
+            &short_lived,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        let store = ArtifactEgressStore::new(short_lived);
+        let uri = store.register(snapshot).unwrap().resource.uri;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        assert!(
+            store
+                .read_resource(&uri, &CancellationToken::new())
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn honors_cancellation_before_snapshot_and_resource_read() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("cancel.bin"), b"cancel").unwrap();
+
+        let cancelled_snapshot = CancellationToken::new();
+        cancelled_snapshot.cancel();
+        let error =
+            snapshot_project_file(root.path(), "cancel.bin", &config(), &cancelled_snapshot)
+                .await
+                .unwrap_err();
+        assert_eq!(error.code(), "file_export_cancelled");
+
+        let snapshot = snapshot_project_file(
+            root.path(),
+            "cancel.bin",
+            &config(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+        let store = ArtifactEgressStore::new(config());
+        let uri = store.register(snapshot).unwrap().resource.uri;
+        let cancelled_read = CancellationToken::new();
+        cancelled_read.cancel();
+        let error = store
+            .read_resource(&uri, &cancelled_read)
+            .await
+            .unwrap_err();
+        assert_eq!(error.code(), "resource_read_cancelled");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn capability_open_rejects_a_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        std::fs::write(outside.path().join("secret.bin"), b"secret").unwrap();
+        symlink(
+            outside.path().join("secret.bin"),
+            root.path().join("linked.bin"),
+        )
+        .unwrap();
+
+        let error = snapshot_project_file(
+            root.path(),
+            "linked.bin",
+            &config(),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(error.code(), "source_unsafe");
+    }
+}

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -272,6 +272,7 @@ pub(crate) fn summarize_output(result: &ToolResult) -> Value {
     let mut text_tokens = 0u64;
     let mut image_base64_bytes = 0u64;
     let mut image_count = 0u64;
+    let mut resource_link_count = 0u64;
     for content in &result.content {
         match content {
             ToolContent::Text(text) => {
@@ -281,6 +282,9 @@ pub(crate) fn summarize_output(result: &ToolResult) -> Value {
             ToolContent::Image { data, .. } => {
                 image_count = image_count.saturating_add(1);
                 image_base64_bytes = image_base64_bytes.saturating_add(data.len() as u64);
+            }
+            ToolContent::ResourceLink(_) => {
+                resource_link_count = resource_link_count.saturating_add(1);
             }
         }
     }
@@ -294,6 +298,7 @@ pub(crate) fn summarize_output(result: &ToolResult) -> Value {
         "approx_text_tokens": text_tokens,
         "image_count": image_count,
         "image_base64_bytes": image_base64_bytes,
+        "resource_link_count": resource_link_count,
         "structured_bytes": structured_bytes,
         "truncated": result.audit.truncated,
         "original_output_tokens": result.audit.original_output_tokens,
@@ -728,6 +733,28 @@ mod tests {
         assert!(!summary.contains("input.bin"));
         assert!(summary.contains("\"file\""));
         assert!(summary.contains("\"path\""));
+    }
+
+    #[test]
+    fn exported_file_output_summary_counts_but_never_names_the_capability() {
+        let resource = rmcp::model::Resource::new(
+            "codex-free://artifact/abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE",
+            "private-report.bin",
+        )
+        .with_mime_type("application/octet-stream")
+        .with_size(42);
+        let result = ToolResult {
+            content: vec![ToolContent::ResourceLink(resource)],
+            is_error: false,
+            structured_content: None,
+            meta: None,
+            audit: Default::default(),
+        };
+
+        let summary = summarize_output(&result).to_string();
+        assert!(summary.contains("\"resource_link_count\":1"));
+        assert!(!summary.contains("codex-free://artifact/"));
+        assert!(!summary.contains("private-report.bin"));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,9 +23,9 @@ use crate::conversation_auth::validate_conversation_auth_token;
 use crate::openai_tunnel::validate_tunnel_id;
 use crate::project_catalog::{ProjectCatalog, discover_project_catalog_at};
 use crate::types::{
-    AppConfig, ArtifactIngressConfig, AuditConfig, CodexProjectCatalogConfig, CommandConfig,
-    ConversationAuthToken, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec, McpToolExposure,
-    MemoryConfig, OpenAiTunnelConfig, OutputConfig, ProjectCatalogConfig,
+    AppConfig, ArtifactEgressConfig, ArtifactIngressConfig, AuditConfig, CodexProjectCatalogConfig,
+    CommandConfig, ConversationAuthToken, ExecConfig, ExecMode, IgnoreConfig, McpServerSpec,
+    McpToolExposure, MemoryConfig, OpenAiTunnelConfig, OutputConfig, ProjectCatalogConfig,
     ProjectCatalogEntryConfig, ProjectDocConfig, ReviewConfig, SkillsConfig, TreeConfig,
     WorktreeConfig, WorktreeMode, WorktreeUpstreamRefreshMode,
 };
@@ -459,6 +459,7 @@ struct FileConfig {
     output: Option<OutputConfig>,
     review: Option<ReviewConfig>,
     artifact_ingress: Option<ArtifactIngressConfig>,
+    artifact_egress: Option<ArtifactEgressConfig>,
     memory: Option<MemoryConfig>,
     skills: Option<SkillsConfig>,
     ignore: Option<IgnoreConfig>,
@@ -656,6 +657,7 @@ pub fn default_config(work_dir: std::path::PathBuf) -> AppConfig {
         output: OutputConfig::default(),
         review: ReviewConfig::default(),
         artifact_ingress: ArtifactIngressConfig::default(),
+        artifact_egress: ArtifactEgressConfig::default(),
         memory: MemoryConfig::default(),
         skills: SkillsConfig::default(),
         ignore: IgnoreConfig::default(),
@@ -1305,6 +1307,8 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
 
     let artifact_ingress = file.artifact_ingress.unwrap_or_default();
     artifact_ingress.validate()?;
+    let artifact_egress = file.artifact_egress.unwrap_or_default();
+    artifact_egress.validate()?;
 
     Ok(AppConfig {
         work_dir,
@@ -1325,6 +1329,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
         output: file.output.unwrap_or_default(),
         review: file.review.unwrap_or_default(),
         artifact_ingress,
+        artifact_egress,
         memory: file.memory.unwrap_or_default(),
         skills: file.skills.unwrap_or_default(),
         ignore: file.ignore.unwrap_or_default(),
@@ -2177,6 +2182,76 @@ mod tests {
             (
                 r#"{"artifactIngress":{"maxConcurrentDownloads":0}}"#,
                 "maxConcurrentDownloads",
+            ),
+        ] {
+            std::fs::write(&config_path, json).unwrap();
+            let error = load_config(cli(root.path(), &config_path)).unwrap_err();
+            assert!(error.contains(expected), "{error}");
+        }
+    }
+
+    #[test]
+    fn artifact_egress_config_accepts_defaults_and_camel_case_overrides() {
+        let empty: FileConfig = serde_json::from_str(r#"{"artifactEgress":{}}"#).unwrap();
+        let empty = empty.artifact_egress.unwrap();
+        assert!(empty.enabled);
+        assert_eq!(
+            empty.max_file_bytes,
+            crate::types::DEFAULT_ARTIFACT_EGRESS_MAX_FILE_BYTES
+        );
+        assert_eq!(
+            empty.max_cached_bytes,
+            crate::types::DEFAULT_ARTIFACT_EGRESS_MAX_CACHED_BYTES
+        );
+        assert_eq!(
+            empty.max_references,
+            crate::types::DEFAULT_ARTIFACT_EGRESS_MAX_REFERENCES
+        );
+        assert_eq!(
+            empty.reference_ttl_ms,
+            crate::types::DEFAULT_ARTIFACT_EGRESS_REFERENCE_TTL_MS
+        );
+
+        let configured: FileConfig = serde_json::from_str(
+            r#"{
+                "artifactEgress": {
+                    "enabled": false,
+                    "maxFileBytes": 4096,
+                    "maxCachedBytes": 8192,
+                    "maxReferences": 4,
+                    "referenceTtlMs": 5000
+                }
+            }"#,
+        )
+        .unwrap();
+        let configured = configured.artifact_egress.unwrap();
+        assert!(!configured.enabled);
+        assert_eq!(configured.max_file_bytes, 4096);
+        assert_eq!(configured.max_cached_bytes, 8192);
+        assert_eq!(configured.max_references, 4);
+        assert_eq!(configured.reference_ttl_ms, 5000);
+    }
+
+    #[test]
+    fn artifact_egress_config_rejects_unsafe_limits() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.json");
+        for (json, expected) in [
+            (
+                r#"{"artifactEgress":{"maxFileBytes":0}}"#,
+                "maxFileBytes must be positive",
+            ),
+            (
+                r#"{"artifactEgress":{"maxFileBytes":4096,"maxCachedBytes":4095}}"#,
+                "maxCachedBytes must be at least maxFileBytes",
+            ),
+            (
+                r#"{"artifactEgress":{"maxReferences":0}}"#,
+                "maxReferences must be between 1 and 1024",
+            ),
+            (
+                r#"{"artifactEgress":{"referenceTtlMs":0}}"#,
+                "referenceTtlMs must be positive",
             ),
         ] {
             std::fs::write(&config_path, json).unwrap();

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -66,12 +66,20 @@ pub const AGENT_BRIEF: &str = concat!(
 );
 
 fn configured_agent_brief(config: &AppConfig) -> String {
-    if !config.artifact_ingress.enabled {
+    let mut host_file_guidance = Vec::new();
+    if config.artifact_ingress.enabled {
+        host_file_guidance.push("- Use import_host_file when the user attaches a file or asks you to place a ChatGPT-generated file into the project. Do not reconstruct binary files through write_file or substitute an arbitrary URL.");
+    }
+    if config.artifact_egress.enabled {
+        host_file_guidance.push("- Use export_host_file when the user asks to receive, download, or open a file that exists in the active project. Return the resource from that tool instead of pasting base64 data or merely reporting a local path.");
+    }
+    if host_file_guidance.is_empty() {
         return AGENT_BRIEF.to_string();
     }
 
     format!(
-        "{AGENT_BRIEF}\n\n## Host files\n\n- Use import_host_file when the user attaches a file or asks you to place a ChatGPT-generated file into the project. Do not reconstruct binary files through write_file or substitute an arbitrary URL."
+        "{AGENT_BRIEF}\n\n## Host files\n\n{}",
+        host_file_guidance.join("\n")
     )
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! original TypeScript.
 
 pub mod apply_patch;
+pub mod artifact_egress;
 pub mod artifact_ingress;
 mod audit;
 pub mod auth;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -14,6 +14,7 @@ pub fn load_tools() -> Vec<Box<dyn Tool>> {
         false,
         false,
         true,
+        true,
         DEFAULT_ARTIFACT_MAX_CONCURRENT_DOWNLOADS,
     )
 }
@@ -22,6 +23,7 @@ pub fn load_tools_for_mode(multi_project: bool) -> Vec<Box<dyn Tool>> {
     load_tools_with_options(
         multi_project,
         false,
+        true,
         true,
         DEFAULT_ARTIFACT_MAX_CONCURRENT_DOWNLOADS,
     )
@@ -32,6 +34,7 @@ pub fn load_tools_for_config(config: &AppConfig) -> Vec<Box<dyn Tool>> {
         config.multi_project,
         config.conversation_auth_token.is_some(),
         config.artifact_ingress.enabled,
+        config.artifact_egress.enabled,
         config.artifact_ingress.max_concurrent_downloads,
     )
 }
@@ -40,6 +43,7 @@ fn load_tools_with_options(
     multi_project: bool,
     conversation_auth: bool,
     artifact_ingress_enabled: bool,
+    artifact_egress_enabled: bool,
     max_concurrent_downloads: usize,
 ) -> Vec<Box<dyn Tool>> {
     let mut all: Vec<Box<dyn Tool>> = Vec::new();
@@ -56,6 +60,9 @@ fn load_tools_with_options(
         all.push(Box::new(tools::import_host_file::ImportHostFile::new(
             max_concurrent_downloads,
         )));
+    }
+    if artifact_egress_enabled {
+        all.push(Box::new(tools::export_host_file::ExportHostFile));
     }
     all.extend([
         Box::new(tools::run_command::RunCommand),

--- a/src/server.rs
+++ b/src/server.rs
@@ -31,6 +31,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tower_http::cors::{Any, CorsLayer};
 
+use crate::artifact_egress::{ARTIFACT_RESOURCE_URI_PREFIX, ArtifactEgressStore};
 use crate::audit::{
     AuditLogger, AuditScope, argument_field_names, summarize_arguments, summarize_output,
 };
@@ -75,6 +76,7 @@ pub struct CodexHandler {
     conversation_authorizations: Arc<ConversationAuthorizationStore>,
     conversation_exec_sessions: Arc<ConversationExecSessionStore>,
     review_checkpoints: Arc<ReviewCheckpointManager>,
+    artifact_egress: Arc<ArtifactEgressStore>,
     audit: Option<Arc<AuditLogger>>,
     session: SessionState,
 }
@@ -142,6 +144,7 @@ fn to_call_tool_result(result: ToolResult) -> CallToolResult {
         .map(|c| match c {
             ToolContent::Text(t) => ContentBlock::text(t),
             ToolContent::Image { data, mime_type } => ContentBlock::image(data, mime_type),
+            ToolContent::ResourceLink(resource) => ContentBlock::resource_link(resource),
         })
         .collect();
 
@@ -224,8 +227,27 @@ impl ServerHandler for CodexHandler {
     async fn read_resource(
         &self,
         request: ReadResourceRequestParams,
-        _context: RequestContext<RoleServer>,
+        context: RequestContext<RoleServer>,
     ) -> Result<ReadResourceResponse, McpError> {
+        match self
+            .artifact_egress
+            .read_resource(&request.uri, &context.ct)
+            .await
+        {
+            Ok(Some(contents)) => {
+                return Ok(ReadResourceResult::new(vec![contents]).into());
+            }
+            Ok(None) => {}
+            Err(error) => {
+                return Err(McpError::internal_error(error.to_string(), None));
+            }
+        }
+        if request.uri.starts_with(ARTIFACT_RESOURCE_URI_PREFIX) {
+            return Err(McpError::resource_not_found(
+                "Unknown or expired exported-file resource".to_string(),
+                None,
+            ));
+        }
         if request.uri != review_ui::REVIEW_UI_URI {
             return Err(McpError::resource_not_found(
                 format!("Unknown resource: {}", request.uri),
@@ -252,6 +274,7 @@ impl ServerHandler for CodexHandler {
             conversation: conversation.clone(),
             conversation_authorizations: self.conversation_authorizations.clone(),
             review_checkpoints: self.review_checkpoints.clone(),
+            artifact_egress: self.artifact_egress.clone(),
             cancellation: context.ct.clone(),
         };
 
@@ -479,6 +502,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     conversation_exec_sessions
         .spawn_idle_reaper(Duration::from_millis(config.exec.idle_timeout_ms));
     let review_checkpoints = Arc::new(ReviewCheckpointManager::new());
+    let artifact_egress = Arc::new(ArtifactEgressStore::new(config.artifact_egress.clone()));
     let conversation_authorizations =
         Arc::new(ConversationAuthorizationStore::for_current_user(&config));
 
@@ -547,6 +571,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
     let factory_conversation_authorizations = conversation_authorizations.clone();
     let factory_conversation_exec_sessions = conversation_exec_sessions.clone();
     let factory_review_checkpoints = review_checkpoints.clone();
+    let factory_artifact_egress = artifact_egress.clone();
     let factory_audit = audit.clone();
     let service = StreamableHttpService::new(
         move || {
@@ -559,6 +584,7 @@ pub async fn start_http_server(mut config: AppConfig) -> anyhow::Result<()> {
                 conversation_authorizations: factory_conversation_authorizations.clone(),
                 conversation_exec_sessions: factory_conversation_exec_sessions.clone(),
                 review_checkpoints: factory_review_checkpoints.clone(),
+                artifact_egress: factory_artifact_egress.clone(),
                 audit: factory_audit.clone(),
                 session,
             })
@@ -966,6 +992,9 @@ mod tests {
             conversation_authorizations: Arc::new(ConversationAuthorizationStore::new()),
             conversation_exec_sessions: Arc::new(ConversationExecSessionStore::new()),
             review_checkpoints: Arc::new(ReviewCheckpointManager::new()),
+            artifact_egress: Arc::new(ArtifactEgressStore::new(
+                crate::types::ArtifactEgressConfig::default(),
+            )),
             audit: None,
             session: SessionState::new(),
         };
@@ -997,6 +1026,9 @@ mod tests {
             conversation_authorizations: authorizations.clone(),
             conversation_exec_sessions: Arc::new(ConversationExecSessionStore::new()),
             review_checkpoints: Arc::new(ReviewCheckpointManager::new()),
+            artifact_egress: Arc::new(ArtifactEgressStore::new(
+                crate::types::ArtifactEgressConfig::default(),
+            )),
             audit: None,
             session: SessionState::new(),
         };
@@ -1082,6 +1114,29 @@ mod tests {
                 .and_then(|metadata| metadata.0.get("trace")),
             Some(&json!("upstream"))
         );
+    }
+
+    #[test]
+    fn call_result_serializes_exported_files_as_resource_links() {
+        let resource = rmcp::model::Resource::new(
+            "codex-free://artifact/abcdefghijklmnopqrstuvwxyz0123456789_-ABCDE",
+            "report.bin",
+        )
+        .with_mime_type("application/octet-stream")
+        .with_size(42);
+        let converted = to_call_tool_result(ToolResult {
+            content: vec![ToolContent::ResourceLink(resource)],
+            is_error: false,
+            structured_content: None,
+            meta: None,
+            audit: Default::default(),
+        });
+        let value = serde_json::to_value(converted).unwrap();
+
+        assert_eq!(value["content"][0]["type"], "resource_link");
+        assert_eq!(value["content"][0]["name"], "report.bin");
+        assert_eq!(value["content"][0]["mimeType"], "application/octet-stream");
+        assert_eq!(value["content"][0]["size"], 42);
     }
 
     #[tokio::test]

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -11,6 +11,7 @@ use rmcp::model::{Icon, MetaObject, ToolAnnotations};
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
 
+use crate::artifact_egress::ArtifactEgressStore;
 use crate::conversation_auth::ConversationAuthorizationStore;
 use crate::exec_sessions::SessionState;
 use crate::project_bindings::ConversationIdentity;
@@ -22,6 +23,7 @@ pub struct ToolRequestContext {
     pub conversation: Option<ConversationIdentity>,
     pub conversation_authorizations: Arc<ConversationAuthorizationStore>,
     pub review_checkpoints: Arc<ReviewCheckpointManager>,
+    pub artifact_egress: Arc<ArtifactEgressStore>,
     /// Cancelled when the transport drops or a per-call deadline (e.g. the
     /// artifact-ingress idle timeout) fires, so long-running tools can abort.
     pub cancellation: CancellationToken,

--- a/src/tools/export_host_file.rs
+++ b/src/tools/export_host_file.rs
@@ -1,0 +1,213 @@
+use async_trait::async_trait;
+use rmcp::model::{MetaObject, ToolAnnotations};
+use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
+
+use crate::artifact_egress::{ArtifactEgressStore, snapshot_project_file};
+use crate::exec_sessions::SessionState;
+use crate::tool::{Tool, ToolRequestContext, arg_str};
+use crate::types::{AppConfig, ToolContent, ToolResult};
+
+pub struct ExportHostFile;
+
+impl ExportHostFile {
+    pub const NAME: &'static str = "export_host_file";
+
+    async fn run(
+        &self,
+        args: Value,
+        config: &AppConfig,
+        store: &ArtifactEgressStore,
+        cancellation: &CancellationToken,
+    ) -> ToolResult {
+        if !config.artifact_egress.enabled {
+            return ToolResult::error(
+                "artifact_egress_disabled: File export is disabled by configuration.",
+            );
+        }
+        let Some(path) = arg_str(&args, "path") else {
+            return ToolResult::error("path must be a string");
+        };
+        let snapshot = match snapshot_project_file(
+            &config.work_dir,
+            path,
+            &config.artifact_egress,
+            cancellation,
+        )
+        .await
+        {
+            Ok(snapshot) => snapshot,
+            Err(error) => return ToolResult::error(error.to_string()),
+        };
+        let registered = match store.register(snapshot) {
+            Ok(registered) => registered,
+            Err(error) => return ToolResult::error(error.to_string()),
+        };
+        let text = format!(
+            "Exported `{path}` as `{}` ({} bytes, SHA-256 {}). The attached resource is available for {} ms.",
+            registered.name, registered.byte_count, registered.sha256, registered.expires_in_ms
+        );
+        ToolResult {
+            content: vec![
+                ToolContent::Text(text),
+                ToolContent::ResourceLink(registered.resource),
+            ],
+            is_error: false,
+            structured_content: Some(json!({
+                "path": path,
+                "name": registered.name,
+                "bytes": registered.byte_count,
+                "sha256": registered.sha256,
+                "mimeType": registered.mime_type,
+                "expiresInMs": registered.expires_in_ms
+            })),
+            meta: None,
+            audit: Default::default(),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ExportHostFile {
+    fn name(&self) -> &'static str {
+        Self::NAME
+    }
+
+    fn title(&self) -> Option<String> {
+        Some("Download project file".to_string())
+    }
+
+    fn annotations(&self) -> Option<ToolAnnotations> {
+        Some(
+            ToolAnnotations::new()
+                .read_only(true)
+                .destructive(false)
+                .idempotent(false)
+                .open_world(false),
+        )
+    }
+
+    fn meta(&self) -> Option<MetaObject> {
+        Some(
+            serde_json::from_value(json!({
+                "openai/toolInvocation/invoking": "Preparing file download",
+                "openai/toolInvocation/invoked": "File ready to download"
+            }))
+            .expect("static file-export tool metadata must be an object"),
+        )
+    }
+
+    fn description(&self) -> String {
+        "Export one existing file from the active project to ChatGPT as a downloadable MCP resource. The path is project-relative. Codex Free snapshots the exact bytes before returning, enforces the configured size and cache limits, and exposes only a short-lived opaque resource reference rather than a local filesystem path."
+            .to_string()
+    }
+
+    fn input_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Existing file path relative to the active project root."
+                }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+        })
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "name": { "type": "string" },
+                "bytes": { "type": "integer" },
+                "sha256": { "type": "string" },
+                "mimeType": { "type": "string" },
+                "expiresInMs": { "type": "integer" }
+            },
+            "required": [
+                "path",
+                "name",
+                "bytes",
+                "sha256",
+                "mimeType",
+                "expiresInMs"
+            ],
+            "additionalProperties": false
+        }))
+    }
+
+    fn fills_structured_content(&self) -> bool {
+        false
+    }
+
+    async fn call(&self, _args: Value, _config: &AppConfig, _session: &SessionState) -> ToolResult {
+        ToolResult::error(
+            "artifact_egress_context_missing: File export requires a server request context.",
+        )
+    }
+
+    async fn call_with_context(
+        &self,
+        args: Value,
+        config: &AppConfig,
+        _session: &SessionState,
+        context: &ToolRequestContext,
+    ) -> ToolResult {
+        self.run(
+            args,
+            config,
+            &context.artifact_egress,
+            &context.cancellation,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn returns_a_resource_link_and_matching_structured_receipt() {
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("report.txt"), b"final report\n").unwrap();
+        let config = crate::config::default_config(root.path().to_path_buf());
+        let store = ArtifactEgressStore::new(config.artifact_egress.clone());
+        let result = ExportHostFile
+            .run(
+                json!({ "path": "report.txt" }),
+                &config,
+                &store,
+                &CancellationToken::new(),
+            )
+            .await;
+
+        assert!(!result.is_error, "{}", result.joined_text());
+        assert!(matches!(
+            &result.content[1],
+            ToolContent::ResourceLink(resource)
+                if resource.name == "report.txt"
+                    && resource.mime_type.as_deref() == Some("text/plain")
+        ));
+        let structured = result.structured_content.unwrap();
+        assert_eq!(structured["path"], "report.txt");
+        assert_eq!(structured["name"], "report.txt");
+        assert_eq!(structured["bytes"], 13);
+        assert_eq!(structured["mimeType"], "text/plain");
+        assert!(structured.get("resourceUri").is_none());
+    }
+
+    #[test]
+    fn schema_and_annotations_describe_read_only_file_egress() {
+        let tool = ExportHostFile;
+        assert_eq!(tool.input_schema()["required"], json!(["path"]));
+        let annotations = tool.annotations().unwrap();
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.destructive_hint, Some(false));
+        assert_eq!(annotations.idempotent_hint, Some(false));
+        assert_eq!(annotations.open_world_hint, Some(false));
+    }
+}

--- a/src/tools/import_host_file.rs
+++ b/src/tools/import_host_file.rs
@@ -285,6 +285,9 @@ mod tests {
                 crate::conversation_auth::ConversationAuthorizationStore::new(),
             ),
             review_checkpoints: Arc::new(crate::review::ReviewCheckpointManager::new()),
+            artifact_egress: Arc::new(crate::artifact_egress::ArtifactEgressStore::new(
+                config.artifact_egress.clone(),
+            )),
             cancellation,
         };
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -4,6 +4,7 @@ pub mod apply_patch;
 pub mod clock_curr_time;
 pub mod clock_sleep;
 pub mod exec_command;
+pub mod export_host_file;
 pub mod get_agent_brief;
 pub mod get_environment;
 pub mod get_project_doc;

--- a/src/tools/setup.rs
+++ b/src/tools/setup.rs
@@ -138,6 +138,9 @@ mod tests {
             conversation: identity,
             conversation_authorizations: authorizations,
             review_checkpoints: Arc::new(ReviewCheckpointManager::new()),
+            artifact_egress: Arc::new(crate::artifact_egress::ArtifactEgressStore::new(
+                crate::types::ArtifactEgressConfig::default(),
+            )),
             cancellation: tokio_util::sync::CancellationToken::new(),
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,7 @@
 use std::fmt;
 use std::ops::Deref;
 
-use rmcp::model::MetaObject;
+use rmcp::model::{MetaObject, Resource};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use zeroize::Zeroize;
@@ -20,6 +20,7 @@ use zeroize::Zeroize;
 pub enum ToolContent {
     Text(String),
     Image { data: String, mime_type: String },
+    ResourceLink(Resource),
 }
 
 /// Metadata retained for operational accounting without retaining tool output.
@@ -268,6 +269,11 @@ pub const DEFAULT_ARTIFACT_IDLE_TIMEOUT_MS: u64 = 30_000;
 pub const DEFAULT_ARTIFACT_MAX_REDIRECTS: u8 = 3;
 pub const DEFAULT_ARTIFACT_MAX_CONCURRENT_DOWNLOADS: usize = 2;
 
+pub const DEFAULT_ARTIFACT_EGRESS_MAX_FILE_BYTES: u64 = 100 * 1024 * 1024;
+pub const DEFAULT_ARTIFACT_EGRESS_MAX_CACHED_BYTES: u64 = 256 * 1024 * 1024;
+pub const DEFAULT_ARTIFACT_EGRESS_MAX_REFERENCES: usize = 64;
+pub const DEFAULT_ARTIFACT_EGRESS_REFERENCE_TTL_MS: u64 = 5 * 60 * 1000;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
 pub struct ArtifactIngressConfig {
@@ -341,6 +347,46 @@ impl ArtifactIngressConfig {
                     "artifactIngress.allowedHosts contains an invalid host pattern: {pattern:?}"
                 ));
             }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct ArtifactEgressConfig {
+    pub enabled: bool,
+    pub max_file_bytes: u64,
+    pub max_cached_bytes: u64,
+    pub max_references: usize,
+    pub reference_ttl_ms: u64,
+}
+
+impl Default for ArtifactEgressConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_file_bytes: DEFAULT_ARTIFACT_EGRESS_MAX_FILE_BYTES,
+            max_cached_bytes: DEFAULT_ARTIFACT_EGRESS_MAX_CACHED_BYTES,
+            max_references: DEFAULT_ARTIFACT_EGRESS_MAX_REFERENCES,
+            reference_ttl_ms: DEFAULT_ARTIFACT_EGRESS_REFERENCE_TTL_MS,
+        }
+    }
+}
+
+impl ArtifactEgressConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.max_file_bytes == 0 {
+            return Err("artifactEgress.maxFileBytes must be positive".to_string());
+        }
+        if self.max_cached_bytes < self.max_file_bytes {
+            return Err("artifactEgress.maxCachedBytes must be at least maxFileBytes".to_string());
+        }
+        if !(1..=1024).contains(&self.max_references) {
+            return Err("artifactEgress.maxReferences must be between 1 and 1024".to_string());
+        }
+        if self.reference_ttl_ms == 0 {
+            return Err("artifactEgress.referenceTtlMs must be positive".to_string());
         }
         Ok(())
     }
@@ -647,7 +693,7 @@ pub struct WorktreeConfig {
 /// The fully-resolved server configuration handed to every tool.
 ///
 /// `work_dir` and `port` are always concrete. `project_catalog`, `projectDoc`,
-/// `output`, `review`, `artifactIngress`, `memory`, `skills`, `ignore` and
+/// `output`, `review`, `artifactIngress`, `artifactEgress`, `memory`, `skills`, `ignore` and
 /// `audit` carry their resolved/defaultable module settings.
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -667,6 +713,7 @@ pub struct AppConfig {
     pub output: OutputConfig,
     pub review: ReviewConfig,
     pub artifact_ingress: ArtifactIngressConfig,
+    pub artifact_egress: ArtifactEgressConfig,
     pub memory: MemoryConfig,
     pub skills: SkillsConfig,
     pub ignore: IgnoreConfig,

--- a/tests/meta_suite.rs
+++ b/tests/meta_suite.rs
@@ -25,15 +25,15 @@ use codex_free::types::{AppConfig, ToolContent, ToolResult};
 // ─── registry.test.ts ──────────────────────────────────────────────────
 
 #[test]
-fn loads_all_27_tools() {
+fn loads_all_28_tools() {
     let tools = load_tools();
-    assert_eq!(tools.len(), 27);
+    assert_eq!(tools.len(), 28);
 }
 
 #[test]
 fn multi_project_mode_adds_catalogue_and_session_selector() {
     let tools = load_tools_for_mode(true);
-    assert_eq!(tools.len(), 29);
+    assert_eq!(tools.len(), 30);
     assert_eq!(tools[0].name(), "list_projects");
     assert_eq!(tools[1].name(), "set_project_root");
 }
@@ -46,8 +46,20 @@ fn artifact_ingress_can_be_omitted_by_configuration() {
         .into_iter()
         .map(|tool| tool.name())
         .collect::<Vec<_>>();
-    assert_eq!(names.len(), 26);
+    assert_eq!(names.len(), 27);
     assert!(!names.contains(&"import_host_file"));
+}
+
+#[test]
+fn artifact_egress_can_be_omitted_by_configuration() {
+    let mut config = default_config(PathBuf::from("/tmp"));
+    config.artifact_egress.enabled = false;
+    let names = load_tools_for_config(&config)
+        .into_iter()
+        .map(|tool| tool.name())
+        .collect::<Vec<_>>();
+    assert_eq!(names.len(), 27);
+    assert!(!names.contains(&"export_host_file"));
 }
 
 #[test]
@@ -56,7 +68,7 @@ fn conversation_auth_mode_adds_innocuously_named_gate_before_protected_tools() {
     config.conversation_auth_token =
         Some("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".into());
     let tools = load_tools_for_config(&config);
-    assert_eq!(tools.len(), 28);
+    assert_eq!(tools.len(), 29);
     assert_eq!(tools[0].name(), "setup");
     let schema = tools[0].input_schema();
     assert!(schema["properties"].get("ref").is_some());
@@ -79,7 +91,7 @@ fn conversation_auth_mode_adds_innocuously_named_gate_before_protected_tools() {
 
     config.multi_project = true;
     let tools = load_tools_for_config(&config);
-    assert_eq!(tools.len(), 30);
+    assert_eq!(tools.len(), 31);
     assert_eq!(tools[0].name(), "setup");
     assert_eq!(tools[1].name(), "list_projects");
     assert_eq!(tools[2].name(), "set_project_root");
@@ -121,6 +133,7 @@ fn includes_expected_tool_names() {
         "read_file",
         "write_file",
         "import_host_file",
+        "export_host_file",
         "run_command",
         "git_status",
         "show_changes",
@@ -422,6 +435,7 @@ fn tools_that_need_their_own_structured_content() {
         vec![
             "clock_curr_time".to_string(),
             "exec_command".to_string(),
+            "export_host_file".to_string(),
             "get_environment".to_string(),
             "get_project_doc".to_string(),
             "import_host_file".to_string(),

--- a/tests/skills_and_docs.rs
+++ b/tests/skills_and_docs.rs
@@ -805,6 +805,19 @@ fn build_mentions_native_file_ingress_only_when_the_tool_is_enabled() {
 }
 
 #[test]
+fn build_mentions_native_file_egress_only_when_the_tool_is_enabled() {
+    let dir = TempDir::new().unwrap();
+    let state = TempDir::new().unwrap();
+    std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+    let enabled = brief_config(dir.path(), state.path(), "bash");
+    assert!(build_instructions(&enabled).contains("Use export_host_file"));
+
+    let mut disabled = enabled;
+    disabled.artifact_egress.enabled = false;
+    assert!(!build_instructions(&disabled).contains("export_host_file"));
+}
+
+#[test]
 fn build_describes_actual_shell() {
     let dir = TempDir::new().unwrap();
     let state = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- add `export_host_file`, the missing reverse direction of `import_host_file`
- return exported files as standard MCP `resource_link` content and resolve their bytes through `resources/read`
- add default-enabled `artifactEgress` configuration for per-file size, cached payload bytes, live reference count, and reference lifetime
- teach the connector instructions, registry, docs, examples, and audit accounting about native file egress

## Design

`export_host_file` accepts one path relative to the active project. Codex Free opens the regular file through a capability-confined project root, snapshots the exact bytes, computes SHA-256, and returns an opaque short-lived resource link. The resource is backed by an immutable process-wide snapshot rather than a delayed filesystem path read, so later replacement, truncation, deletion, or symlink retargeting cannot change the downloaded bytes.

The opaque URI contains a random 256-bit capability and is intentionally omitted from ordinary structured content and audit output. Dynamic file resources are not enumerable through `resources/list`; only a caller holding the resource link can retrieve one. The cache evicts the oldest entries to enforce both byte and reference bounds, and references also expire by TTL or disappear on restart.

The default configuration is:

```json
"artifactEgress": {
  "enabled": true,
  "maxFileBytes": 104857600,
  "maxCachedBytes": 268435456,
  "maxReferences": 64,
  "referenceTtlMs": 300000
}
```

Setting `artifactEgress.enabled` to `false` removes `export_host_file` from `tools/list`.

## Security and failure behavior

- rejects absolute paths, traversal, control-bearing/oversized path strings, non-regular files, and capability escapes through symlinks
- checks the configured file-size bound before reading and again while streaming, including files that grow during the read
- performs file opening, hashing, and base64 resource encoding off the async runtime's blocking workers and honors MCP cancellation
- never exposes an absolute local path or duplicates the bearer-capability URI into structured content or audit records
- returns a generic `resource_not_found` for unknown, expired, evicted, or restart-invalidated artifact capabilities
- does not proxy resource links returned by bridged upstream MCP servers; that remains separate resource-proxying work

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --offline --all-targets --all-features -- -D warnings`
- `cargo test --offline --all-targets`
- full project-scoped diff review, including untracked/new files

The implementation adds no dependency and leaves `Cargo.toml` and `Cargo.lock` unchanged.
