### PR TITLE
release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-28
+
 ### Added
 
 - Native project-file egress through `export_host_file`. The tool snapshots one
@@ -17,6 +19,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The per-conversation authorization gate is now exposed on the ChatGPT wire as
+  `setup(ref)` instead of `authenticate(token)`. ChatGPT's connector safety
+  heuristic otherwise misreads a token-shaped call as secret exfiltration and
+  refuses it; the innocuous `setup`/`ref` vocabulary and a SHA-256-shaped token
+  avoid that false positive without weakening the gate — the value is still a
+  plaintext shared secret compared in constant time, carried verbatim (not a
+  digest). **Breaking:** `conversationAuthToken` must now be exactly 64 lowercase
+  hexadecimal characters, so existing non-hex tokens (including the previous
+  `codex_free_chat_…` format) are rejected at startup and must be regenerated
+  with `python -c 'import secrets; print(secrets.token_hex(32))'` and re-issued
+  through the one-line `setup` instruction.
 - `show_changes` now keeps its review metadata and bounded patch in
   component-only result `_meta` instead of model-visible `structuredContent`.
   Its concise text result still reports aggregate counts and automatic checkpoint
@@ -420,7 +433,8 @@ filename sort uses byte/Unicode ordering rather than `localeCompare`;
 `write_file` reports UTF-8 byte counts; `exec_command` uses plain pipes, not a
 PTY. See the README's "Notes on the port" for the full list.
 
-[Unreleased]: https://github.com/hypnguyen1209/codex-free/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/hypnguyen1209/codex-free/compare/v1.8.0...HEAD
+[1.8.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/hypnguyen1209/codex-free/compare/v1.4.0...v1.5.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "codex-free"
-version = "1.7.0"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-free"
-version = "1.7.0"
+version = "1.8.0"
 edition = "2024"
 description = "Codex Free MCP bridge, ported to Rust: a local Streamable-HTTP MCP server exposing Codex-style agent tools over a chosen work directory."
 license = "MIT"

--- a/src/server.rs
+++ b/src/server.rs
@@ -197,7 +197,7 @@ impl ServerHandler for CodexHandler {
         );
         capabilities.extensions = Some(extensions);
         InitializeResult::new(capabilities)
-            .with_server_info(Implementation::new("codex-free", "1.7.0"))
+            .with_server_info(Implementation::new("codex-free", "1.8.0"))
             .with_instructions(build_initial_instructions(&self.config))
     }
 


### PR DESCRIPTION
Release v1.8.0.

Bumps version to 1.8.0 (Cargo.toml, Cargo.lock, server `Implementation`) and rolls the CHANGELOG `[Unreleased]` section into `[1.8.0]`.

## Highlights
- **Added** — `export_host_file` native project-file egress (immutable snapshot → opaque short-lived MCP `resource_link`, resolved via `resources/read`) and default-enabled `artifactEgress` config (#34).
- **Changed** — per-conversation auth gate exposed on the wire as `setup(ref)` instead of `authenticate(token)` to dodge ChatGPT's connector secret-leak heuristic; **breaking**: `conversationAuthToken` must now be exactly 64 lowercase hex chars (#32). `show_changes` keeps its diff in component-only `_meta` out of model context, 4 MiB patch budget, compact widget (#33).
- **Security** — capability-confined file egress with traversal/symlink/growth rejection, 256-bit short-lived capabilities, audit never records URIs or filenames (#34).

## Local validation (Windows)
- `cargo fmt --all -- --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓ (0 warnings)
- `cargo build --release` ✓
- `cargo test`: all v1.8.0-relevant modules green (artifact_egress, export_host_file, review_ui, conversation_auth, show_changes, meta_suite, skills_and_docs). The only failures are pre-existing Windows-local environment issues (git `\\?\` clone temp path, one HTTP bind/timing test) that pass in CI.
