### PR TITLE
fix: bound model-visible tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `output.maxToolOutputTokens`, defaulting to 10,000 approximate tokens, as a
+  connector-wide ceiling for textual model-visible tool results.
+
+### Changed
+
+- `exec_command` and `write_stdin` now clamp caller-requested output budgets to
+  server policy. `grep` caps match count, context and individual long lines while
+  keeping the actual match visible, and `run_command` returns bounded partial
+  output on timeout.
+
+### Security
+
+- Tool `content` and `structuredContent` are finalized through a common output
+  policy before entering model context. One-shot command stdout and stderr are
+  drained through bounded head/tail buffers, while component-only `_meta` remains
+  outside the model-visible limit.
+
 ## [1.8.0] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ an existing config keeps working.
     "rootMarkers": [".git"]
   },
   "output": {
+    "maxToolOutputTokens": 10000,
     "maxFileLines": 1000,
     "maxFileBytes": 131072,
     "maxEntries": 500,
@@ -639,9 +640,10 @@ The `output` block bounds what a single tool call may return. See [Context and m
 
 | Key | Default | Description |
 |-----|---------|-------------|
+| `maxToolOutputTokens` | `10000` | Approximate token ceiling applied independently to textual `content` and `structuredContent` visible to the model. Call-level command budgets may lower it but cannot raise it |
 | `maxFileLines` | `1000` | Lines `read_file` returns per call; a caller's own `limit` can lower this but not raise it |
 | `maxFileBytes` | `131072` | Byte ceiling for the same window, which is what actually bounds a minified file |
-| `maxEntries` | `500` | Results per `glob` or `list_directory` call |
+| `maxEntries` | `500` | Results per `glob`, `grep`, or `list_directory` call |
 | `maxTreeNodes` | `1000` | Nodes in one `tree` walk, counted across the whole tree rather than per directory |
 
 The `review` block bounds presentation without changing checkpoint semantics:
@@ -854,13 +856,13 @@ Codex Free also advertises the standard MCP Apps extension and serves a self-con
 
 Codex runs against a large context window and keeps its session in a process you control. ChatGPT Web does neither: the window is smaller than most real tasks, and when it fills — or when you open a new chat — the plan and everything learned along the way are gone, with no sign to the model that they ever existed. Codex Free attacks both halves of that.
 
-**Spend the window on less.** Every tool that could return an unbounded amount of text stops at a budget and says so on its last line, naming the argument that continues from where it stopped:
+**Spend the window on less.** Every non-self-managed tool result passes through a 10,000-token model-output ceiling by default. The policy covers both textual `content` and model-visible `structuredContent`; component-only result `_meta` remains outside model context. File and list tools still stop at their semantic paging boundaries and name the argument that continues from where they stopped:
 
 ```
 (showing lines 1-1000 of 4820 — call again with offset=1000 for the rest)
 ```
 
-That line matters as much as the cap. Silent truncation reads as "that was the whole file", which is worse than no cap at all. `read_file` has a byte ceiling as well as a line one, because a minified bundle is a single line several megabytes long that a line cap alone would hand back in full. `exec_command` and `grep` are bounded too, ported that way from Codex.
+That line matters as much as the cap. Silent truncation reads as "that was the whole file", which is worse than no cap at all. `read_file` has a byte ceiling as well as a line one, because a minified bundle is a single line several megabytes long that a line cap alone would hand back in full. `grep` additionally caps context, match count and individual lines while preserving the actual match inside a long minified line. `exec_command` and `write_stdin` keep Codex's 10,000-token default but clamp larger requests to server policy. `run_command` drains stdout and stderr through bounded head/tail buffers before applying the same model-output policy, so a chatty or timed-out child cannot consume unbounded process memory or context. Oversized arbitrary `structuredContent` becomes a bounded error requesting narrower arguments rather than invalid partial JSON.
 
 **Keep what would be expensive to rediscover.** `remember` writes one keyed note; `recall` hands back the notes and the current plan. `update_plan` persists too, so the plan survives the conversation that made it. Writing to a key that exists replaces it, and an empty value deletes it — a keyed store stays current where an append log accumulates contradictions until it is worthless.
 

--- a/codex.config.json
+++ b/codex.config.json
@@ -32,6 +32,13 @@
     },
     "entries": []
   },
+  "output": {
+    "maxToolOutputTokens": 10000,
+    "maxFileLines": 1000,
+    "maxFileBytes": 131072,
+    "maxEntries": 500,
+    "maxTreeNodes": 1000
+  },
   "review": {
     "maxPatchBytes": 4194304
   },

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,7 +156,9 @@ Five integration surfaces are exposed to the client:
 9. Tool dispatch supplies a request context containing the stable conversation
    identity, shared authorization store, and shared review manager; tools that do
    not need it use the default context-free implementation. The server fills in
-   default `structuredContent` when appropriate. Dispatch also emits diagnostic tracing and, when audit
+   the model-output policy to textual `content` and explicit `structuredContent`,
+   then fills default structured text mirrors within the same ceiling. Component-only
+   result `_meta` is deliberately excluded. Dispatch also emits diagnostic tracing and, when audit
    logging is enabled, paired JSONL `tool_start` / `tool_finish` records: identity
    and project values are hashed, and scalar argument values and returned payloads
    are replaced by schema-bounded shape and size accounting (unknown argument keys
@@ -197,6 +199,7 @@ trait Tool: Send + Sync {
     fn input_schema(&self) -> Value;
     fn output_schema(&self) -> Option<Value>;
     fn fills_structured_content(&self) -> bool;         // opt out of default-fill
+    fn manages_model_output_budget(&self) -> bool;      // false by default
     fn requires_project_root(&self) -> bool;            // true by default
     fn uses_exec_session_state(&self) -> bool;          // false by default
     fn may_modify_project(&self) -> bool;               // fail closed on review errors
@@ -206,11 +209,17 @@ trait Tool: Send + Sync {
 ```
 
 ### `ToolResult` (`types.rs`)
-`{ content: Vec<ToolContent>, is_error: bool, structured_content: Option<Value>, audit: ToolAuditMetadata }`.
+`{ content: Vec<ToolContent>, is_error: bool, structured_content: Option<Value>, meta: Option<MetaObject>, audit: ToolAuditMetadata }`.
 The server converts it to rmcp's `CallToolResult`. Tools with an `outputSchema`
 whose text *is* the structured form rely on the server's default-fill
 (`{ "content": <joined text> }`); tools that build their own structured content —
 or bridge it from upstream — return `fills_structured_content() == false`.
+Before conversion, the server applies `output.maxToolOutputTokens` to every
+non-self-managed textual result. Default text mirrors are fitted after JSON
+escaping. Oversized explicit structured data becomes an error response because
+arbitrary partial JSON cannot be guaranteed to satisfy the advertised schema.
+`exec_command` and `write_stdin` self-manage the policy around their nested output
+receipt. Result `_meta`, images and resource links are not text-truncated.
 `ToolAuditMetadata` is not sent over MCP; bounded-output and resident-process tools
 use it to report truncation, original token count, exec-session ID and PID without
 putting operational fields into their public output schema.
@@ -713,7 +722,7 @@ the legacy fallback. All fields are optional.
               "extraAllowedCommands": ["ls", "cat", …], "maxSessions": 8,
               "defaultShell": "…" },
   "ignore": { "useGitignore": true, "useDefaultPatterns": true, "customPatterns": [] },
-  "output": { "maxFileLines": 1000, "maxFileBytes": 131072, "maxEntries": 500, "maxTreeNodes": 1000 },
+  "output": { "maxToolOutputTokens": 10000, "maxFileLines": 1000, "maxFileBytes": 131072, "maxEntries": 500, "maxTreeNodes": 1000 },
   "review": { "maxPatchBytes": 4194304 },
   "audit": { "logFile": null, "includeCommandPreview": false,
              "commandPreviewMaxBytes": 512, "redactEnv": [] },

--- a/docs/superpowers/specs/2026-08-12-codex-tool-calls-port-design.md
+++ b/docs/superpowers/specs/2026-08-12-codex-tool-calls-port-design.md
@@ -263,9 +263,7 @@ Behavior: look up the session (unknown id → `isError` with the list of live id
 
 ### Output Truncation
 
-Both exec tools honor `max_output_tokens`. Tokens are approximated as `chars / 4` — no tokenizer dependency, and the budget is advisory.
-
-When output exceeds budget: keep the first 30% and last 70% of the allowance (tails carry errors and exit messages, which matter more), join with `\n... [<n> lines truncated] ...\n`, and set `original_token_count` to the pre-truncation estimate.
+Both exec tools honor `max_output_tokens`. Tokens are approximated as four UTF-16 code units each, without a tokenizer dependency. Since the bounded-model-output follow-up, a call may lower this budget but cannot raise it beyond `output.maxToolOutputTokens`; output retains bounded head and tail text with an explicit middle marker and reports the pre-truncation estimate. See `2026-08-28-bounded-model-output-design.md` for the connector-wide policy.
 
 ### `apply_patch`
 

--- a/docs/superpowers/specs/2026-08-28-bounded-model-output-design.md
+++ b/docs/superpowers/specs/2026-08-28-bounded-model-output-design.md
@@ -1,0 +1,130 @@
+# Bounded Model Output
+
+## Problem
+
+Several Codex Free tools had result-count or timeout limits without a hard bound
+on model-visible output. The dedicated `grep` tool could return a small number of
+multi-megabyte lines, `run_command` retained complete stdout and stderr in memory,
+and `exec_command.max_output_tokens` could raise the nominal 10,000-token default
+without a server-side ceiling.
+
+The same class of bug can recur in any built-in or bridged MCP tool, because both
+MCP `content` and `structuredContent` are visible to the model. A fix confined to
+`grep` would therefore leave the connector without a reliable context-window
+invariant.
+
+## Goals
+
+- Bound every textual model-visible tool result by default.
+- Keep process capture memory bounded independently from model-output size.
+- Let callers request a smaller command-output budget but never raise policy.
+- Preserve useful prefixes and suffixes and announce every model-facing cut.
+- Keep component-only `_meta` outside the model-output policy so review widgets
+  can retain their private payloads.
+- Preserve MCP output-schema validity.
+
+## Non-goals
+
+- The policy does not estimate image tokens or alter image/resource-link blocks.
+- It does not make arbitrary upstream tools pageable when their API has no paging
+  arguments. Oversized structured responses fail with guidance to narrow the call.
+- It does not replace the existing file, entry, tree, patch, or artifact limits.
+  Those remain useful semantic and memory bounds before final result processing.
+
+## Policy
+
+`output.maxToolOutputTokens` is a positive integer with a default of 10,000. Token
+counting uses the existing Codex-compatible approximation of four UTF-16 code
+units per token.
+
+The configured value is a ceiling, not a new default requested by each caller:
+
+```text
+effective command output = min(requested or 10,000, configured ceiling)
+```
+
+This matches the important property of current upstream Codex unified exec: a
+tool call may lower its output budget, but a larger request cannot override the
+model/tool-output policy. The comparison was made against upstream commit
+`5eea8d0dd3f6b38b0e457d266fd7c918eb189bb6`.
+
+## Result Finalization
+
+Every non-self-managed tool result passes through one server-side finalizer before
+conversion to the MCP response.
+
+1. Text blocks are treated as one logical text stream and truncated in the middle
+   while retaining bounded head and tail content.
+2. Explicit `structuredContent` is measured by streaming JSON serialization, so
+   checking its size does not allocate a second complete serialized copy.
+3. If explicit structured data exceeds policy, it is omitted and the result is
+   converted to an MCP error with a bounded diagnostic. Error results are exempt
+   from the advertised success output schema; emitting arbitrary partial JSON
+   could otherwise violate required properties, array constraints, discriminated
+   unions, or references.
+4. For ordinary native tools whose output schema is `{content: string}`, the
+   finalizer generates the mirror only after text bounding. It reduces the text
+   further when JSON escaping would make that generated mirror exceed policy.
+5. Component-only `_meta`, image blocks, and resource links are preserved.
+6. Truncation and the best available original token estimate are recorded in the
+   existing audit metadata.
+
+`exec_command` and `write_stdin` are self-managed because their structured receipt
+contains the same bounded output string. They clamp the caller's requested budget
+before constructing either representation.
+
+## Command Capture
+
+Model-output bounds do not prevent a child process from exhausting server memory
+before its result is returned, so command capture has a separate byte ceiling.
+
+- Resident unified exec retains at most 1 MiB between yields, split equally
+  between a stable head and rolling tail.
+- `run_command` now drains stdout and stderr concurrently into separate 512 KiB
+  head/tail buffers, retaining at most approximately 1 MiB total.
+- Output beyond a capture ceiling is counted and replaced by an explicit middle
+  marker.
+- Timeout kills the child, settles or aborts lingering pipe drains, and returns
+  bounded partial output plus the timeout diagnostic.
+- The combined one-shot result is then subjected to the configured token policy.
+
+The byte capture ceiling and token output ceiling intentionally solve different
+problems: the former protects process memory, while the latter protects model
+context.
+
+## Search Bounds
+
+`grep` keeps its search-specific semantics in addition to the universal finalizer:
+
+- `maxResults` defaults to 500 and cannot exceed `output.maxEntries` when that
+  entry limit is enabled.
+- Requested context is capped at 20 lines on each side of a match.
+- A rendered result line is capped at 4,096 bytes. Matching lines are windowed
+  around the actual regex match, so a minified line retains the relevant text
+  rather than only its unrelated beginning and end.
+- Results are appended into a byte-budgeted collector and scanning stops when the
+  configured model-output budget is reached.
+- The final line names every active reason for truncation: match count, output
+  budget, context cap, or long-line elision.
+
+## Failure Semantics
+
+- Text truncation is successful output with an explicit marker.
+- Oversized explicit structured data is a bounded error requesting narrower
+  arguments.
+- A configured budget too small to serialize even an empty required text mirror
+  also produces a bounded error instead of an invalid success response.
+- A zero `maxToolOutputTokens` value is rejected at startup.
+
+## Verification
+
+Regression coverage includes:
+
+- strict token fit and Unicode-boundary preservation;
+- generated structured mirrors containing heavily escaped text;
+- oversized explicit structured data and untouched component `_meta`;
+- a single enormous minified grep line with the match in its middle;
+- `grep.maxResults` and context clamping;
+- 2 MB `run_command` stdout and partial timeout output;
+- a 70,000-token unified-exec request clamped to a 20-token server policy;
+- configuration parsing and zero-budget rejection.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1309,6 +1309,8 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
     artifact_ingress.validate()?;
     let artifact_egress = file.artifact_egress.unwrap_or_default();
     artifact_egress.validate()?;
+    let output = file.output.unwrap_or_default();
+    output.validate()?;
 
     Ok(AppConfig {
         work_dir,
@@ -1326,7 +1328,7 @@ pub fn load_config(cli: Cli) -> Result<AppConfig, String> {
         command,
         exec,
         project_doc: file.project_doc.unwrap_or_default(),
-        output: file.output.unwrap_or_default(),
+        output,
         review: file.review.unwrap_or_default(),
         artifact_ingress,
         artifact_egress,
@@ -2127,6 +2129,28 @@ mod tests {
         let configured: FileConfig =
             serde_json::from_str(r#"{"review":{"maxPatchBytes":1234}}"#).unwrap();
         assert_eq!(configured.review.unwrap().max_patch_bytes, 1234);
+    }
+
+    #[test]
+    fn output_config_accepts_model_output_token_override() {
+        let configured: FileConfig =
+            serde_json::from_str(r#"{"output":{"maxToolOutputTokens":1234,"maxEntries":7}}"#)
+                .unwrap();
+        let output = configured.output.unwrap();
+        assert_eq!(output.max_tool_output_tokens, Some(1234));
+        assert_eq!(output.max_entries, Some(7));
+    }
+
+    #[test]
+    fn output_config_rejects_zero_model_output_budget() {
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("config.json");
+        std::fs::write(&config_path, r#"{"output":{"maxToolOutputTokens":0}}"#).unwrap();
+        let error = load_config(cli(root.path(), &config_path)).unwrap_err();
+        assert!(
+            error.contains("maxToolOutputTokens must be positive"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/src/exec_sessions.rs
+++ b/src/exec_sessions.rs
@@ -16,6 +16,9 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::process::{ChildStdin, Command};
 use tokio::sync::{Mutex as TokioMutex, Notify};
 
+use crate::output_budget::{
+    approx_token_count as count_output_tokens, truncate_text as truncate_model_text,
+};
 use crate::process_env::scrub_untrusted_child_env;
 use crate::project_bindings::{
     ConversationIdentity, ProjectBindingScope, ProjectRootSelection, prepare_project_root,
@@ -34,14 +37,14 @@ pub const EXEC_MAX_YIELD_MS: u64 = 30_000;
 pub const STDIN_WRITE_DEFAULT_YIELD_MS: u64 = 250;
 pub const STDIN_POLL_DEFAULT_YIELD_MS: u64 = 5_000;
 pub const STDIN_POLL_MAX_YIELD_MS: u64 = 300_000;
-pub const DEFAULT_MAX_OUTPUT_TOKENS: u64 = 10_000;
+pub const DEFAULT_MAX_OUTPUT_TOKENS: u64 = crate::output_budget::DEFAULT_MAX_TOOL_OUTPUT_TOKENS;
 
 static TRANSPORT_SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 /// Codex's `approx_token_count` equivalent: roughly four characters per token.
 /// Counted in UTF-16 code units to match the TS `text.length`.
 pub fn approx_token_count(text: &str) -> u64 {
-    (text.encode_utf16().count() as u64).div_ceil(4)
+    count_output_tokens(text)
 }
 
 pub fn clamp(value: u64, min: u64, max: u64) -> u64 {
@@ -71,22 +74,11 @@ pub struct UnifiedExecOutput {
 /// the model always knows the true size. `truncated` is the separate signal
 /// callers use for audit.
 pub fn truncate_output(text: &str, max_output_tokens: u64) -> (String, u64, bool) {
-    let budget_chars = (max_output_tokens.max(1) as usize) * 4;
-    // Measured and sliced in UTF-16 code units, matching the TS `text.length`
-    // and `text.slice(...)`.
-    let units: Vec<u16> = text.encode_utf16().collect();
-    let original = (units.len() as u64).div_ceil(4);
-    if units.len() <= budget_chars {
-        return (text.to_string(), original, false);
-    }
-    let keep = budget_chars / 2;
-    let head = String::from_utf16_lossy(&units[..keep]);
-    let tail = String::from_utf16_lossy(&units[units.len() - keep..]);
-    let omitted = units.len() - keep - keep;
+    let truncated = truncate_model_text(text, max_output_tokens);
     (
-        format!("{head}\n\n[... {omitted} bytes omitted ...]\n\n{tail}"),
-        original,
-        true,
+        truncated.text,
+        truncated.original_token_count,
+        truncated.truncated,
     )
 }
 
@@ -1274,8 +1266,10 @@ mod tests {
         let (out, orig, truncated) = truncate_output(&text, 4); // budget 16 chars
         assert!(truncated);
         assert_eq!(orig, 25); // 100 UTF-16 units / 4
-        assert!(out.contains("omitted"));
-        assert!(out.starts_with("aaaaaaaa"));
+        assert!(out.contains("..."));
+        assert!(out.starts_with('a'));
+        assert!(out.ends_with('a'));
+        assert!(approx_token_count(&out) <= 4);
     }
 
     #[test]

--- a/src/output_budget.rs
+++ b/src/output_budget.rs
@@ -1,15 +1,459 @@
-//! Ceilings on what a single tool call may return. Ports `src/output-budget.ts`.
+//! Ceilings on model-visible tool output and semantic file/list windows.
 //!
-//! Every cut is announced in the tool's own text with the argument that
-//! continues from where it stopped; silent truncation reads as "that was the
-//! whole file", which is worse than no cap at all.
+//! Tool-specific paging remains preferable because it gives the model a precise
+//! continuation. The connector-wide policy is the fallback that prevents any
+//! built-in or bridged result from bypassing the context bound.
 
-use crate::types::AppConfig;
+use std::collections::VecDeque;
+use std::io::{self, Write};
 
+use serde_json::Value;
+
+use crate::types::{AppConfig, ToolContent, ToolResult};
+
+pub const DEFAULT_MAX_TOOL_OUTPUT_TOKENS: u64 = 10_000;
 pub const DEFAULT_MAX_FILE_LINES: usize = 1_000;
 pub const DEFAULT_MAX_FILE_BYTES: usize = 131_072;
 pub const DEFAULT_MAX_ENTRIES: usize = 500;
 pub const DEFAULT_MAX_TREE_NODES: usize = 1_000;
+const APPROX_BYTES_PER_TOKEN: u64 = 4;
+
+pub fn tool_output_token_budget(config: &AppConfig) -> u64 {
+    config
+        .output
+        .max_tool_output_tokens
+        .unwrap_or(DEFAULT_MAX_TOOL_OUTPUT_TOKENS)
+        .max(1)
+}
+
+pub fn resolve_requested_output_tokens(config: &AppConfig, requested: Option<u64>) -> u64 {
+    requested
+        .filter(|tokens| *tokens > 0)
+        .unwrap_or(DEFAULT_MAX_TOOL_OUTPUT_TOKENS)
+        .min(tool_output_token_budget(config))
+}
+
+pub fn approx_token_count(text: &str) -> u64 {
+    (text.encode_utf16().count() as u64).div_ceil(APPROX_BYTES_PER_TOKEN)
+}
+
+pub fn approx_bytes_for_tokens(tokens: u64) -> usize {
+    usize::try_from(tokens.saturating_mul(APPROX_BYTES_PER_TOKEN)).unwrap_or(usize::MAX)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TextTruncation {
+    pub text: String,
+    pub original_token_count: u64,
+    pub truncated: bool,
+}
+
+pub fn truncate_text(text: &str, max_output_tokens: u64) -> TextTruncation {
+    truncate_text_segments(&[text], max_output_tokens)
+}
+
+fn truncate_text_segments(texts: &[&str], max_output_tokens: u64) -> TextTruncation {
+    let original_units = texts
+        .iter()
+        .map(|text| text.encode_utf16().count())
+        .fold(texts.len().saturating_sub(1), usize::saturating_add);
+    let original_token_count = (original_units as u64).div_ceil(APPROX_BYTES_PER_TOKEN);
+    let budget_units = usize::try_from(
+        max_output_tokens
+            .max(1)
+            .saturating_mul(APPROX_BYTES_PER_TOKEN),
+    )
+    .unwrap_or(usize::MAX);
+
+    if original_units <= budget_units {
+        return TextTruncation {
+            text: texts.join("\n"),
+            original_token_count,
+            truncated: false,
+        };
+    }
+
+    let detailed_marker = format!(
+        "\n\n[... output truncated; original approximate token count: {original_token_count} ...]\n\n"
+    );
+    let marker = if detailed_marker.encode_utf16().count() + 2 <= budget_units {
+        detailed_marker
+    } else if 7 <= budget_units {
+        "\n...\n".to_string()
+    } else {
+        "...".to_string()
+    };
+    let marker_units = marker.encode_utf16().count();
+
+    let retained_units = budget_units - marker_units;
+    let head_units = retained_units / 2;
+    let tail_units = retained_units - head_units;
+    let head = text_segments_prefix(texts, head_units);
+    let tail = text_segments_suffix(texts, tail_units);
+
+    TextTruncation {
+        text: format!("{head}{marker}{tail}"),
+        original_token_count,
+        truncated: true,
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ToolResultBudgetOutcome {
+    pub text_truncated: bool,
+    pub structured_content_truncated: bool,
+}
+
+pub fn enforce_tool_result_budget(
+    result: &mut ToolResult,
+    max_output_tokens: u64,
+) -> ToolResultBudgetOutcome {
+    let max_output_tokens = max_output_tokens.max(1);
+    let original_text_tokens = text_content_token_count(&result.content);
+
+    let original_structured_tokens = result
+        .structured_content
+        .as_ref()
+        .map(serialized_token_count)
+        .unwrap_or(0);
+    let structured_content_truncated = original_structured_tokens > max_output_tokens;
+    if structured_content_truncated {
+        result.structured_content = None;
+        result.is_error = true;
+        result.content.insert(
+            0,
+            ToolContent::Text(
+                "Oversized structuredContent omitted. Retry with narrower arguments.".to_string(),
+            ),
+        );
+    }
+
+    let text_truncated = truncate_text_content_blocks(&mut result.content, max_output_tokens);
+    if text_truncated || structured_content_truncated {
+        result.audit.truncated = Some(true);
+        let original_tokens = original_text_tokens.saturating_add(original_structured_tokens);
+        result.audit.original_output_tokens = Some(
+            result
+                .audit
+                .original_output_tokens
+                .unwrap_or(0)
+                .max(original_tokens),
+        );
+    }
+
+    ToolResultBudgetOutcome {
+        text_truncated,
+        structured_content_truncated,
+    }
+}
+
+pub fn fill_text_mirror_with_budget(result: &mut ToolResult, max_output_tokens: u64) -> bool {
+    let max_output_tokens = max_output_tokens.max(1);
+    let original_content = result.content.clone();
+    let original_text_tokens = text_content_token_count(&original_content);
+    let mut candidate_budget = max_output_tokens;
+
+    for _ in 0..16 {
+        let mut candidate_content = original_content.clone();
+        truncate_text_content_blocks(&mut candidate_content, candidate_budget);
+        let text = joined_text(&candidate_content);
+        let structured = serde_json::json!({ "content": text });
+        let structured_tokens = serialized_token_count(&structured);
+        if structured_tokens <= max_output_tokens {
+            let truncated = candidate_budget < max_output_tokens;
+            result.content = candidate_content;
+            result.structured_content = Some(structured);
+            if truncated {
+                result.audit.truncated = Some(true);
+                result.audit.original_output_tokens = Some(
+                    result
+                        .audit
+                        .original_output_tokens
+                        .unwrap_or(0)
+                        .max(original_text_tokens),
+                );
+            }
+            return truncated;
+        }
+
+        if candidate_budget == 0 {
+            break;
+        }
+        let scaled = candidate_budget
+            .saturating_mul(max_output_tokens)
+            .checked_div(structured_tokens.max(1))
+            .unwrap_or(0);
+        candidate_budget = scaled.min(candidate_budget - 1);
+    }
+
+    result.is_error = true;
+    result.structured_content = None;
+    result.content = vec![ToolContent::Text(
+        truncate_text(
+            "The configured model-output token limit is too small to serialize this tool's required structured response.",
+            max_output_tokens,
+        )
+        .text,
+    )];
+    result.audit.truncated = Some(true);
+    result.audit.original_output_tokens = Some(
+        result
+            .audit
+            .original_output_tokens
+            .unwrap_or(0)
+            .max(original_text_tokens),
+    );
+    true
+}
+
+fn truncate_text_content_blocks(content: &mut Vec<ToolContent>, max_output_tokens: u64) -> bool {
+    if max_output_tokens == 0 {
+        let had_text = content
+            .iter()
+            .any(|item| matches!(item, ToolContent::Text(_)));
+        content.retain(|item| !matches!(item, ToolContent::Text(_)));
+        return had_text;
+    }
+
+    let text_blocks = content
+        .iter()
+        .filter_map(|item| match item {
+            ToolContent::Text(text) => Some(text.as_str()),
+            ToolContent::Image { .. } | ToolContent::ResourceLink(_) => None,
+        })
+        .collect::<Vec<_>>();
+    if text_blocks.is_empty() {
+        return false;
+    }
+
+    let total_tokens = text_blocks
+        .iter()
+        .map(|text| approx_token_count(text))
+        .fold(
+            text_blocks.len().saturating_sub(1).div_ceil(4) as u64,
+            u64::saturating_add,
+        );
+    if total_tokens <= max_output_tokens {
+        return false;
+    }
+
+    let truncated = truncate_text_segments(&text_blocks, max_output_tokens).text;
+    let mut inserted_text = false;
+    let mut bounded = Vec::with_capacity(content.len());
+    for item in std::mem::take(content) {
+        match item {
+            ToolContent::Text(_) if !inserted_text => {
+                bounded.push(ToolContent::Text(truncated.clone()));
+                inserted_text = true;
+            }
+            ToolContent::Text(_) => {}
+            other => bounded.push(other),
+        }
+    }
+    *content = bounded;
+    true
+}
+
+fn text_content_token_count(content: &[ToolContent]) -> u64 {
+    let mut text_blocks = 0usize;
+    let text_tokens = content
+        .iter()
+        .filter_map(|item| match item {
+            ToolContent::Text(text) => {
+                text_blocks += 1;
+                Some(approx_token_count(text))
+            }
+            ToolContent::Image { .. } | ToolContent::ResourceLink(_) => None,
+        })
+        .fold(0u64, u64::saturating_add);
+    text_tokens.saturating_add(text_blocks.saturating_sub(1).div_ceil(4) as u64)
+}
+
+fn joined_text(content: &[ToolContent]) -> String {
+    content
+        .iter()
+        .filter_map(|item| match item {
+            ToolContent::Text(text) => Some(text.as_str()),
+            ToolContent::Image { .. } | ToolContent::ResourceLink(_) => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn serialized_token_count(value: &Value) -> u64 {
+    let mut counter = ByteCounter::default();
+    if serde_json::to_writer(&mut counter, value).is_err() {
+        return u64::MAX;
+    }
+    counter.len.div_ceil(APPROX_BYTES_PER_TOKEN)
+}
+
+#[derive(Default)]
+struct ByteCounter {
+    len: u64,
+}
+
+impl Write for ByteCounter {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.len = self.len.saturating_add(bytes.len() as u64);
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+fn utf16_prefix_end(text: &str, max_units: usize) -> usize {
+    let mut used = 0usize;
+    let mut end = 0usize;
+    for (index, character) in text.char_indices() {
+        let units = character.len_utf16();
+        if used.saturating_add(units) > max_units {
+            break;
+        }
+        used += units;
+        end = index + character.len_utf8();
+    }
+    end
+}
+
+fn text_segments_prefix(texts: &[&str], max_units: usize) -> String {
+    let mut remaining = max_units;
+    let mut output = String::new();
+    for (index, text) in texts.iter().enumerate() {
+        if index > 0 {
+            if remaining == 0 {
+                break;
+            }
+            output.push('\n');
+            remaining -= 1;
+        }
+
+        let end = utf16_prefix_end(text, remaining);
+        output.push_str(&text[..end]);
+        remaining = remaining.saturating_sub(text[..end].encode_utf16().count());
+        if end < text.len() {
+            break;
+        }
+    }
+    output
+}
+
+fn text_segments_suffix(texts: &[&str], max_units: usize) -> String {
+    let mut remaining = max_units;
+    let mut parts = Vec::new();
+    for index in (0..texts.len()).rev() {
+        let text = texts[index];
+        let start = utf16_suffix_start(text, remaining);
+        parts.push(text[start..].to_string());
+        remaining = remaining.saturating_sub(text[start..].encode_utf16().count());
+        if start > 0 || index == 0 || remaining == 0 {
+            break;
+        }
+        parts.push("\n".to_string());
+        remaining -= 1;
+    }
+    parts.reverse();
+    parts.concat()
+}
+
+fn utf16_suffix_start(text: &str, max_units: usize) -> usize {
+    let mut used = 0usize;
+    let mut start = text.len();
+    for (index, character) in text.char_indices().rev() {
+        let units = character.len_utf16();
+        if used.saturating_add(units) > max_units {
+            break;
+        }
+        used += units;
+        start = index;
+    }
+    start
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct BoundedTextBuffer<const MAX_BYTES: usize> {
+    head: Vec<u8>,
+    tail: VecDeque<u8>,
+    omitted_bytes: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BoundedTextOutput {
+    pub text: String,
+    pub truncated: bool,
+    pub omitted_bytes: u64,
+}
+
+impl<const MAX_BYTES: usize> BoundedTextBuffer<MAX_BYTES> {
+    const HEAD_BYTES: usize = MAX_BYTES / 2;
+    const TAIL_BYTES: usize = MAX_BYTES - Self::HEAD_BYTES;
+
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn push_bytes(&mut self, chunk: &[u8]) {
+        let mut chunk = chunk;
+        if self.head.len() < Self::HEAD_BYTES {
+            let space = Self::HEAD_BYTES - self.head.len();
+            if chunk.len() <= space {
+                self.head.extend_from_slice(chunk);
+                return;
+            }
+            self.head.extend_from_slice(&chunk[..space]);
+            chunk = &chunk[space..];
+        }
+
+        let remaining_tail = Self::TAIL_BYTES.saturating_sub(self.tail.len());
+        let excess = chunk.len().saturating_sub(remaining_tail);
+        self.omitted_bytes = self.omitted_bytes.saturating_add(excess as u64);
+        if excess <= self.tail.len() {
+            self.tail.drain(..excess);
+            self.tail.extend(chunk);
+        } else {
+            let skip = excess - self.tail.len();
+            self.tail.clear();
+            self.tail.extend(&chunk[skip..]);
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn push_str(&mut self, chunk: &str) {
+        self.push_bytes(chunk.as_bytes());
+    }
+
+    pub(crate) fn take(&mut self, reason: &str) -> BoundedTextOutput {
+        let head = std::mem::take(&mut self.head);
+        let mut tail = std::mem::take(&mut self.tail);
+        let omitted_bytes = std::mem::replace(&mut self.omitted_bytes, 0);
+        if omitted_bytes == 0 {
+            let mut bytes = head;
+            bytes.extend(tail);
+            BoundedTextOutput {
+                text: String::from_utf8_lossy(&bytes).into_owned(),
+                truncated: false,
+                omitted_bytes,
+            }
+        } else {
+            let head = String::from_utf8_lossy(&head);
+            let tail = String::from_utf8_lossy(tail.make_contiguous());
+            BoundedTextOutput {
+                text: format!(
+                    "{head}\n\n[... {omitted_bytes} bytes elided ({reason}) ...]\n\n{tail}"
+                ),
+                truncated: true,
+                omitted_bytes,
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn retained_bytes(&self) -> usize {
+        self.head.len().saturating_add(self.tail.len())
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub struct FileBudget {
@@ -194,5 +638,100 @@ mod tests {
         let (items, dropped) = limit_list(vec![1, 2, 3, 4, 5], 3);
         assert_eq!(items, vec![1, 2, 3]);
         assert_eq!(dropped, 2);
+    }
+
+    #[test]
+    fn text_truncation_includes_marker_inside_budget() {
+        let truncated = truncate_text(&"a".repeat(1_000), 20);
+        assert!(truncated.truncated);
+        assert_eq!(truncated.original_token_count, 250);
+        assert!(truncated.text.starts_with('a'));
+        assert!(truncated.text.ends_with('a'));
+        assert!(truncated.text.contains("output truncated"));
+        assert!(approx_token_count(&truncated.text) <= 20);
+    }
+
+    #[test]
+    fn text_truncation_keeps_utf8_boundaries() {
+        let truncated = truncate_text(&"é😀".repeat(100), 12);
+        assert!(truncated.truncated);
+        assert!(approx_token_count(&truncated.text) <= 12);
+        assert!(std::str::from_utf8(truncated.text.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn result_budget_bounds_text_content() {
+        let mut result = ToolResult::text("prefix".to_string() + &"x".repeat(1_000));
+        let outcome = enforce_tool_result_budget(&mut result, 25);
+        assert!(outcome.text_truncated);
+        assert!(!outcome.structured_content_truncated);
+        assert_eq!(result.audit.truncated, Some(true));
+        assert!(approx_token_count(&result.joined_text()) <= 25);
+    }
+
+    #[test]
+    fn oversized_structured_content_becomes_bounded_error() {
+        let mut result = ToolResult::text("useful textual fallback")
+            .with_structured(serde_json::json!({ "payload": "x".repeat(10_000) }));
+        let outcome = enforce_tool_result_budget(&mut result, 50);
+        assert!(outcome.structured_content_truncated);
+        assert!(result.is_error);
+        assert!(result.structured_content.is_none());
+        assert!(
+            result
+                .joined_text()
+                .contains("Retry with narrower arguments")
+        );
+        assert!(approx_token_count(&result.joined_text()) <= 50);
+    }
+
+    #[test]
+    fn component_only_metadata_is_not_part_of_the_model_output_budget() {
+        let mut meta = rmcp::model::MetaObject::new();
+        meta.0
+            .insert("widget".to_string(), Value::String("x".repeat(10_000)));
+        let mut result = ToolResult {
+            content: vec![ToolContent::Text("ok".to_string())],
+            is_error: false,
+            structured_content: None,
+            meta: Some(meta),
+            audit: Default::default(),
+        };
+
+        let outcome = enforce_tool_result_budget(&mut result, 5);
+        assert_eq!(outcome, ToolResultBudgetOutcome::default());
+        assert_eq!(result.joined_text(), "ok");
+        assert_eq!(
+            result
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.0.get("widget"))
+                .and_then(Value::as_str)
+                .map(str::len),
+            Some(10_000)
+        );
+    }
+
+    #[test]
+    fn bounded_text_buffer_keeps_head_and_tail() {
+        let mut buffer = BoundedTextBuffer::<16>::new();
+        buffer.push_str("abcdefghijklmnopqrstuvwx");
+        assert_eq!(buffer.retained_bytes(), 16);
+        let output = buffer.take("test limit");
+        assert!(output.truncated);
+        assert_eq!(output.omitted_bytes, 8);
+        assert!(output.text.starts_with("abcdefgh"));
+        assert!(output.text.ends_with("qrstuvwx"));
+    }
+
+    #[test]
+    fn bounded_text_buffer_decodes_utf8_after_chunk_reassembly() {
+        let mut buffer = BoundedTextBuffer::<32>::new();
+        let bytes = "a😀b".as_bytes();
+        buffer.push_bytes(&bytes[..3]);
+        buffer.push_bytes(&bytes[3..]);
+        let output = buffer.take("test limit");
+        assert_eq!(output.text, "a😀b");
+        assert!(!output.truncated);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,6 +40,9 @@ use crate::conversation_auth::{AUTHORIZATION_TOOL_WIRE_NAME, ConversationAuthori
 use crate::exec_sessions::{ConversationExecSessionStore, SessionState};
 use crate::instructions::build_initial_instructions;
 use crate::openai_tunnel::TunnelHealth;
+use crate::output_budget::{
+    enforce_tool_result_budget, fill_text_mirror_with_budget, tool_output_token_budget,
+};
 use crate::project_bindings::{ConversationIdentity, ProjectBindingStore};
 use crate::registry::load_tools_for_config;
 use crate::review::{ReviewAvailability, ReviewCheckpointManager, ReviewOwner};
@@ -156,6 +159,32 @@ fn to_call_tool_result(result: ToolResult) -> CallToolResult {
     ctr.structured_content = result.structured_content;
     ctr.meta = result.meta;
     ctr
+}
+
+fn finalize_model_visible_result(
+    tool: Option<&dyn Tool>,
+    result: &mut ToolResult,
+    config: &AppConfig,
+) {
+    let budget = tool_output_token_budget(config);
+    let manages_budget = tool.is_some_and(Tool::manages_model_output_budget);
+    if !manages_budget {
+        enforce_tool_result_budget(result, budget);
+    }
+
+    let should_fill = tool.is_some_and(|tool| {
+        tool.output_schema().is_some()
+            && tool.fills_structured_content()
+            && !result.is_error
+            && result.structured_content.is_none()
+    });
+    if should_fill {
+        if manages_budget {
+            result.structured_content = Some(json!({ "content": result.joined_text() }));
+        } else {
+            fill_text_mirror_with_budget(result, budget);
+        }
+    }
 }
 
 fn advertised_tool(tool: &dyn Tool, config: &AppConfig) -> rmcp::model::Tool {
@@ -432,19 +461,7 @@ impl ServerHandler for CodexHandler {
             }
         };
 
-        // Fill in the `structuredContent` the MCP spec expects from any tool that
-        // advertises an `outputSchema`. Most tools use the `{ content: string }`
-        // schema, for which the text they return *is* the structured form; tools
-        // with a different schema build their own and pass through. Errors are
-        // left alone — the spec exempts `isError` results.
-        if let Some(tool) = tool
-            && tool.output_schema().is_some()
-            && tool.fills_structured_content()
-            && !result.is_error
-            && result.structured_content.is_none()
-        {
-            result.structured_content = Some(json!({ "content": result.joined_text() }));
-        }
+        finalize_model_visible_result(tool.map(|tool| tool.as_ref()), &mut result, &self.config);
 
         let duration_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
         tracing::info!(
@@ -1114,6 +1131,50 @@ mod tests {
                 .and_then(|metadata| metadata.0.get("trace")),
             Some(&json!("upstream"))
         );
+    }
+
+    #[test]
+    fn finalizer_bounds_text_and_generated_structured_mirror() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = crate::config::default_config(root.path().to_path_buf());
+        config.output.max_tool_output_tokens = Some(20);
+        let tool = crate::tools::grep::Grep;
+        let mut result = ToolResult::text("\"\\\n".repeat(1_000));
+
+        finalize_model_visible_result(Some(&tool), &mut result, &config);
+
+        assert!(!result.is_error);
+        assert_eq!(result.audit.truncated, Some(true));
+        let structured = result.structured_content.as_ref().unwrap();
+        let text = result.joined_text();
+        assert_eq!(
+            structured.get("content").and_then(Value::as_str),
+            Some(text.as_str())
+        );
+        let serialized = serde_json::to_string(structured).unwrap();
+        assert!(crate::output_budget::approx_token_count(&serialized) <= 20);
+    }
+
+    #[test]
+    fn finalizer_rejects_oversized_explicit_structured_content() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = crate::config::default_config(root.path().to_path_buf());
+        config.output.max_tool_output_tokens = Some(20);
+        let tool = crate::tools::grep::Grep;
+        let mut result = ToolResult::text("fallback").with_structured(json!({
+            "payload": "x".repeat(10_000)
+        }));
+
+        finalize_model_visible_result(Some(&tool), &mut result, &config);
+
+        assert!(result.is_error);
+        assert!(result.structured_content.is_none());
+        assert!(
+            result
+                .joined_text()
+                .contains("Retry with narrower arguments")
+        );
+        assert!(crate::output_budget::approx_token_count(&result.joined_text()) <= 20);
     }
 
     #[test]

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -82,6 +82,13 @@ pub trait Tool: Send + Sync {
         true
     }
 
+    /// Whether this tool applies the configured model-output policy internally.
+    /// Structured command results need to budget their nested `output` field
+    /// before serialising the surrounding receipt.
+    fn manages_model_output_budget(&self) -> bool {
+        false
+    }
+
     /// Whether this tool needs an active project root for the current call.
     /// Upstream tools and project-independent clocks opt out.
     fn requires_project_root(&self) -> bool {

--- a/src/tools/exec_command.rs
+++ b/src/tools/exec_command.rs
@@ -7,6 +7,7 @@ use crate::exec_sessions::{
     SessionState, ShellType, UnifiedExecOutput, clamp, generate_chunk_id, resolve_shell,
     shell_type_of, start_exec_session, truncate_output,
 };
+use crate::output_budget::resolve_requested_output_tokens;
 use crate::safe_path::resolve_safe_path;
 use crate::tool::{Tool, arg_str, arg_u64};
 use crate::types::{AppConfig, ExecMode, ToolAuditMetadata, ToolResult};
@@ -95,7 +96,7 @@ impl Tool for ExecCommand {
                 "workdir": { "type": "string", "description": "Working directory for the command, relative to the project root. Defaults to the project root." },
                 "tty": { "type": "boolean", "description": "Unsupported by this bridge — commands always run with plain pipes. Passing true returns an error." },
                 "yield_time_ms": { "type": "number", "description": format!("Wait before yielding output. Defaults to {EXEC_DEFAULT_YIELD_MS} ms; effective range is {EXEC_MIN_YIELD_MS}-{EXEC_MAX_YIELD_MS} ms.") },
-                "max_output_tokens": { "type": "number", "description": format!("Output token budget. Defaults to {DEFAULT_MAX_OUTPUT_TOKENS} tokens; the middle of longer output is elided.") },
+                "max_output_tokens": { "type": "number", "description": format!("Output token budget. Defaults to {DEFAULT_MAX_OUTPUT_TOKENS} tokens; larger requests are capped by the server output policy and the middle of longer output is elided.") },
                 "shell": { "type": "string", "description": "Shell binary to launch. Defaults to the platform shell." }
             },
             "required": ["cmd"],
@@ -108,6 +109,10 @@ impl Tool for ExecCommand {
     }
 
     fn uses_exec_session_state(&self) -> bool {
+        true
+    }
+
+    fn manages_model_output_budget(&self) -> bool {
         true
     }
 
@@ -136,10 +141,8 @@ impl Tool for ExecCommand {
         // return before any output has surfaced.
         #[cfg(windows)]
         let yield_ms = yield_ms.max(EXEC_DEFAULT_YIELD_MS);
-        let max_output_tokens = match arg_u64(&args, "max_output_tokens") {
-            Some(n) if n > 0 => n,
-            _ => DEFAULT_MAX_OUTPUT_TOKENS,
-        };
+        let max_output_tokens =
+            resolve_requested_output_tokens(config, arg_u64(&args, "max_output_tokens"));
 
         let cwd = match resolve_safe_path(
             arg_str(&args, "workdir").unwrap_or(""),
@@ -216,7 +219,16 @@ impl Tool for ExecCommand {
 mod tests {
     use super::*;
     use crate::config::default_config;
+    use crate::output_budget::approx_token_count;
     use serde_json::json;
+
+    fn large_output_command() -> &'static str {
+        if cfg!(windows) {
+            "[Console]::Out.Write('x' * 4000)"
+        } else {
+            "head -c 4000 /dev/zero | tr '\\0' x"
+        }
+    }
 
     #[tokio::test]
     async fn completed_command_reports_process_audit_metadata() {
@@ -237,5 +249,38 @@ mod tests {
         assert_eq!(result.audit.resident, Some(false));
         assert!(result.audit.exec_session_id.is_some());
         assert!(result.audit.process_id.is_some());
+    }
+
+    #[tokio::test]
+    async fn requested_output_budget_cannot_exceed_server_policy() {
+        let root = tempfile::tempdir().unwrap();
+        let mut config = default_config(root.path().to_path_buf());
+        config.exec.mode = ExecMode::Unrestricted;
+        config.output.max_tool_output_tokens = Some(20);
+        let session = SessionState::new();
+
+        let result = ExecCommand
+            .call(
+                json!({
+                    "cmd": large_output_command(),
+                    "yield_time_ms": 3000,
+                    "max_output_tokens": 70000
+                }),
+                &config,
+                &session,
+            )
+            .await;
+
+        assert!(!result.is_error, "{}", result.joined_text());
+        let output = result
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("output"))
+            .and_then(Value::as_str)
+            .unwrap();
+        assert!(approx_token_count(output) <= 20, "{output}");
+        assert!(output.contains("output truncated"), "{output}");
+        assert_eq!(result.audit.truncated, Some(true));
+        assert!(result.audit.original_output_tokens.unwrap() > 20);
     }
 }

--- a/src/tools/grep.rs
+++ b/src/tools/grep.rs
@@ -7,11 +7,19 @@ use serde_json::{Value, json};
 
 use crate::exec_sessions::SessionState;
 use crate::ignore_rules::{IgnoreMatcher, build_ignore, to_rel_posix};
+use crate::output_budget::{
+    approx_bytes_for_tokens, entry_budget, tool_output_token_budget, truncate_text,
+};
 use crate::safe_path::resolve_safe_path;
-use crate::tool::{Tool, arg_bool, arg_str};
+use crate::tool::{Tool, arg_bool, arg_str, arg_u64};
 use crate::types::{AppConfig, ToolResult};
 
 pub struct Grep;
+
+const DEFAULT_MAX_RESULTS: usize = 500;
+const MAX_CONTEXT_LINES: usize = 20;
+const MAX_RENDERED_LINE_BYTES: usize = 4_096;
+const OUTPUT_NOTICE_RESERVE_BYTES: usize = 256;
 
 /// File extensions treated as binary and never searched.
 const BINARY_EXTENSIONS: &[&str] = &[
@@ -72,7 +80,7 @@ impl Tool for Grep {
     }
 
     fn description(&self) -> String {
-        "Search file contents across the project using a regex pattern. Returns matching lines with file paths and line numbers (e.g. 'src/app.ts:42:const server = ...'). Recursively searches all text files, skipping binary files and common directories (node_modules, .git, dist). Use this to find function definitions, usages, error messages, or any text across the codebase.".into()
+        "Search file contents across the project using a regex pattern. Returns bounded matching lines with file paths and line numbers (e.g. 'src/app.ts:42:const server = ...'); long lines are elided around the actual match. Recursively searches text files while respecting ignore rules. Use this to find definitions, usages, error messages, or other codebase text.".into()
     }
 
     fn input_schema(&self) -> Value {
@@ -82,9 +90,9 @@ impl Tool for Grep {
                 "pattern": { "type": "string", "description": "Regex pattern to search for" },
                 "path": { "type": "string", "description": "Subdirectory to search in. Default: work-dir root" },
                 "include": { "type": "string", "description": "Only search files matching this glob (e.g. *.ts)" },
-                "context": { "type": "number", "description": "Number of context lines before and after each match" },
+                "context": { "type": "number", "minimum": 0, "description": format!("Number of context lines before and after each match. Capped at {MAX_CONTEXT_LINES}.") },
                 "ignoreCase": { "type": "boolean", "description": "Case-insensitive search. Default: false" },
-                "maxResults": { "type": "number", "description": "Max number of matching lines to return. Default: 500" },
+                "maxResults": { "type": "number", "minimum": 1, "description": format!("Max number of matching lines to return. Defaults to {DEFAULT_MAX_RESULTS} and cannot exceed the configured output.maxEntries limit.") },
                 "filesOnly": { "type": "boolean", "description": "Only return file paths that contain matches, not the matching lines" }
             },
             "required": ["pattern"]
@@ -110,17 +118,27 @@ impl Tool for Grep {
             None => config.work_dir.clone(),
         };
 
-        let context_lines = args
-            .get("context")
-            .and_then(|v| v.as_i64())
-            .filter(|n| *n >= 0)
+        let requested_context = arg_u64(&args, "context")
+            .map(|value| usize::try_from(value).unwrap_or(usize::MAX))
             .unwrap_or(0);
+        let context_lines = requested_context.min(MAX_CONTEXT_LINES);
+        let context_clamped = requested_context > context_lines;
         let include_pattern = arg_str(&args, "include");
         let ignore_case = arg_bool(&args, "ignoreCase");
-        let max_results = args
-            .get("maxResults")
-            .and_then(|v| v.as_i64())
-            .unwrap_or(500);
+        let requested_max_results = arg_u64(&args, "maxResults");
+        if requested_max_results == Some(0) {
+            return ToolResult::error("maxResults must be positive");
+        }
+        let configured_max_results = entry_budget(config);
+        let requested_max_results = requested_max_results
+            .map(|value| usize::try_from(value).unwrap_or(usize::MAX))
+            .unwrap_or(DEFAULT_MAX_RESULTS);
+        let max_results = if configured_max_results == 0 {
+            requested_max_results
+        } else {
+            requested_max_results.min(configured_max_results)
+        };
+        let max_results_clamped = requested_max_results > max_results;
         let files_only = arg_bool(&args, "filesOnly");
 
         let pattern = arg_str(&args, "pattern").unwrap_or("");
@@ -142,15 +160,16 @@ impl Tool for Grep {
         let mut files: Vec<PathBuf> = Vec::new();
         collect_files(&search_path, ext_match.as_deref(), &matcher, &mut files);
 
-        let mut results: Vec<String> = Vec::new();
-        let mut match_count: i64 = 0;
-        let mut truncated = false;
+        let output_tokens = tool_output_token_budget(config);
+        let output_bytes = approx_bytes_for_tokens(output_tokens);
+        let mut results =
+            OutputCollector::new(output_bytes.saturating_sub(OUTPUT_NOTICE_RESERVE_BYTES));
+        let mut match_count = 0usize;
+        let mut match_limit_reached = false;
+        let mut output_limit_reached = false;
+        let mut line_content_truncated = false;
 
-        for file_path in &files {
-            if truncated {
-                break;
-            }
-
+        'files: for file_path in &files {
             let bytes = match std::fs::read(file_path) {
                 Ok(b) => b,
                 Err(_) => continue,
@@ -163,10 +182,14 @@ impl Tool for Grep {
             if files_only {
                 for line in &lines {
                     if regex.is_match(line) {
-                        results.push(rel_path.clone());
                         match_count += 1;
-                        if match_count >= max_results {
-                            truncated = true;
+                        if match_count > max_results {
+                            match_limit_reached = true;
+                            break 'files;
+                        }
+                        if !results.push_line(&rel_path) {
+                            output_limit_reached = true;
+                            break 'files;
                         }
                         break;
                     }
@@ -181,11 +204,11 @@ impl Tool for Grep {
                 if regex.is_match(line) {
                     match_count += 1;
                     if match_count > max_results {
-                        truncated = true;
+                        match_limit_reached = true;
                         break;
                     }
-                    let start = (i as i64 - context_lines).max(0) as usize;
-                    let end = i.saturating_add(context_lines as usize).min(last);
+                    let start = i.saturating_sub(context_lines);
+                    let end = i.saturating_add(context_lines).min(last);
                     for j in start..=end {
                         match_indices.insert(j);
                     }
@@ -199,23 +222,194 @@ impl Tool for Grep {
             let mut prev_idx: i64 = -2;
             for idx in &match_indices {
                 let idx = *idx;
-                if context_lines > 0 && (idx as i64) - prev_idx > 1 && prev_idx >= 0 {
-                    results.push("--".to_string());
+                if context_lines > 0
+                    && (idx as i64) - prev_idx > 1
+                    && prev_idx >= 0
+                    && !results.push_line("--")
+                {
+                    output_limit_reached = true;
+                    break 'files;
                 }
-                let marker = if regex.is_match(lines[idx]) { ":" } else { "-" };
-                results.push(format!("{}:{}{}{}", rel_path, idx + 1, marker, lines[idx]));
+                let matched = regex.is_match(lines[idx]);
+                let marker = if matched { ":" } else { "-" };
+                let (rendered, line_truncated) = render_result_line(
+                    &rel_path,
+                    idx + 1,
+                    marker,
+                    lines[idx],
+                    matched.then(|| regex.find(lines[idx])).flatten(),
+                    results.remaining_line_bytes().min(MAX_RENDERED_LINE_BYTES),
+                );
+                line_content_truncated |= line_truncated;
+                if !results.push_line(&rendered) {
+                    output_limit_reached = true;
+                    break 'files;
+                }
                 prev_idx = idx as i64;
+            }
+            if match_limit_reached {
+                break 'files;
             }
         }
 
-        if results.is_empty() {
+        if results.is_empty() && match_count == 0 {
             return ToolResult::text("No matches found.");
         }
 
-        let mut output = results.join("\n");
-        if truncated {
-            output.push_str(&format!("\n\n(truncated at {max_results} matches)"));
+        let mut reasons = Vec::new();
+        if match_limit_reached {
+            reasons.push(format!("stopped at {max_results} matches"));
         }
-        ToolResult::text(output).with_truncation(truncated)
+        if output_limit_reached {
+            reasons.push(format!(
+                "stopped at the configured {output_tokens}-token model-output limit"
+            ));
+        }
+        if context_clamped {
+            reasons.push(format!("context capped at {MAX_CONTEXT_LINES} lines"));
+        }
+        if line_content_truncated {
+            reasons.push("long result lines were elided".to_string());
+        }
+        if match_limit_reached && max_results_clamped {
+            reasons.push(format!("maxResults capped at {max_results}"));
+        }
+
+        let mut output = results.finish();
+        if !reasons.is_empty() {
+            if !output.is_empty() {
+                output.push_str("\n\n");
+            }
+            output.push_str(&format!("(truncated: {})", reasons.join("; ")));
+        }
+        let bounded = truncate_text(&output, output_tokens);
+        ToolResult::text(bounded.text)
+            .with_truncation(!reasons.is_empty() || results.truncated || bounded.truncated)
     }
+}
+
+struct OutputCollector {
+    text: String,
+    max_bytes: usize,
+    truncated: bool,
+}
+
+impl OutputCollector {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            text: String::new(),
+            max_bytes,
+            truncated: false,
+        }
+    }
+
+    fn push_line(&mut self, line: &str) -> bool {
+        let separator = usize::from(!self.text.is_empty());
+        if self
+            .text
+            .len()
+            .saturating_add(separator)
+            .saturating_add(line.len())
+            > self.max_bytes
+        {
+            self.truncated = true;
+            return false;
+        }
+        if separator > 0 {
+            self.text.push('\n');
+        }
+        self.text.push_str(line);
+        true
+    }
+
+    fn remaining_line_bytes(&self) -> usize {
+        let separator = usize::from(!self.text.is_empty());
+        self.max_bytes
+            .saturating_sub(self.text.len().saturating_add(separator))
+    }
+
+    fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    fn finish(&self) -> String {
+        self.text.clone()
+    }
+}
+
+fn render_result_line(
+    path: &str,
+    line_number: usize,
+    marker: &str,
+    line: &str,
+    matched_range: Option<regex::Match<'_>>,
+    max_bytes: usize,
+) -> (String, bool) {
+    let prefix = format!("{path}:{line_number}{marker}");
+    if prefix.len() >= max_bytes {
+        return bounded_line(&prefix, None, max_bytes);
+    }
+    let available = max_bytes.saturating_sub(prefix.len());
+    let snippet = bounded_line(
+        line,
+        matched_range.map(|matched| (matched.start(), matched.end())),
+        available,
+    );
+    (format!("{prefix}{}", snippet.0), snippet.1)
+}
+
+fn bounded_line(line: &str, focus: Option<(usize, usize)>, max_bytes: usize) -> (String, bool) {
+    if line.len() <= max_bytes {
+        return (line.to_string(), false);
+    }
+    if max_bytes <= 8 {
+        return (
+            line[..floor_char_boundary(line, max_bytes)].to_string(),
+            true,
+        );
+    }
+
+    let content_bytes = max_bytes - 8;
+    let (focus_start, focus_end) = focus.unwrap_or((0, 0));
+    let focus_len = focus_end.saturating_sub(focus_start);
+    let (mut start, mut end) = if focus_len >= content_bytes {
+        (
+            focus_start,
+            focus_start.saturating_add(content_bytes).min(line.len()),
+        )
+    } else {
+        let surrounding = content_bytes - focus_len;
+        let before = surrounding / 2;
+        let mut start = focus_start.saturating_sub(before);
+        let mut end = focus_end.saturating_add(surrounding - (focus_start - start));
+        if end > line.len() {
+            let shift = end - line.len();
+            start = start.saturating_sub(shift);
+            end = line.len();
+        }
+        (start, end)
+    };
+
+    start = floor_char_boundary(line, start);
+    end = floor_char_boundary(line, end.max(start));
+    let mut snippet = String::with_capacity(max_bytes);
+    if start > 0 {
+        snippet.push_str("... ");
+    }
+    snippet.push_str(&line[start..end]);
+    if end < line.len() {
+        snippet.push_str(" ...");
+    }
+    (snippet, true)
+}
+
+fn floor_char_boundary(text: &str, index: usize) -> usize {
+    if index >= text.len() {
+        return text.len();
+    }
+    let mut index = index;
+    while index > 0 && !text.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
 }

--- a/src/tools/run_command.rs
+++ b/src/tools/run_command.rs
@@ -1,16 +1,25 @@
 use std::process::Stdio;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
+use tokio::task::JoinHandle;
 
 use crate::exec_sessions::SessionState;
+use crate::output_budget::{
+    BoundedTextBuffer, approx_token_count, tool_output_token_budget, truncate_text,
+};
 use crate::process_env::scrub_untrusted_child_env;
 use crate::tool::{Tool, arg_str, arg_u64};
-use crate::types::{AppConfig, ToolResult};
+use crate::types::{AppConfig, ToolAuditMetadata, ToolContent, ToolResult};
 
 pub struct RunCommand;
+
+const RUN_COMMAND_STREAM_MAX_BYTES: usize = 512 * 1024;
+const DRAIN_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[async_trait]
 impl Tool for RunCommand {
@@ -19,7 +28,7 @@ impl Tool for RunCommand {
     }
 
     fn description(&self) -> String {
-        "Execute a shell command in the project directory. Only allowlisted commands are permitted (e.g. bun, npm, node, git, python, cargo, make). Returns stdout, stderr, and exit code. Use this to run tests, install dependencies, build projects, or execute scripts. Times out after 30s by default.".into()
+        "Execute an allowlisted binary with an argument array in the project directory. Returns bounded stdout, stderr, and exit code; timed-out commands return bounded partial output. Use exec_command instead when shell syntax such as pipes or redirects is required. Times out after 30s by default.".into()
     }
 
     fn input_schema(&self) -> Value {
@@ -82,50 +91,137 @@ impl Tool for RunCommand {
             .kill_on_drop(true);
         scrub_untrusted_child_env(&mut cmd, config);
 
-        let child = match cmd.spawn() {
+        let mut child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => return ToolResult::error(e.to_string()),
         };
 
-        let output =
-            match tokio::time::timeout(Duration::from_millis(timeout), child.wait_with_output())
-                .await
-            {
-                Err(_) => {
-                    return ToolResult::error(format!(
-                        "Command timed out after {}s",
-                        timeout as f64 / 1000.0
-                    ));
-                }
-                Ok(Err(e)) => return ToolResult::error(e.to_string()),
-                Ok(Ok(o)) => o,
-            };
+        let stdout = Arc::new(StdMutex::new(BoundedTextBuffer::<
+            RUN_COMMAND_STREAM_MAX_BYTES,
+        >::new()));
+        let stderr = Arc::new(StdMutex::new(BoundedTextBuffer::<
+            RUN_COMMAND_STREAM_MAX_BYTES,
+        >::new()));
+        let stdout_drain = child
+            .stdout
+            .take()
+            .map(|stream| spawn_bounded_drain(stream, stdout.clone()));
+        let stderr_drain = child
+            .stderr
+            .take()
+            .map(|stream| spawn_bounded_drain(stream, stderr.clone()));
 
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        let exit_code = output.status.code().unwrap_or(-1);
+        let waited = tokio::time::timeout(Duration::from_millis(timeout), child.wait()).await;
+        let (timed_out, status) = match waited {
+            Ok(Ok(status)) => (false, Some(status)),
+            Ok(Err(error)) => {
+                let _ = child.kill().await;
+                let _ = settle_drain(stdout_drain).await;
+                let _ = settle_drain(stderr_drain).await;
+                return ToolResult::error(error.to_string());
+            }
+            Err(_) => {
+                let _ = child.kill().await;
+                let status = child.wait().await.ok();
+                (true, status)
+            }
+        };
+
+        let stdout_settled = settle_drain(stdout_drain).await;
+        let stderr_settled = settle_drain(stderr_drain).await;
+
+        let stdout = stdout
+            .lock()
+            .unwrap()
+            .take("run_command stdout capture limit");
+        let stderr = stderr
+            .lock()
+            .unwrap()
+            .take("run_command stderr capture limit");
+        let exit_code = status.and_then(|status| status.code()).unwrap_or(-1);
 
         let mut out = String::new();
-        if !stdout.is_empty() {
-            out.push_str(&stdout);
+        if !stdout.text.is_empty() {
+            out.push_str(&stdout.text);
         }
-        if !stderr.is_empty() {
+        if !stderr.text.is_empty() {
             if !out.is_empty() {
                 out.push_str("\n--- stderr ---\n");
             }
-            out.push_str(&stderr);
+            out.push_str(&stderr.text);
         }
         if out.is_empty() {
             out.push_str("(no output)");
         }
-        out.push_str(&format!("\n\nexit code: {exit_code}"));
+        if timed_out {
+            out.push_str(&format!(
+                "\n\ncommand timed out after {}s",
+                timeout as f64 / 1000.0
+            ));
+        } else {
+            out.push_str(&format!("\n\nexit code: {exit_code}"));
+        }
+        if !stdout_settled || !stderr_settled {
+            out.push_str("\n\n[... output pipe remained open; later bytes omitted ...]");
+        }
+
+        let bounded = truncate_text(&out, tool_output_token_budget(config));
+        let capture_truncated =
+            stdout.truncated || stderr.truncated || !stdout_settled || !stderr_settled;
+        let original_output_tokens = bounded.original_token_count.saturating_add(
+            stdout
+                .omitted_bytes
+                .saturating_add(stderr.omitted_bytes)
+                .div_ceil(4),
+        );
 
         ToolResult {
-            content: vec![crate::types::ToolContent::Text(out)],
-            is_error: exit_code != 0,
+            content: vec![ToolContent::Text(bounded.text)],
+            is_error: timed_out || exit_code != 0,
             structured_content: None,
             meta: None,
-            audit: Default::default(),
+            audit: ToolAuditMetadata {
+                truncated: Some(capture_truncated || bounded.truncated),
+                original_output_tokens: (capture_truncated || bounded.truncated)
+                    .then_some(original_output_tokens.max(approx_token_count(&out))),
+                ..Default::default()
+            },
         }
+    }
+}
+
+fn spawn_bounded_drain<R>(
+    mut reader: R,
+    buffer: Arc<StdMutex<BoundedTextBuffer<RUN_COMMAND_STREAM_MAX_BYTES>>>,
+) -> JoinHandle<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let mut chunk = [0u8; 8192];
+        loop {
+            match reader.read(&mut chunk).await {
+                Ok(0) | Err(_) => break,
+                Ok(read) => {
+                    buffer.lock().unwrap().push_bytes(&chunk[..read]);
+                }
+            }
+        }
+    })
+}
+
+async fn settle_drain(handle: Option<JoinHandle<()>>) -> bool {
+    let Some(mut handle) = handle else {
+        return true;
+    };
+    if tokio::time::timeout(DRAIN_SHUTDOWN_TIMEOUT, &mut handle)
+        .await
+        .is_err()
+    {
+        handle.abort();
+        let _ = handle.await;
+        false
+    } else {
+        true
     }
 }

--- a/src/tools/write_stdin.rs
+++ b/src/tools/write_stdin.rs
@@ -6,6 +6,7 @@ use crate::exec_sessions::{
     STDIN_POLL_MAX_YIELD_MS, STDIN_WRITE_DEFAULT_YIELD_MS, SessionState, UnifiedExecOutput, clamp,
     generate_chunk_id, truncate_output,
 };
+use crate::output_budget::resolve_requested_output_tokens;
 use crate::tool::{Tool, arg_str, arg_u64};
 use crate::tools::exec_command::{render_unified_exec_output, unified_exec_output_schema};
 use crate::types::{AppConfig, ToolAuditMetadata, ToolContent, ToolResult};
@@ -29,7 +30,7 @@ impl Tool for WriteStdin {
                 "session_id": { "type": "number", "description": "Identifier of the running exec session, as returned by exec_command." },
                 "chars": { "type": "string", "description": "Bytes to write to stdin. Defaults to empty, which polls without writing." },
                 "yield_time_ms": { "type": "number", "description": format!("Wait before yielding output. Non-empty writes default to {STDIN_WRITE_DEFAULT_YIELD_MS} ms and cap at {EXEC_MAX_YIELD_MS} ms; empty polls wait {STDIN_POLL_DEFAULT_YIELD_MS}-{STDIN_POLL_MAX_YIELD_MS} ms by default.") },
-                "max_output_tokens": { "type": "number", "description": format!("Output token budget. Defaults to {DEFAULT_MAX_OUTPUT_TOKENS} tokens; the middle of longer output is elided.") }
+                "max_output_tokens": { "type": "number", "description": format!("Output token budget. Defaults to {DEFAULT_MAX_OUTPUT_TOKENS} tokens; larger requests are capped by the server output policy and the middle of longer output is elided.") }
             },
             "required": ["session_id"],
             "additionalProperties": false
@@ -44,11 +45,15 @@ impl Tool for WriteStdin {
         true
     }
 
+    fn manages_model_output_budget(&self) -> bool {
+        true
+    }
+
     fn may_modify_project(&self) -> bool {
         true
     }
 
-    async fn call(&self, args: Value, _config: &AppConfig, session: &SessionState) -> ToolResult {
+    async fn call(&self, args: Value, config: &AppConfig, session: &SessionState) -> ToolResult {
         let Some(session_id) = arg_u64(&args, "session_id") else {
             return ToolResult::error("session_id must be a number");
         };
@@ -83,10 +88,8 @@ impl Tool for WriteStdin {
                 EXEC_MAX_YIELD_MS,
             )
         };
-        let max_output_tokens = match arg_u64(&args, "max_output_tokens") {
-            Some(n) if n > 0 => n,
-            _ => DEFAULT_MAX_OUTPUT_TOKENS,
-        };
+        let max_output_tokens =
+            resolve_requested_output_tokens(config, arg_u64(&args, "max_output_tokens"));
 
         let started = std::time::Instant::now();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -427,6 +427,8 @@ pub struct IgnoreConfig {
 #[serde(rename_all = "camelCase")]
 pub struct OutputConfig {
     #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub max_tool_output_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_file_lines: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_file_bytes: Option<usize>,
@@ -434,6 +436,15 @@ pub struct OutputConfig {
     pub max_entries: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub max_tree_nodes: Option<usize>,
+}
+
+impl OutputConfig {
+    pub fn validate(&self) -> Result<(), String> {
+        if self.max_tool_output_tokens == Some(0) {
+            return Err("output.maxToolOutputTokens must be positive".to_string());
+        }
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/tests/fs_and_walk.rs
+++ b/tests/fs_and_walk.rs
@@ -18,6 +18,7 @@ use tempfile::TempDir;
 use codex_free::config::default_config;
 use codex_free::exec_sessions::SessionState;
 use codex_free::ignore_rules::{DEFAULT_IGNORE, build_ignore, to_rel_posix};
+use codex_free::output_budget::approx_token_count;
 use codex_free::tool::Tool;
 use codex_free::tools::glob::Glob;
 use codex_free::tools::grep::Grep;
@@ -322,6 +323,82 @@ async fn grep_filters_by_include_pattern() {
     .await;
     assert!(out.contains("README.md"), "{out}");
     assert!(!out.contains("index.ts"), "{out}");
+}
+
+#[tokio::test]
+async fn grep_bounds_a_single_enormous_matching_line() {
+    let dir = TempDir::new().unwrap();
+    let line = format!("{}NEEDLE{}", "a".repeat(20_000), "z".repeat(20_000));
+    write(dir.path(), "bundle.js", &line);
+    let mut config = default_config(dir.path().to_path_buf());
+    config.output.max_tool_output_tokens = Some(200);
+
+    let result = run_result(&Grep, json!({ "pattern": "NEEDLE" }), &config).await;
+    let out = result.joined_text();
+    assert!(out.contains("NEEDLE"), "{out}");
+    assert!(out.contains("long result lines were elided"), "{out}");
+    assert_eq!(result.audit.truncated, Some(true));
+    assert!(
+        approx_token_count(&out) <= 200,
+        "tokens={}\n{out}",
+        approx_token_count(&out)
+    );
+}
+
+#[tokio::test]
+async fn grep_clamps_max_results_to_the_configured_entry_limit() {
+    let dir = TempDir::new().unwrap();
+    for index in 0..10 {
+        write(dir.path(), &format!("match-{index}.txt"), "needle\n");
+    }
+    let mut config = default_config(dir.path().to_path_buf());
+    config.output.max_entries = Some(3);
+
+    let result = run_result(
+        &Grep,
+        json!({ "pattern": "needle", "maxResults": 1_000 }),
+        &config,
+    )
+    .await;
+    let out = result.joined_text();
+    assert_eq!(
+        out.lines()
+            .filter(|line| line.contains(":1:needle"))
+            .count(),
+        3
+    );
+    assert!(out.contains("stopped at 3 matches"), "{out}");
+    assert!(out.contains("maxResults capped at 3"), "{out}");
+    assert_eq!(result.audit.truncated, Some(true));
+}
+
+#[tokio::test]
+async fn grep_caps_requested_context_lines() {
+    let dir = TempDir::new().unwrap();
+    let body = (0..100)
+        .map(|index| {
+            if index == 50 {
+                "needle".to_string()
+            } else {
+                format!("line-{index}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    write(dir.path(), "context.txt", &body);
+    let config = default_config(dir.path().to_path_buf());
+
+    let result = run_result(
+        &Grep,
+        json!({ "pattern": "needle", "context": 10_000 }),
+        &config,
+    )
+    .await;
+    let out = result.joined_text();
+    assert!(out.contains("context capped at 20 lines"), "{out}");
+    assert!(!out.contains("line-0"), "{out}");
+    assert!(!out.contains("line-99"), "{out}");
+    assert_eq!(result.audit.truncated, Some(true));
 }
 
 #[tokio::test]

--- a/tests/infra_logic.rs
+++ b/tests/infra_logic.rs
@@ -19,8 +19,10 @@ use codex_free::exec_sessions::{
     ShellType, default_shell_bin, resolve_shell, shell_type_of, wrap_for_shell,
 };
 use codex_free::output_budget::{
-    DEFAULT_MAX_ENTRIES, DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILE_LINES, DEFAULT_MAX_TREE_NODES,
-    FileBudget, entry_budget, file_budget, limit_list, tree_node_budget, window_file_lines,
+    DEFAULT_MAX_ENTRIES, DEFAULT_MAX_FILE_BYTES, DEFAULT_MAX_FILE_LINES,
+    DEFAULT_MAX_TOOL_OUTPUT_TOKENS, DEFAULT_MAX_TREE_NODES, FileBudget, entry_budget, file_budget,
+    limit_list, resolve_requested_output_tokens, tool_output_token_budget, tree_node_budget,
+    window_file_lines,
 };
 use codex_free::types::{AppConfig, ExecMode};
 
@@ -482,6 +484,10 @@ fn budget_accessors_fall_back_to_defaults() {
     assert_eq!(fb.max_bytes, DEFAULT_MAX_FILE_BYTES);
     assert_eq!(entry_budget(&config), DEFAULT_MAX_ENTRIES);
     assert_eq!(tree_node_budget(&config), DEFAULT_MAX_TREE_NODES);
+    assert_eq!(
+        tool_output_token_budget(&config),
+        DEFAULT_MAX_TOOL_OUTPUT_TOKENS
+    );
 }
 
 #[test]
@@ -489,10 +495,14 @@ fn budget_accessors_take_each_configured_key() {
     let mut config = default_config(PathBuf::from("/tmp"));
     config.output.max_file_lines = Some(10);
     config.output.max_entries = Some(7);
+    config.output.max_tool_output_tokens = Some(123);
     let fb = file_budget(&config);
     assert_eq!(fb.max_lines, 10);
     assert_eq!(fb.max_bytes, DEFAULT_MAX_FILE_BYTES);
     assert_eq!(entry_budget(&config), 7);
+    assert_eq!(tool_output_token_budget(&config), 123);
+    assert_eq!(resolve_requested_output_tokens(&config, Some(999)), 123);
+    assert_eq!(resolve_requested_output_tokens(&config, Some(17)), 17);
 }
 
 #[test]

--- a/tests/tools_core.rs
+++ b/tests/tools_core.rs
@@ -12,6 +12,7 @@ use tempfile::TempDir;
 
 use codex_free::config::default_config;
 use codex_free::exec_sessions::SessionState;
+use codex_free::output_budget::approx_token_count;
 use codex_free::tool::Tool;
 use codex_free::tools::apply_patch::ApplyPatch;
 use codex_free::tools::clock_curr_time::ClockCurrTime;
@@ -546,24 +547,86 @@ async fn run_command_returns_exit_code_on_failure() {
     assert!(r.joined_text().contains("exit code"));
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn run_command_bounds_large_stdout_before_returning_it() {
+    let dir = TempDir::new().unwrap();
+    let mut config = config_in(&dir);
+    config.allowed_commands = vec!["sh".to_string()];
+    config.output.max_tool_output_tokens = Some(100);
+    let session = SessionState::new();
+
+    let r = RunCommand
+        .call(
+            json!({
+                "command": "sh",
+                "args": ["-c", "head -c 2000000 /dev/zero | tr '\\0' x"],
+                "timeout": 10_000
+            }),
+            &config,
+            &session,
+        )
+        .await;
+
+    let text = r.joined_text();
+    assert!(!r.is_error, "{text}");
+    assert_eq!(r.audit.truncated, Some(true));
+    assert!(text.contains("output truncated"), "{text}");
+    assert!(text.contains("exit code: 0"), "{text}");
+    assert!(approx_token_count(&text) <= 100);
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn run_command_bounds_large_stdout_before_returning_it() {
+    let dir = TempDir::new().unwrap();
+    let mut config = config_in(&dir);
+    config.allowed_commands = vec!["powershell.exe".to_string()];
+    config.output.max_tool_output_tokens = Some(100);
+    let session = SessionState::new();
+
+    let r = RunCommand
+        .call(
+            json!({
+                "command": "powershell.exe",
+                "args": ["-NoProfile", "-Command", "[Console]::Out.Write('x' * 2000000)"],
+                "timeout": 10_000
+            }),
+            &config,
+            &session,
+        )
+        .await;
+
+    let text = r.joined_text();
+    assert!(!r.is_error, "{text}");
+    assert_eq!(r.audit.truncated, Some(true));
+    assert!(text.contains("output truncated"), "{text}");
+    assert!(text.contains("exit code: 0"), "{text}");
+    assert!(approx_token_count(&text) <= 100);
+}
+
 #[cfg(windows)]
 #[tokio::test]
 async fn run_command_respects_timeout() {
     let dir = TempDir::new().unwrap();
     let mut config = config_in(&dir);
-    config.allowed_commands = vec!["ping".to_string()];
+    config.allowed_commands = vec!["powershell.exe".to_string()];
     let session = SessionState::new();
 
-    // `ping -n 60` runs ~60s; a 1s timeout fires first.
     let r = RunCommand
         .call(
-            json!({ "command": "ping", "args": ["-n", "60", "127.0.0.1"], "timeout": 1000 }),
+            json!({
+                "command": "powershell.exe",
+                "args": ["-NoProfile", "-Command", "[Console]::Out.Write('ready'); Start-Sleep -Seconds 60"],
+                "timeout": 100
+            }),
             &config,
             &session,
         )
         .await;
 
     assert!(r.is_error);
+    assert!(r.joined_text().contains("ready"));
     assert!(r.joined_text().contains("timed out"));
 }
 
@@ -572,18 +635,23 @@ async fn run_command_respects_timeout() {
 async fn run_command_respects_timeout() {
     let dir = TempDir::new().unwrap();
     let mut config = config_in(&dir);
-    config.allowed_commands = vec!["sleep".to_string()];
+    config.allowed_commands = vec!["sh".to_string()];
     let session = SessionState::new();
 
     let r = RunCommand
         .call(
-            json!({ "command": "sleep", "args": ["60"], "timeout": 1000 }),
+            json!({
+                "command": "sh",
+                "args": ["-c", "printf ready; sleep 60"],
+                "timeout": 100
+            }),
             &config,
             &session,
         )
         .await;
 
     assert!(r.is_error);
+    assert!(r.joined_text().contains("ready"));
     assert!(r.joined_text().contains("timed out"));
 }
 


### PR DESCRIPTION
## Problem

`grep.maxResults` limited the number of matching lines but not their byte or token size, so a small number of minified/generated lines or large context windows could still produce an enormous model-visible result. The same class of failure existed elsewhere: `run_command` retained complete stdout/stderr, and callers could raise `exec_command` / `write_stdin` beyond their nominal 10,000-token default.

## Design

- Add `output.maxToolOutputTokens`, defaulting to 10,000 approximate tokens.
- Finalize non-self-managed tool results through a common server-side policy before they enter MCP `content` or model-visible `structuredContent`.
- Preserve head and tail text with an explicit truncation marker and audit metadata.
- Convert oversized arbitrary structured results to bounded MCP errors rather than emitting schema-invalid partial JSON.
- Keep component-only result `_meta`, images, and resource links outside the textual model-output policy.
- Clamp unified-exec call-level budgets to server policy, matching the important behavior of upstream Codex: callers may lower the limit but cannot raise it.
- Drain `run_command` stdout and stderr concurrently into bounded head/tail buffers, including bounded partial output on timeout.
- Add grep-specific safeguards for match count, context expansion, total output, and pathological individual lines; matching lines are windowed around the actual regex match.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all`

Regression tests cover multi-megabyte command output, timeout partial output, a large caller-requested unified-exec budget, an enormous single-line grep match, grep context/result clamping, Unicode-safe truncation, generated structured mirrors, and oversized explicit structured output.
